### PR TITLE
Update standard deviation to use sample not population

### DIFF
--- a/src/main/java/org/joshsim/engine/value/type/RealizedDistribution.java
+++ b/src/main/java/org/joshsim/engine/value/type/RealizedDistribution.java
@@ -248,8 +248,7 @@ public class RealizedDistribution extends Distribution {
         .map(Scalar::getAsDecimal)
         .mapToDouble(BigDecimal::doubleValue)
         .map(value -> Math.pow(value - mean, 2))
-        .average()
-        .orElse(0.0);
+        .sum() / (values.size() - 1);
     double stdDev = Math.sqrt(variance);
     DecimalScalar result = new DecimalScalar(getCaster(), BigDecimal.valueOf(stdDev), getUnits());
     return Optional.of(result);

--- a/src/test/java/org/joshsim/engine/value/type/RealizedDistributionTest.java
+++ b/src/test/java/org/joshsim/engine/value/type/RealizedDistributionTest.java
@@ -346,7 +346,7 @@ class RealizedDistributionTest {
   @Test
   void testGetStd() {
     assertEquals(
-        1.4142,
+        1.5811,
         distribution.getStd().orElseThrow().getAsDecimal().doubleValue(),
         0.0001
     );

--- a/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
@@ -26,7 +26,9 @@ import org.joshsim.engine.value.type.RealizedDistribution;
 import org.joshsim.lang.interpret.ValueResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 
 /**

--- a/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
@@ -26,9 +26,7 @@ import org.joshsim.engine.value.type.RealizedDistribution;
 import org.joshsim.lang.interpret.ValueResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 
 /**
@@ -506,7 +504,7 @@ public class SingleThreadEventHandlerMachineTest {
     // Then
     machine.end();
     DecimalScalar result = (DecimalScalar) machine.getResult();
-    assertTrue(Math.abs(result.getAsDecimal().doubleValue() - 1.4142) < 0.0001);
+    assertTrue(Math.abs(result.getAsDecimal().doubleValue() - 1.5811) < 0.0001);
   }
 
   @Test


### PR DESCRIPTION
We should use sample standard deviation for realized distribution. This would be more consistent with default standard deviation implementations elsewhere.