### PR TITLE
Add distribution scope

### DIFF
--- a/src/main/java/org/joshsim/engine/func/DistributionScope.java
+++ b/src/main/java/org/joshsim/engine/func/DistributionScope.java
@@ -1,0 +1,84 @@
+/**
+ * Structures to describe a scope which contains an entity.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.engine.func;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.joshsim.engine.entity.base.Entity;
+import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.entity.prototype.EmptyEntityPrototypeStore;
+import org.joshsim.engine.entity.prototype.EntityPrototypeStore;
+import org.joshsim.engine.value.converter.Converter;
+import org.joshsim.engine.value.converter.EmptyConverter;
+import org.joshsim.engine.value.engine.EngineValueFactory;
+import org.joshsim.engine.value.type.Distribution;
+import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.lang.interpret.ValueResolver;
+
+
+/**
+ * Simple scope which contains an entity.
+ */
+public class DistributionScope implements Scope {
+
+  private final Distribution value;
+  private final Set<String> expectedAttrs;
+
+  /**
+   * Create a scope decorator around this distribution.
+   *
+   * @param value Distribution to use for current.
+   */
+  public DistributionScope(Distribution value) {
+    this.value = value;
+    this.expectedAttrs = getAttributes(value);
+  }
+
+  @Override
+  public EngineValue get(String name) {
+    Iterable<EngineValue> values = value.getContents(value.getSize().orElseThrow(), false);
+
+    ValueResolver innerResolver = new ValueResolver(name);
+    EngineValueFactory valueFactory = new EngineValueFactory();
+    
+    List<EngineValue> transformedValues = StreamSupport.stream(values.spliterator(), false)
+        .map(innerResolver::get)
+        .map((x) -> x.orElseThrow())
+        .map(valueFactory::build);
+
+    return valueFactory.buildRealizedDistribution(
+        transformedValues,
+        transformedValues.get(0).getUnits()
+    );
+  }
+
+  @Override
+  public boolean has(String name) {
+    return expectedAttrs.contains(name);
+  }
+
+
+  @Override
+  public Iterable<String> getAttributes() {
+    return expectedAttrs;
+  }
+
+  /**
+   * Extract all attribute names from a sampled entity's event handlers or set attributes.
+   *
+   * @param target the Distriubtion to sample for an Entity from which to extract attribute names.
+   * @return Set of attribute names found in the entity's event handlers or set attributes.
+   */
+  private Set<String> getAttributes(Distribution target) {
+    return StreamSupport
+            .stream(target.sample().getAsEntity().getAttributeNames().spliterator(), false)
+            .collect(Collectors.toSet());
+  }
+}

--- a/src/main/java/org/joshsim/engine/func/EntityScope.java
+++ b/src/main/java/org/joshsim/engine/func/EntityScope.java
@@ -11,11 +11,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.joshsim.engine.entity.base.Entity;
-import org.joshsim.engine.entity.base.MutableEntity;
-import org.joshsim.engine.entity.prototype.EmptyEntityPrototypeStore;
-import org.joshsim.engine.entity.prototype.EntityPrototypeStore;
-import org.joshsim.engine.value.converter.Converter;
-import org.joshsim.engine.value.converter.EmptyConverter;
 import org.joshsim.engine.value.type.EngineValue;
 
 
@@ -30,7 +25,7 @@ public class EntityScope implements Scope {
   /**
    * Create a scope decorator around this entity.
    *
-   * @param value EngineValue to use for current.
+   * @param value EngineValue to use for the root.
    */
   public EntityScope(Entity value) {
     this.value = value;

--- a/src/main/java/org/joshsim/engine/value/type/Distribution.java
+++ b/src/main/java/org/joshsim/engine/value/type/Distribution.java
@@ -61,11 +61,12 @@ public abstract class Distribution extends EngineValue {
   /**
    * Get a specified number of values from the distribution.
    *
-   * <p>Sample repeatedly from this distribution given a number of samples to retrieve. In each
-   * sampling this draw can either happen with or without replacement. With replacement, each
+   * <p>Get a subset of elements from this distribution given a number of samples to retrieve. In
+   * each draw, this operation can either happen with or without replacement. With replacement, each
    * value has a probability of selection proportional to the frequency of that value. Without
    * replacement, each value has a probability of selection proprotion to the frequency of that
-   * value minus the number of times it was drawn in this invocation of getContents.</p>
+   * value minus the number of times it was drawn in this invocation of getContents. Unlike sample,
+   * this does not guarantee random ordering but may be more performant.</p>
    *
    * @param count number of values to retrieve.
    * @param withReplacement boolean flag indicating whether to sample with replacement. True if

--- a/src/main/java/org/joshsim/engine/value/type/RealizedDistribution.java
+++ b/src/main/java/org/joshsim/engine/value/type/RealizedDistribution.java
@@ -217,6 +217,12 @@ public class RealizedDistribution extends Distribution {
 
   @Override
   public Iterable<EngineValue> getContents(int count, boolean withReplacement) {
+    // If exactly all requested, can return immediately to save some memory and time.
+    if (values.size() == count) {
+      return values;
+    }
+
+    // Otherwise, sublist or wrap.
     if (withReplacement) {
       ArrayList<EngineValue> result = new ArrayList<>();
       for (int i = 0; i < count; i++) {
@@ -224,7 +230,12 @@ public class RealizedDistribution extends Distribution {
       }
       return result;
     } else {
-      return values.subList(0, Math.min(count, values.size()));
+      if (values.size() < count) {
+        throw new IllegalArgumentException(
+          "Cannot get more elements than present in a realized distribution without replacement."
+        );
+      }
+      return values.subList(0, count);
     }
   }
 

--- a/src/main/java/org/joshsim/lang/interpret/ValueResolver.java
+++ b/src/main/java/org/joshsim/lang/interpret/ValueResolver.java
@@ -56,7 +56,24 @@ public class ValueResolver {
       return Optional.of(resolved);
     } else {
       ValueResolver continuationResolver = continuationResolverMaybe.get();
-      return continuationResolver.get(new EntityScope(resolved.getAsMutableEntity()));
+      Optional<Integer> innerSize = resolved.getSize();
+      
+      if (innerSize.isEmpty()) {
+        String message = String.format(
+          "Cannot resolve attributes in %s as it is a distribution or type of undefined size.",
+          resolved.getLanguageType()
+        );
+        throw new IllegalArgumentException(message);
+      }
+
+      Scope newScope;
+      if (innerSize.get() == 1) {
+        newScope = new EntityScope(resolved.getAsMutableEntity()));
+      } else {
+        newScope = new DistributionScope(resolved.getAsDistribution());
+      }
+
+      return continuationResolver.get(newScope);
     }
   }
 


### PR DESCRIPTION
Allow for retrieving attributes across distribution of entities. Note that this also changes RealizedDistribution to throw an error if contents are requested beyond the size of that distribution without replacement. This makes it consistent with sample behavior.