### PR TITLE
Migrate style for constructor.

### DIFF
--- a/src/main/java/org/joshsim/engine/value/BooleanScalar.java
+++ b/src/main/java/org/joshsim/engine/value/BooleanScalar.java
@@ -22,13 +22,13 @@ public class BooleanScalar extends Scalar {
   /**
    * Constructs a BooleanScalar with the specified values.
    *
-   * @param newCaster The caster for this engine value.
-   * @param newInnerValue The inner boolean value.
-   * @param newUnits The units associated with this engine value.
+   * @param caster The caster for this engine value.
+   * @param innerValue The inner boolean value.
+   * @param units The units associated with this engine value.
    */
-  public BooleanScalar(EngineValueCaster newCaster, boolean newInnerValue, String newUnits) {
-    super(newCaster, newUnits);
-    innerValue = newInnerValue;
+  public BooleanScalar(EngineValueCaster caster, boolean innerValue, String units) {
+    super(caster, units);
+    this.innerValue = innerValue;
   }
 
   @Override

--- a/src/main/java/org/joshsim/engine/value/DecimalScalar.java
+++ b/src/main/java/org/joshsim/engine/value/DecimalScalar.java
@@ -22,13 +22,13 @@ public class DecimalScalar extends Scalar {
   /**
   * Constructs a new DecimalScalar with the specified value.
   *
-  * @param newCaster the caster to use for automatic type conversion.
-  * @param newInnerValue value the value of this scalar.
-  * @param newUnits the units of this scalar.
+  * @param caster the caster to use for automatic type conversion.
+  * @param innerValue value the value of this scalar.
+  * @param units the units of this scalar.
   */
-  public DecimalScalar(EngineValueCaster newCaster, BigDecimal newInnerValue, String newUnits) {
-    super(newCaster, newUnits);
-    innerValue = newInnerValue;
+  public DecimalScalar(EngineValueCaster caster, BigDecimal innerValue, String units) {
+    super(caster, units);
+    this.innerValue = innerValue;
   }
 
   @Override

--- a/src/main/java/org/joshsim/engine/value/EngineValueFactory.java
+++ b/src/main/java/org/joshsim/engine/value/EngineValueFactory.java
@@ -29,7 +29,7 @@ public class EngineValueFactory {
   /**
    * Constructor for EngineValueFactory.
    *
-   * @param newCaster EngineValueCaster to cast within operations involving the EngineValue.
+   * @param caster EngineValueCaster to cast within operations involving the EngineValue.
    */
   public EngineValueFactory(EngineValueCaster caster) {
     this.caster = caster;

--- a/src/main/java/org/joshsim/engine/value/EngineValueFactory.java
+++ b/src/main/java/org/joshsim/engine/value/EngineValueFactory.java
@@ -31,8 +31,8 @@ public class EngineValueFactory {
    *
    * @param newCaster EngineValueCaster to cast within operations involving the EngineValue.
    */
-  public EngineValueFactory(EngineValueCaster newCaster) {
-    caster = newCaster;
+  public EngineValueFactory(EngineValueCaster caster) {
+    this.caster = caster;
   }
 
   /**

--- a/src/main/java/org/joshsim/engine/value/EngineValueTuple.java
+++ b/src/main/java/org/joshsim/engine/value/EngineValueTuple.java
@@ -20,12 +20,12 @@ public class EngineValueTuple {
   /**
    * Create a new tuple of engine values.
    *
-   * @param newFirst the first engine value for this tuple, for example the left side operand.
-   * @param newSecond the second engine value for this tuple, for example the left side operand.
+   * @param first the first engine value for this tuple, for example the left side operand.
+   * @param second the second engine value for this tuple, for example the left side operand.
    */
-  public EngineValueTuple(EngineValue newFirst, EngineValue newSecond) {
-    first = newFirst;
-    second = newSecond;
+  public EngineValueTuple(EngineValue first, EngineValue second) {
+    this.first = first;
+    this.second = second;
     types = new TypesTuple(first.getLanguageType(), second.getLanguageType());
     units = new UnitsTuple(first.getUnits(), second.getUnits());
   }
@@ -96,12 +96,12 @@ public class EngineValueTuple {
     /**
      * Create a new tuple to represent a pair of identifying names.
      *
-     * @param newFirst the first value, for example from the left-side operand.
-     * @param newSecond the first value, for example from the right-side operand.
+     * @param first the first value, for example from the left-side operand.
+     * @param second the first value, for example from the right-side operand.
      */
-    public InnerTuple(String newFirst, String newSecond) {
-      first = newFirst;
-      second = newSecond;
+    public InnerTuple(String first, String second) {
+      this.first = first;
+      this.second = second;
     }
 
     /**
@@ -168,12 +168,12 @@ public class EngineValueTuple {
      * <p>This constructor initializes a new pair of types given for the  first and second values. 
      * This might include types, for example, like int or decimal.</p>
      *
-     * @param newFirst the first type, representing for example the type of the left-side operand.
-     * @param newSecond the second type, representing for example the type of the right-side
+     * @param first the first type, representing for example the type of the left-side operand.
+     * @param second the second type, representing for example the type of the right-side
      *     operand.
      */
-    public TypesTuple(String newFirst, String newSecond) {
-      super(newFirst, newSecond);
+    public TypesTuple(String first, String second) {
+      super(first, second);
     }
 
     @Override
@@ -194,12 +194,11 @@ public class EngineValueTuple {
      * <p>This constructor initializes a new pair of units given for the first and second values. 
      * This might include units, for example, like meters or centimeters.</p>
      *
-     * @param newFirst the first unit, representing for example the unit of the left-side operand.
-     * @param newSecond the second unit, representing for example the unit of the right-side
-     *     operand.
+     * @param first the first unit, representing for example the unit of the left-side operand.
+     * @param second the second unit, representing for example the unit of the right-side operand.
      */
-    public UnitsTuple(String newFirst, String newSecond) {
-      super(newFirst, newSecond);
+    public UnitsTuple(String first, String second) {
+      super(first, second);
     }
 
     @Override

--- a/src/main/java/org/joshsim/engine/value/IntScalar.java
+++ b/src/main/java/org/joshsim/engine/value/IntScalar.java
@@ -22,13 +22,13 @@ public class IntScalar extends Scalar {
   /**
    * Constructs an IntScalar instance with specified caster, value, and units.
    *
-   * @param newCaster the EngineValueCaster used for casting
-   * @param newInnerValue the initial integer value of this IntScalar
-   * @param newUnits the units associated with this IntScalar
+   * @param caster the EngineValueCaster used for casting
+   * @param innerValue the initial integer value of this IntScalar
+   * @param units the units associated with this IntScalar
    */
-  public IntScalar(EngineValueCaster newCaster, long newInnerValue, String newUnits) {
-    super(newCaster, newUnits);
-    innerValue = newInnerValue;
+  public IntScalar(EngineValueCaster caster, long innerValue, String units) {
+    super(caster, units);
+    this.innerValue = innerValue;
   }
 
   @Override

--- a/src/main/java/org/joshsim/engine/value/Scalar.java
+++ b/src/main/java/org/joshsim/engine/value/Scalar.java
@@ -20,11 +20,11 @@ public abstract class Scalar implements EngineValue, Comparable<Scalar> {
   /**
    * Create a new scalar with the given units.
    *
-   * @param newUnits String describing the units which may be a user-defined unit.
+   * @param units String describing the units which may be a user-defined unit.
    */
-  public Scalar(EngineValueCaster newCaster, String newUnits) {
-    caster = newCaster;
-    units = newUnits;
+  public Scalar(EngineValueCaster caster, String units) {
+    this.caster = caster;
+    this.units = units;
   }
 
   /**

--- a/src/main/java/org/joshsim/engine/value/StringScalar.java
+++ b/src/main/java/org/joshsim/engine/value/StringScalar.java
@@ -22,13 +22,13 @@ public class StringScalar extends Scalar {
   /**
   * Constructs a new DecimalScalar with the specified value.
   *
-  * @param newCaster the caster to use for automatic type conversion.
-  * @param newInnerValue the value of this StringScalar.
-  * @param newUnits the units of this StringScalar.
+  * @param caster the caster to use for automatic type conversion.
+  * @param innerValue the value of this StringScalar.
+  * @param units the units of this StringScalar.
   */
-  public StringScalar(EngineValueCaster newCaster, String newInnerValue, String newUnits) {
-    super(newCaster, newUnits);
-    innerValue = newInnerValue;
+  public StringScalar(EngineValueCaster caster, String innerValue, String units) {
+    super(caster, units);
+    this.innerValue = innerValue;
   }
 
   @Override

--- a/src/main/java/org/joshsim/engine/value/Units.java
+++ b/src/main/java/org/joshsim/engine/value/Units.java
@@ -52,13 +52,13 @@ public class Units {
   /**
    * Constructs Units with the specified numerator and denominator unit maps.
    *
-   * @param newNumerator a Map representing the units in the numerator, mapping from name to count.
-   * @param newDenominator a Map representing the units in the denominator, mapping from name to
+   * @param numeratorUnits a Map representing the units in the numerator, mapping from name to count.
+   * @param denominatorUnits a Map representing the units in the denominator, mapping from name to
    *     count.
    */
-  public Units(Map<String, Integer> newNumerator, Map<String, Integer> newDenominator) {
-    numeratorUnits = newNumerator;
-    denominatorUnits = newDenominator;
+  public Units(Map<String, Integer> numeratorUnits, Map<String, Integer> denominatorUnits) {
+    this.numeratorUnits = numeratorUnits;
+    this.denominatorUnits = denominatorUnits;
   }
 
   /**

--- a/src/main/java/org/joshsim/engine/value/Units.java
+++ b/src/main/java/org/joshsim/engine/value/Units.java
@@ -52,7 +52,8 @@ public class Units {
   /**
    * Constructs Units with the specified numerator and denominator unit maps.
    *
-   * @param numeratorUnits a Map representing the units in the numerator, mapping from name to count.
+   * @param numeratorUnits a Map representing the units in the numerator, mapping from name to
+   *     count.
    * @param denominatorUnits a Map representing the units in the denominator, mapping from name to
    *     count.
    */

--- a/src/main/java/org/joshsim/lang/parse/ParseError.java
+++ b/src/main/java/org/joshsim/lang/parse/ParseError.java
@@ -23,12 +23,12 @@ public class ParseError {
   /**
    * Constructs a new ParseError with the specified line number and message.
    *
-   * @param newLine the line number where the parsing error occurred
-   * @param newMessage the error message describing the parsing failure
+   * @param line the line number where the parsing error occurred
+   * @param message the error message describing the parsing failure
    */
-  public ParseError(int newLine, String newMessage) {
-    line = newLine;
-    message = newMessage;
+  public ParseError(int line, String message) {
+    this.line = line;
+    this.message = message;
   }
 
   /**

--- a/src/main/java/org/joshsim/lang/parse/ParseResult.java
+++ b/src/main/java/org/joshsim/lang/parse/ParseResult.java
@@ -10,7 +10,6 @@ import java.lang.IllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.joshsim.lang.antlr.JoshLangParser;
 
 /**
  * Structure representing the result of parsing a Josh source code file.
@@ -23,26 +22,26 @@ public class ParseResult {
   /**
    * Constructs a ParseResult with the specified program and no errors.
    *
-   * @param newProgram the parsed program.
+   * @param program the parsed program.
    */
-  public ParseResult(JoshLangParser.ProgramContext newProgram) {
-    program = Optional.of(newProgram);
-    errors = new ArrayList<>();
+  public ParseResult(JoshLangParser.ProgramContext program) {
+    this.program = Optional.of(program);
+    this.errors = new ArrayList<>();
   }
 
   /**
    * Constructs a ParseResult with the specified errors and no program.
    *
-   * @param newErrors the errors encountered which must not be empty.
-   * @throws IllegalArgumentException if newErrors is empty.
+   * @param errors the errors encountered which must not be empty.
+   * @throws IllegalArgumentException if errors is empty.
    */
-  public ParseResult(List<ParseError> newErrors) {
-    if (newErrors.isEmpty()) {
+  public ParseResult(List<ParseError> errors) {
+    if (errors.isEmpty()) {
       throw new IllegalArgumentException("Passed an empty errors list without parsed program.");
     }
 
     program = Optional.empty();
-    errors = newErrors;
+    this.errors = errors;
   }
 
   /**

--- a/src/main/java/org/joshsim/lang/parse/ParseResult.java
+++ b/src/main/java/org/joshsim/lang/parse/ParseResult.java
@@ -10,6 +10,7 @@ import java.lang.IllegalArgumentException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.joshsim.lang.antlr.JoshLangParser;
 
 /**
  * Structure representing the result of parsing a Josh source code file.


### PR DESCRIPTION
Moving from using `new` prefix on parameter names for constructors to avoid shadowing to instead expect parameter names to match instance fields and using `this` to work around shadowing. However, use of `this` outside of the constructor to access instance variables remains discouraged.