### PR TITLE
Simplify shadowing entity and ensure it is made when in machine

### DIFF
--- a/src/main/java/org/joshsim/engine/entity/base/DirectLockMutableEntity.java
+++ b/src/main/java/org/joshsim/engine/entity/base/DirectLockMutableEntity.java
@@ -1,0 +1,122 @@
+/**
+ * Base entity for a mutable entity using a re-entrant lock.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.engine.entity.base;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.joshsim.engine.entity.handler.EventHandler;
+import org.joshsim.engine.entity.handler.EventHandlerGroup;
+import org.joshsim.engine.entity.handler.EventKey;
+import org.joshsim.engine.value.type.EngineValue;
+
+
+/**
+ * Represents a base entity that is mutable with a re-entrant lock.
+ */
+public abstract class DirectLockMutableEntity implements MutableEntity {
+
+  private final String name;
+  private final Map<EventKey, EventHandlerGroup> eventHandlerGroups;
+  private final Map<String, EngineValue> attributes;
+  private final Lock lock;
+
+  /**
+   * Constructor for Entity.
+   *
+   * @param name Name of the entity.
+   * @param eventHandlerGroups A map of event keys to their corresponding EventHandlerGroups.
+   * @param attributes A map of attribute names to their corresponding EngineValues.
+   */
+  public DirectLockMutableEntity(
+      String name,
+      Map<EventKey, EventHandlerGroup> eventHandlerGroups,
+      Map<String, EngineValue> attributes
+  ) {
+    this.name = name;
+    this.eventHandlerGroups = eventHandlerGroups != null
+        ? eventHandlerGroups : new HashMap<>();
+    this.attributes = attributes != null
+        ? attributes : new HashMap<>();
+    lock = new ReentrantLock();
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Iterable<EventHandlerGroup> getEventHandlers() {
+    return eventHandlerGroups.values();
+  }
+
+  @Override
+  public Optional<EventHandlerGroup> getEventHandlers(EventKey eventKey) {
+    return Optional.ofNullable(eventHandlerGroups.get(eventKey));
+  }
+
+  @Override
+  public Optional<EngineValue> getAttributeValue(String name) {
+    return Optional.ofNullable(attributes.get(name));
+  }
+
+  @Override
+  public void setAttributeValue(String name, EngineValue value) {
+    attributes.put(name, value);
+  }
+
+  @Override
+  public void lock() {
+    lock.lock();
+  }
+
+  @Override
+  public void unlock() {
+    lock.unlock();
+  }
+
+  @Override
+  public Entity freeze() {
+    Map<String, EngineValue> frozenAttributes = new HashMap<>();
+
+    for (String attributeName : attributes.keySet()) {
+      EngineValue unfrozenValue = attributes.get(attributeName);
+      EngineValue frozenValue = unfrozenValue.freeze();
+      frozenAttributes.put(attributeName, frozenValue);
+    }
+
+    return new FrozenEntity(
+        getEntityType(),
+        name,
+        frozenAttributes,
+        getGeometry()
+    );
+  }
+
+  @Override
+  public Iterable<String> getAttributeNames() {
+    return StreamSupport.stream(getEventHandlers().spliterator(), false)
+        .flatMap(group -> StreamSupport.stream(group.getEventHandlers().spliterator(), false))
+        .map(EventHandler::getAttributeName)
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public Optional<GeoKey> getKey() {
+    if (getGeometry().isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(new GeoKey(this));
+    }
+  }
+
+}

--- a/src/main/java/org/joshsim/engine/entity/base/MemberSpatialEntity.java
+++ b/src/main/java/org/joshsim/engine/entity/base/MemberSpatialEntity.java
@@ -21,7 +21,7 @@ import org.joshsim.engine.value.type.EngineValue;
  * entities and spatial information. This specifically refers to those which recieve geometry by
  * being part of another entity like a Patch.</p>
  */
-public abstract class MemberSpatialEntity extends MutableEntity {
+public abstract class MemberSpatialEntity extends DirectLockMutableEntity {
 
   private final Entity parent;
 

--- a/src/main/java/org/joshsim/engine/entity/base/MutableEntity.java
+++ b/src/main/java/org/joshsim/engine/entity/base/MutableEntity.java
@@ -20,50 +20,16 @@ import org.joshsim.engine.value.type.EngineValue;
 
 
 /**
- * Represents a base entity that is mutable.
- * This class provides mechanisms for managing attributes and event handlers,
- * and supports locking to be thread-safe.
+ * An entity whose state can be mutated in-place.
  */
-public abstract class MutableEntity implements Entity, Lockable {
-
-  private final String name;
-  private final Map<EventKey, EventHandlerGroup> eventHandlerGroups;
-  private final Map<String, EngineValue> attributes;
-  private final Lock lock;
-
-  /**
-   * Constructor for Entity.
-   *
-   * @param name Name of the entity.
-   * @param eventHandlerGroups A map of event keys to their corresponding EventHandlerGroups.
-   * @param attributes A map of attribute names to their corresponding EngineValues.
-   */
-  public MutableEntity(
-      String name,
-      Map<EventKey, EventHandlerGroup> eventHandlerGroups,
-      Map<String, EngineValue> attributes
-  ) {
-    this.name = name;
-    this.eventHandlerGroups = eventHandlerGroups != null
-        ? eventHandlerGroups : new HashMap<>();
-    this.attributes = attributes != null
-        ? attributes : new HashMap<>();
-    lock = new ReentrantLock();
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
+public interface MutableEntity extends Entity, Lockable {
 
   /**
    * Get event handlers for all attributes and events.
    *
    * @returns Hashmap of (state x attribute x event) to EventHandlerGroups.
    */
-  public Iterable<EventHandlerGroup> getEventHandlers() {
-    return eventHandlerGroups.values();
-  }
+  Iterable<EventHandlerGroup> getEventHandlers();
 
   /**
    * Get event handlers for a specific attribute and event.
@@ -71,14 +37,10 @@ public abstract class MutableEntity implements Entity, Lockable {
    * @param eventKey The event for which handler groups should be returned.
    * @return the event handler group, or empty if it does not exist
    */
-  public Optional<EventHandlerGroup> getEventHandlers(EventKey eventKey) {
-    return Optional.ofNullable(eventHandlerGroups.get(eventKey));
-  }
+  public Optional<EventHandlerGroup> getEventHandlers(EventKey eventKey);
 
   @Override
-  public Optional<EngineValue> getAttributeValue(String name) {
-    return Optional.ofNullable(attributes.get(name));
-  }
+  public Optional<EngineValue> getAttributeValue(String name);
 
   /**
    * Set the value of an attribute by name.
@@ -86,53 +48,6 @@ public abstract class MutableEntity implements Entity, Lockable {
    * @param name the attribute name
    * @param value the value to set
    */
-  public void setAttributeValue(String name, EngineValue value) {
-    attributes.put(name, value);
-  }
-
-  @Override
-  public void lock() {
-    lock.lock();
-  }
-
-  @Override
-  public void unlock() {
-    lock.unlock();
-  }
-
-  @Override
-  public Entity freeze() {
-    Map<String, EngineValue> frozenAttributes = new HashMap<>();
-    
-    for (String attributeName : attributes.keySet()) {
-      EngineValue unfrozenValue = attributes.get(attributeName);
-      EngineValue frozenValue = unfrozenValue.freeze();
-      frozenAttributes.put(attributeName, frozenValue);
-    }
-    
-    return new FrozenEntity(
-        getEntityType(),
-        name,
-        frozenAttributes,
-        getGeometry()
-    );
-  }
-
-  @Override
-  public Iterable<String> getAttributeNames() {
-    return StreamSupport.stream(getEventHandlers().spliterator(), false)
-        .flatMap(group -> StreamSupport.stream(group.getEventHandlers().spliterator(), false))
-        .map(EventHandler::getAttributeName)
-        .collect(Collectors.toSet());
-  }
-
-  @Override
-  public Optional<GeoKey> getKey() {
-    if (getGeometry().isEmpty()) {
-      return Optional.empty();
-    } else {
-      return Optional.of(new GeoKey(this));
-    }
-  }
+  public void setAttributeValue(String name, EngineValue value);
 
 }

--- a/src/main/java/org/joshsim/engine/entity/base/RootSpatialEntity.java
+++ b/src/main/java/org/joshsim/engine/entity/base/RootSpatialEntity.java
@@ -19,7 +19,7 @@ import org.joshsim.engine.value.type.EngineValue;
  * <p>RootSpatialEntity is a type of SpatialEntity which has its own geometry as opposed to
  * inhering that geometry by being part of another entity.</p>
  */
-public abstract class RootSpatialEntity extends MutableEntity {
+public abstract class RootSpatialEntity extends DirectLockMutableEntity {
   private final Geometry geometry;
 
   /**

--- a/src/main/java/org/joshsim/engine/entity/prototype/EmbeddedParentEntityPrototype.java
+++ b/src/main/java/org/joshsim/engine/entity/prototype/EmbeddedParentEntityPrototype.java
@@ -1,8 +1,10 @@
 package org.joshsim.engine.entity.prototype;
 
 import org.joshsim.engine.entity.base.Entity;
+import org.joshsim.engine.entity.base.MutableEntity;
 import org.joshsim.engine.entity.type.EntityType;
 import org.joshsim.engine.geometry.Geometry;
+
 
 /**
  * Create a decorator that embeds a parent for an entity prototype.
@@ -37,7 +39,7 @@ public class EmbeddedParentEntityPrototype implements EntityPrototype {
   }
 
   @Override
-  public Entity build() {
+  public MutableEntity build() {
     if (inner.requiresParent()) {
       return inner.buildSpatial(parent);
     } else if (inner.requiresGeometry()) {
@@ -48,12 +50,12 @@ public class EmbeddedParentEntityPrototype implements EntityPrototype {
   }
 
   @Override
-  public Entity buildSpatial(Entity parent) {
+  public MutableEntity buildSpatial(Entity parent) {
     return inner.buildSpatial(parent);
   }
 
   @Override
-  public Entity buildSpatial(Geometry parent) {
+  public MutableEntity buildSpatial(Geometry parent) {
     return inner.buildSpatial(parent);
   }
 
@@ -66,5 +68,6 @@ public class EmbeddedParentEntityPrototype implements EntityPrototype {
   public boolean requiresGeometry() {
     return false;
   }
+
 
 }

--- a/src/main/java/org/joshsim/engine/entity/prototype/EntityPrototype.java
+++ b/src/main/java/org/joshsim/engine/entity/prototype/EntityPrototype.java
@@ -8,6 +8,7 @@ package org.joshsim.engine.entity.prototype;
 
 import org.joshsim.engine.entity.base.Entity;
 import org.joshsim.engine.entity.base.EntityBuilder;
+import org.joshsim.engine.entity.base.MutableEntity;
 import org.joshsim.engine.entity.type.EntityType;
 import org.joshsim.engine.geometry.Geometry;
 
@@ -42,7 +43,7 @@ public interface EntityPrototype {
    * @return A new Entity instance created from this prototype.
    * @throws RuntimeException if the entity type cannot be built without spatial context.
    */
-  Entity build();
+  MutableEntity build();
 
   /**
    * Builds a spatial entity instance from this prototype with a parent entity.
@@ -52,7 +53,7 @@ public interface EntityPrototype {
    * @return A new Entity instance created from this prototype.
    * @throws RuntimeException if the entity type cannot be built with a parent entity.
    */
-  Entity buildSpatial(Entity parent);
+  MutableEntity buildSpatial(Entity parent);
 
   /**
    * Builds a spatial entity instance from this prototype with a geometry parent.
@@ -62,7 +63,7 @@ public interface EntityPrototype {
    * @return A new Entity instance created from this prototype.
    * @throws RuntimeException if the entity type cannot be built with a geometry parent.
    */
-  Entity buildSpatial(Geometry parent);
+  MutableEntity buildSpatial(Geometry parent);
 
   /**
    * Determine if this entity prototype requires a parent to be provided to be constructed.

--- a/src/main/java/org/joshsim/engine/entity/prototype/ParentlessEntityPrototype.java
+++ b/src/main/java/org/joshsim/engine/entity/prototype/ParentlessEntityPrototype.java
@@ -8,6 +8,7 @@ package org.joshsim.engine.entity.prototype;
 
 import org.joshsim.engine.entity.base.Entity;
 import org.joshsim.engine.entity.base.EntityBuilder;
+import org.joshsim.engine.entity.base.MutableEntity;
 import org.joshsim.engine.entity.type.EntityType;
 import org.joshsim.engine.geometry.Geometry;
 
@@ -50,7 +51,7 @@ public class ParentlessEntityPrototype implements EntityPrototype {
   }
 
   @Override
-  public Entity build() {
+  public MutableEntity build() {
     return switch (entityType) {
       case EXTERNAL_RESOURCE -> throw new RuntimeException("External resources yet implemented.");
       case SIMULATION -> entityBuilder.buildSimulation();
@@ -59,7 +60,7 @@ public class ParentlessEntityPrototype implements EntityPrototype {
   }
 
   @Override
-  public Entity buildSpatial(Entity parent) {
+  public MutableEntity buildSpatial(Entity parent) {
     return switch (entityType) {
       case AGENT -> entityBuilder.buildAgent(parent);
       case DISTURBANCE -> entityBuilder.buildDisturbance(parent);
@@ -68,7 +69,7 @@ public class ParentlessEntityPrototype implements EntityPrototype {
   }
 
   @Override
-  public Entity buildSpatial(Geometry parent) {
+  public MutableEntity buildSpatial(Geometry parent) {
     return switch (entityType) {
       case PATCH -> entityBuilder.buildPatch(parent);
       default -> throw new RuntimeException("Cannot instantiate with a geometry: " + entityType);

--- a/src/main/java/org/joshsim/engine/entity/type/ExternalResource.java
+++ b/src/main/java/org/joshsim/engine/entity/type/ExternalResource.java
@@ -7,7 +7,7 @@
 package org.joshsim.engine.entity.type;
 
 import java.util.HashMap;
-import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.entity.base.DirectLockMutableEntity;
 import org.joshsim.engine.entity.handler.EventHandlerGroup;
 import org.joshsim.engine.entity.handler.EventKey;
 import org.joshsim.engine.geometry.Geometry;
@@ -21,7 +21,7 @@ import org.joshsim.engine.value.type.EngineValue;
  * <p>Represents an external resource entity in the system which provides access to distributed
  * values based on a geometry and attribute-sensitive paths.</p>
  */
-public abstract class ExternalResource extends MutableEntity {
+public abstract class ExternalResource extends DirectLockMutableEntity {
   /**
    * Constructor for a ExternalResource, which allows access to external data to influence Entities.
    *

--- a/src/main/java/org/joshsim/engine/simulation/Simulation.java
+++ b/src/main/java/org/joshsim/engine/simulation/Simulation.java
@@ -8,7 +8,7 @@ package org.joshsim.engine.simulation;
 
 import java.util.Map;
 import java.util.Optional;
-import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.entity.base.DirectLockMutableEntity;
 import org.joshsim.engine.entity.handler.EventHandlerGroup;
 import org.joshsim.engine.entity.handler.EventKey;
 import org.joshsim.engine.entity.type.EntityType;
@@ -18,7 +18,7 @@ import org.joshsim.engine.value.type.EngineValue;
 /**
  * Simulation entity with cross-timestep attributes.
  */
-public class Simulation extends MutableEntity {
+public class Simulation extends DirectLockMutableEntity {
 
   /**
    * Constructor for a Simulation, which contains 'meta' attributes and event handlers.

--- a/src/main/java/org/joshsim/lang/bridge/ShadowingEntityPrototype.java
+++ b/src/main/java/org/joshsim/lang/bridge/ShadowingEntityPrototype.java
@@ -1,0 +1,73 @@
+package org.joshsim.lang.bridge;
+
+import org.joshsim.engine.entity.base.Entity;
+import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.entity.prototype.EntityPrototype;
+import org.joshsim.engine.entity.type.EntityType;
+import org.joshsim.engine.func.Scope;
+import org.joshsim.engine.geometry.Geometry;
+
+
+/**
+ * Create a decorator that builds a ShadowingEntity from a scope.
+ */
+public class ShadowingEntityPrototype implements EntityPrototype {
+
+  private final EntityPrototype inner;
+  private final Scope scope;
+
+  /**
+   * Decorate a prototype with parent information.
+   *
+   * @param inner Prototype for entity to be decorated as a ShadowingEntity.
+   * @param scope The Scope from which to read required attributes.
+   */
+  public ShadowingEntityPrototype(EntityPrototype inner, Scope scope) {
+    this.inner = inner;
+    this.scope = scope;
+  }
+
+  @Override
+  public String getIdentifier() {
+    return inner.getIdentifier();
+  }
+
+  @Override
+  public EntityType getEntityType() {
+    return inner.getEntityType();
+  }
+
+  @Override
+  public MutableEntity build() {
+    return inner.build();
+  }
+
+  @Override
+  public MutableEntity buildSpatial(Entity parent) {
+    return inner.buildSpatial(parent);
+  }
+
+  @Override
+  public MutableEntity buildSpatial(Geometry parent) {
+    return inner.buildSpatial(parent);
+  }
+
+  @Override
+  public boolean requiresParent() {
+    return inner.requiresParent();
+  }
+
+  @Override
+  public boolean requiresGeometry() {
+    return inner.requiresGeometry();
+  }
+
+  private MutableEntity wrap(MutableEntity entityToWrap) {
+    return new ShadowingEntity(
+        entityToWrap,
+        scope.get("here").getAsEntity(),
+        scope.get("meta").getAsEntity()
+    );
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -28,6 +28,7 @@ import org.joshsim.engine.value.type.Distribution;
 import org.joshsim.engine.value.type.EngineValue;
 import org.joshsim.engine.value.type.Scalar;
 import org.joshsim.lang.bridge.EngineBridge;
+import org.joshsim.lang.bridge.ShadowingEntityPrototype;
 import org.joshsim.lang.interpret.ValueResolver;
 import org.joshsim.lang.interpret.action.EventHandlerAction;
 
@@ -373,9 +374,13 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
   @Override
   public EventHandlerMachine createEntity(String entityType) {
     EntityPrototype prototype = bridge.getPrototype(entityType);
-    EmbeddedParentEntityPrototype decoratedPrototype = new EmbeddedParentEntityPrototype(
+    EntityPrototype innerDecorated = new EmbeddedParentEntityPrototype(
         prototype,
         scope.get("current").getAsEntity()
+    );
+    EntityPrototype decoratedPrototype = new ShadowingEntityPrototype(
+        innerDecorated,
+        scope
     );
 
     EngineValue countValue = convert(pop(), COUNT_UNITS);

--- a/src/test/java/org/joshsim/engine/entity/prototype/EmbeddedParentEntityPrototypeTest.java
+++ b/src/test/java/org/joshsim/engine/entity/prototype/EmbeddedParentEntityPrototypeTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.joshsim.engine.entity.base.Entity;
+import org.joshsim.engine.entity.base.MutableEntity;
 import org.joshsim.engine.geometry.Geometry;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,7 @@ class EmbeddedParentEntityPrototypeTest {
         innerPrototype,
         parentEntity
     );
-    Entity expectedEntity = mock(Entity.class);
+    MutableEntity expectedEntity = mock(MutableEntity.class);
 
     when(innerPrototype.requiresParent()).thenReturn(true);
     when(innerPrototype.buildSpatial(parentEntity)).thenReturn(expectedEntity);
@@ -49,7 +50,7 @@ class EmbeddedParentEntityPrototypeTest {
         innerPrototype,
         parentEntity
     );
-    Entity expectedEntity = mock(Entity.class);
+    MutableEntity expectedEntity = mock(MutableEntity.class);
 
     when(innerPrototype.requiresParent()).thenReturn(false);
     when(innerPrototype.requiresGeometry()).thenReturn(true);
@@ -71,7 +72,7 @@ class EmbeddedParentEntityPrototypeTest {
         innerPrototype,
         parentEntity
     );
-    Entity expectedEntity = mock(Entity.class);
+    MutableEntity expectedEntity = mock(MutableEntity.class);
 
     when(innerPrototype.requiresParent()).thenReturn(false);
     when(innerPrototype.requiresGeometry()).thenReturn(false);

--- a/src/test/java/org/joshsim/lang/bridge/ShadowingEntityTest.java
+++ b/src/test/java/org/joshsim/lang/bridge/ShadowingEntityTest.java
@@ -81,13 +81,16 @@ public class ShadowingEntityTest {
     EngineValue priorValue = spatialEntity.getPriorAttribute(attrName);
     assertEquals(mockEngineValue, priorValue);
 
-    spatialEntity.setCurrentAttribute(attrName, mockEngineValue);
+    spatialEntity.setAttributeValue(attrName, mockEngineValue);
     verify(mockSpatialEntity).setAttributeValue(attrName, mockEngineValue);
   }
 
   @Test
   void testGetHandlersFailsOutsideSubstep() {
-    assertThrows(IllegalStateException.class, () -> spatialEntity.getHandlers("testAttr"));
+    assertThrows(
+        IllegalStateException.class,
+        () -> spatialEntity.getHandlersForAttribute("testAttr")
+    );
   }
 
   @Test
@@ -100,7 +103,7 @@ public class ShadowingEntityTest {
         .thenReturn(Optional.of(mockEventHandlerGroup));
 
     spatialEntity.startSubstep(substepName);
-    Optional<EventHandlerGroup> handlers = spatialEntity.getHandlers(attrName);
+    Optional<EventHandlerGroup> handlers = spatialEntity.getHandlersForAttribute(attrName);
     assertTrue(handlers.isPresent());
     spatialEntity.endSubstep();
   }
@@ -119,7 +122,7 @@ public class ShadowingEntityTest {
     when(mockSpatialEntity.getAttributeValue(attrName)).thenReturn(Optional.of(mockEngineValue));
 
     spatialEntity.startSubstep(substepName);
-    spatialEntity.setCurrentAttribute(attrName, mockEngineValue);
+    spatialEntity.setAttributeValue(attrName, mockEngineValue);
     Optional<EngineValue> result = spatialEntity.getAttributeValue(attrName);
 
     assertFalse(result.isEmpty());
@@ -141,7 +144,7 @@ public class ShadowingEntityTest {
   void testNonexistentAttributeAccess() {
     String nonexistentAttr = "nonexistent";
     assertThrows(IllegalArgumentException.class, () ->
-        spatialEntity.setCurrentAttribute(nonexistentAttr, mockEngineValue));
+        spatialEntity.setAttributeValue(nonexistentAttr, mockEngineValue));
     assertThrows(IllegalArgumentException.class, () ->
         spatialEntity.getPriorAttribute(nonexistentAttr));
   }

--- a/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.joshsim.engine.entity.base.Entity;
+import org.joshsim.engine.entity.base.MutableEntity;
 import org.joshsim.engine.entity.prototype.EntityPrototype;
 import org.joshsim.engine.func.Scope;
 import org.joshsim.engine.geometry.Geometry;
@@ -51,7 +52,7 @@ public class SingleThreadEventHandlerMachineTest {
   @Mock(lenient = true) private Distribution mockDistribution;
   @Mock(lenient = true) private EngineBridge mockBridge;
   @Mock(lenient = true) private EntityPrototype mockPrototype;
-  @Mock(lenient = true) private Entity mockCreatedEntity;
+  @Mock(lenient = true) private MutableEntity mockCreatedEntity;
 
   private SingleThreadEventHandlerMachine machine;
   private EngineValueFactory factory;


### PR DESCRIPTION
Ensure that the virtual machine for the interpreter is building shadowing entities to ensure imperative resolution is happening automatically.