### PR TITLE
Add WASM build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,28 @@ jobs:
         with:
           name: fatJar
           path: build/libs/joshsim-fat.jar
+  buildWasm:
+    needs: buildJava
+    environment: Build
+    runs-on: ubuntu-latest
+    name: Build WASM
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build fat jar
+        run: gradle generateWasm
+      - name: Upload jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm
+          path: build/generated/teavm/wasm
   testJava:
     needs: buildJava
     environment: Build

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ teavm {
 }
 
 application {
-  mainClass = "org.joshsim.JoshSim"
+  mainClass = "org.joshsim.JoshSimCommander"
 }
 
 // JUnit target for al tests.

--- a/build.gradle
+++ b/build.gradle
@@ -42,14 +42,8 @@ dependencies {
   implementation("org.teavm:teavm-jso-apis:0.10.0")
 }
 
-teavm {
-    compileScopes = ["compile"]
-    minifying = true
-    optimizationLevel = "ADVANCED"
-    targetDirectory = "build/wasm"
-    mainClass = "org.joshsim.JoshSim"
-    webappDirectory = "build/webapp"
-    generateSourceMaps = true
+teavm.wasm {
+  mainClass = "org.joshsim.JoshSim"
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,6 @@ dependencies {
   antlr("org.antlr:antlr4:4.13.2") // The ANTLR tool for grammar processing
   implementation("org.antlr:antlr4-runtime:4.13.2") // ANTLR runtime for generated code
   
-  // Command line parsing
-  implementation("info.picocli:picocli:4.7.6")
-  
   // Rewrite dependencies
   rewrite("org.openrewrite:rewrite-java:7.46.0")
   rewrite("org.openrewrite.recipe:rewrite-static-analysis:2.4.0")
@@ -35,6 +32,9 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter")
   testImplementation("org.mockito:mockito-core:5.16.0")
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+  // Command line parsing
+  implementation("info.picocli:picocli:4.7.6")
 
   // TeaVM dependencies
   implementation("org.teavm:teavm-classlib:0.10.0")

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id "checkstyle" // for code style checking
   id "antlr" // for ANTLR grammar
   id "org.openrewrite.rewrite" version "7.2.0" // Formatting for google style guide
-  id "org.teavm.library" version "0.11.0" // TeaVM for WASM compilation
+  id "org.teavm" version "0.11.0" // TeaVM for WASM compilation
 }
 
 java {
@@ -35,19 +35,11 @@ dependencies {
 
   // Command line parsing
   implementation("info.picocli:picocli:4.7.6")
-
-  // TeaVM dependencies
-  implementation("org.teavm:teavm-classlib:0.10.0")
-  implementation("org.teavm:teavm-jso:0.10.0")
-  implementation("org.teavm:teavm-jso-apis:0.10.0")
 }
 
 teavm {
   wasm {
-    classesToExclude = ["org.joshsim.JoshSim"]
-    dependencies {
-      excludeLibrary("picocli")
-    }
+    mainClass = "org.joshsim.JoshSimFacade"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id "application" // for creating executable JARs
   id "checkstyle" // for code style checking
   id "antlr" // for ANTLR grammar
-  id "org.openrewrite.rewrite" version "7.2.0"
+  id "org.openrewrite.rewrite" version "7.2.0" // Formatting for google style guide
 }
 
 java {
@@ -40,6 +40,7 @@ application {
   mainClass = "org.joshsim.JoshSim"
 }
 
+// JUnit target for al tests.
 test {
   useJUnitPlatform()
   testLogging {
@@ -47,6 +48,7 @@ test {
   }
 }
 
+// Jar containing all dependencies required for production
 task fatJar(type: Jar) {
   manifest {
     attributes(
@@ -68,6 +70,7 @@ task fatJar(type: Jar) {
   exclude "META-INF/*.RSA", "META-INF/*.SF", "META-INF/*.DSA"
 }
 
+// Standard JavaDoc target
 javadoc {
   options {
     outputLevel = JavadocOutputLevel.QUIET
@@ -80,6 +83,7 @@ javadoc {
   destinationDir = file("${buildDir}/docs/javadoc")
 }
 
+// Shared configuration options for checkstyle
 checkstyle {
   toolVersion = "10.21.4"
   configFile = file("${rootDir}/config/checkstyle/google_checks.xml")
@@ -89,14 +93,17 @@ checkstyle {
   ignoreFailures = false
 }
 
+// Checkstyle target for main code
 checkstyleMain {
   source = "src/main/java/org/joshsim"
 }
 
+// Checkstyle target for test code
 checkstyleTest {
   source = "src/test/java/org/joshsim"
 }
 
+// Local formatting tool
 rewrite {
   activeRecipe("org.openrewrite.staticanalysis.CodeCleanup")
   checkstyleConfigFile = file("${rootDir}/config/checkstyle/google_checks.xml")

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,14 @@ dependencies {
   implementation("org.teavm:teavm-jso-apis:0.10.0")
 }
 
-teavm.wasm {
-  mainClass = "org.joshsim.JoshSim"
+teavm {
+  wasm {
+    targetType = "WEBASSEMBLY_LIBRARY"
+    classesToExclude = ["org.joshsim.JoshSim"]
+    dependencies {
+      excludeLibrary("picocli")
+    }
+  }
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ test {
 task fatJar(type: Jar) {
   manifest {
     attributes(
-      "Main-Class": "org.joshsim.JoshSim"
+      "Main-Class": "org.joshsim.JoshSimCommander"
     )
   }
   archiveBaseName = "joshsim"

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id "checkstyle" // for code style checking
   id "antlr" // for ANTLR grammar
   id "org.openrewrite.rewrite" version "7.2.0" // Formatting for google style guide
-  id "org.teavm" version "0.10.0" // TeaVM for WASM compilation
+  id "org.teavm.library" version "0.11.0" // TeaVM for WASM compilation
 }
 
 java {
@@ -44,7 +44,6 @@ dependencies {
 
 teavm {
   wasm {
-    targetType = "WEBASSEMBLY_LIBRARY"
     classesToExclude = ["org.joshsim.JoshSim"]
     dependencies {
       excludeLibrary("picocli")

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
   id "checkstyle" // for code style checking
   id "antlr" // for ANTLR grammar
   id "org.openrewrite.rewrite" version "7.2.0" // Formatting for google style guide
+  id "org.teavm" version "0.10.0" // TeaVM for WASM compilation
 }
 
 java {
@@ -34,6 +35,21 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter")
   testImplementation("org.mockito:mockito-core:5.16.0")
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+  // TeaVM dependencies
+  implementation("org.teavm:teavm-classlib:0.10.0")
+  implementation("org.teavm:teavm-jso:0.10.0")
+  implementation("org.teavm:teavm-jso-apis:0.10.0")
+}
+
+teavm {
+    compileScopes = ["compile"]
+    minifying = true
+    optimizationLevel = "ADVANCED"
+    targetDirectory = "build/wasm"
+    mainClass = "org.joshsim.JoshSim"
+    webappDirectory = "build/webapp"
+    generateSourceMaps = true
 }
 
 application {

--- a/src/main/java/org/joshsim/JoshSim.java
+++ b/src/main/java/org/joshsim/JoshSim.java
@@ -27,8 +27,10 @@ import picocli.CommandLine.Parameters;
 /**
  * Command line interface for Josh.
  * 
- * <p>Provides several subcommands like validate and run with options to help users validate
- * simulation files or execute them through the interface.</p>
+ * <p>Provides several subcommands like validate and run which check simulation files or execute
+ * them via the command line respectively. This is in contrast to using Josh as a library like
+ * through JoshSimFacade where client code can perform operations on the platform
+ * programmatically.</p>
  *
  * @version 1.0
  * @since 1.0

--- a/src/main/java/org/joshsim/JoshSim.java
+++ b/src/main/java/org/joshsim/JoshSim.java
@@ -19,14 +19,13 @@ import java.nio.file.Files;
 import java.util.concurrent.Callable;
 import org.joshsim.lang.parse.ParseError;
 import org.joshsim.lang.parse.ParseResult;
-import org.joshsim.lang.parse.Parser;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 /**
- * Command line interface for JoshSim.
+ * Command line interface for Josh.
  * 
  * <p>Provides several subcommands like validate and run with options to help users validate
  * simulation files or execute them through the interface.</p>
@@ -87,8 +86,7 @@ public class JoshSim {
         return 2;
       }
 
-      Parser parser = new Parser();
-      ParseResult result = parser.parse(fileContent);
+      ParseResult result = JoshSimFacade.parse(fileContent);
 
       if (result.hasErrors()) {
         String leadMessage = String.format("Found errors in Josh code at %s:", file);

--- a/src/main/java/org/joshsim/JoshSimCommander.java
+++ b/src/main/java/org/joshsim/JoshSimCommander.java
@@ -44,7 +44,7 @@ import picocli.CommandLine.Parameters;
         JoshSim.ValidateCommand.class
     }
 )
-public class JoshSim {
+public class JoshSimCommander {
 
   /**
    * Command to validate a simulation file.

--- a/src/main/java/org/joshsim/JoshSimCommander.java
+++ b/src/main/java/org/joshsim/JoshSimCommander.java
@@ -41,7 +41,7 @@ import picocli.CommandLine.Parameters;
     version = "1.0",
     description = "JoshSim command line interface",
     subcommands = {
-        JoshSim.ValidateCommand.class
+        JoshSimCommander.ValidateCommand.class
     }
 )
 public class JoshSimCommander {
@@ -143,7 +143,7 @@ public class JoshSimCommander {
    * @param args command line arguments passed to the JoshSim application to be parsed by picocli.
    */
   public static void main(String[] args) {
-    int exitCode = new CommandLine(new JoshSim()).execute(args);
+    int exitCode = new CommandLine(new JoshSimCommander()).execute(args);
     System.exit(exitCode);
   }
 }

--- a/src/main/java/org/joshsim/JoshSimFacade.java
+++ b/src/main/java/org/joshsim/JoshSimFacade.java
@@ -1,0 +1,41 @@
+/**
+ * Facade for interacting with the Josh platform via code.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.concurrent.Callable;
+import org.joshsim.lang.parse.ParseError;
+import org.joshsim.lang.parse.ParseResult;
+import org.joshsim.lang.parse.Parser;
+
+
+/**
+ * Entry point into the Josh platform when used as a library.
+ *
+ * <p>Facade which helps facilitate common operations within the Josh simulation platform when used
+ * as a library as opposed to as an interactive / command-line tool.</p>
+ */
+public class JoshSimFacade {
+
+  /**
+   * Parse a Josh script.
+   *
+   * <p>Parse a Josh script such as to to check for syntax errors or generate an AST in support of
+   * developer tools.</p>
+   *
+   * @param code String code to parse as a Josh source.
+   * @returns the result of parsing the code where hasErrors and getErrors can report on syntax
+   *     issues found.
+   */
+  public static ParseResult parse(String code) {
+    Parser parser = new Parser();
+    return parser.parse(code);
+  }
+  
+}


### PR DESCRIPTION
Add support for building a WASM distribution via TeaVM. This uses a reduced build size without a CLI for embedding into web.

Sorry for the runaround on this @GondekNP. I determined that the WASM build was kinda large and took a while to build because [picocli](https://picocli.info/) has some options to parse a whole bunch of very specific things like `InetAddress` and the like. This ends up bringing a lot more from the JDK than is actually required. Creating a [facade](https://refactoring.guru/design-patterns/facade) for the library and pointing TeaVM to that instead of the CLI entrypoint cuts out those unneeded standard classes and keeps the build much smaller. I think this is the right move since Picocli does all of that for convienence since it expects a full JDK whereas TeaVM does tree shaking to slim down the WASM artifact.