### PR TITLE
Add CSV export for patches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 
   // Apache Commons Collections for LRUMap
   implementation("org.apache.commons:commons-collections4:4.5.0-M3")
+  
+  // Apache Commons CSV for CSV handling
+  implementation("org.apache.commons:commons-csv:1.10.0")
 
   // Geotools for Raster transformations and COG support
   implementation("org.geotools:gt-main:32.2")

--- a/examples/simulations/simple.josh
+++ b/examples/simulations/simple.josh
@@ -10,6 +10,8 @@ start simulation TestSimpleSimulation
   stepCount.init = 0 count
   stepCount.step = prior.stepCount + 1 count
 
+  exportFiles.patch = "file:///tmp/simple_josh.csv"
+
 end simulation
 
 
@@ -17,8 +19,8 @@ start patch Default
 
   ForeverTree.init = create ForeverTree
 
-  averageAge.step = mean(ForeverTree.age)
-  averageHeight.step = mean(ForeverTree.height)
+  export.averageAge.step = mean(ForeverTree.age)
+  export.averageHeight.step = mean(ForeverTree.height)
 
 end patch
 

--- a/examples/simulations/stress.josh
+++ b/examples/simulations/stress.josh
@@ -10,6 +10,8 @@ start simulation TestSimpleSimulation
   stepCount.init = 0 count
   stepCount.step = prior.stepCount + 1 count
 
+  exportFiles.patch = "file:///tmp/stress_josh.csv"
+
 end simulation
 
 
@@ -17,8 +19,8 @@ start patch Default
 
   ForeverTree.init = create ForeverTree
 
-  averageAge.step = mean(ForeverTree.age)
-  averageHeight.step = mean(ForeverTree.height)
+  export.averageAge.step = mean(ForeverTree.age)
+  export.averageHeight.step = mean(ForeverTree.height)
 
 end patch
 

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -24,4 +24,6 @@ assert_ok() {
   fi
 }
 
+rm -f /tmp/simple_josh.csv
 assert_ok examples/simulations/simple.josh TestSimpleSimulation || exit 1
+[ -f "/tmp/simple_josh.csv" ] || exit 2

--- a/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
+++ b/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
@@ -40,6 +40,7 @@ RCURLY_: '}';
 RPAREN_: ')';
 
 // Keywords
+AGENT_: 'agent';
 ALIAS_: 'alias';
 ALL_: 'all';
 AND_: 'and';
@@ -99,7 +100,7 @@ IDENTIFIER_: [A-Za-z][A-Za-z0-9]*;
 WHITE_SPACE: [ \u000B\t\r\n] -> channel(HIDDEN);
 
 // Identifiers
-nakedIdentifier: (IDENTIFIER_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_);
+nakedIdentifier: (IDENTIFIER_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_);
 identifier: nakedIdentifier (DOT_ (nakedIdentifier))*;
 
 // Values

--- a/src/main/java/org/joshsim/JoshSimFacade.java
+++ b/src/main/java/org/joshsim/JoshSimFacade.java
@@ -92,7 +92,9 @@ public class JoshSimFacade {
 
       if (patchExportFacade.isPresent()) {
         TimeStep stepCompleted = bridge.getReplicate().getTimeStep(completedStep).orElseThrow();
-        stepCompleted.getPatches().forEach((x) -> patchExportFacade.get().write(x));
+        stepCompleted.getPatches().forEach(
+            (x) -> patchExportFacade.get().write(x, completedStep)
+        );
       }
 
       if (completedStep > 2) {
@@ -113,7 +115,7 @@ public class JoshSimFacade {
 
     Optional<ExportFacade> exportFacade;
     if (destination.isPresent()) {
-      ExportTarget target = ExportTargetParser.parse(destination.get().toString());
+      ExportTarget target = ExportTargetParser.parse(destination.get().getAsString());
       exportFacade = Optional.of(ExportFacadeFactory.build(target));
     } else {
       exportFacade = Optional.empty();

--- a/src/main/java/org/joshsim/JoshSimFacade.java
+++ b/src/main/java/org/joshsim/JoshSimFacade.java
@@ -6,6 +6,7 @@
 
 package org.joshsim;
 
+import java.util.Optional;
 import org.joshsim.engine.entity.base.MutableEntity;
 import org.joshsim.engine.simulation.TimeStep;
 import org.joshsim.engine.value.type.EngineValue;
@@ -21,8 +22,6 @@ import org.joshsim.lang.interpret.JoshInterpreter;
 import org.joshsim.lang.interpret.JoshProgram;
 import org.joshsim.lang.parse.JoshParser;
 import org.joshsim.lang.parse.ParseResult;
-
-import java.util.Optional;
 
 
 /**

--- a/src/main/java/org/joshsim/lang/bridge/CombinedExportFacade.java
+++ b/src/main/java/org/joshsim/lang/bridge/CombinedExportFacade.java
@@ -1,3 +1,9 @@
+/**
+ * Convenience facade to run zero or more exports.
+ *
+ * @license BSD-3-Clause
+ */
+
 package org.joshsim.lang.bridge;
 
 import java.util.Optional;
@@ -11,7 +17,11 @@ import org.joshsim.lang.export.ExportTargetParser;
 
 
 /**
- * Convenience function that manages zero or more exports.
+ * Convenience facade that manages zero or more exports.
+ *
+ * <p>Facade which constructs and manages individual export facades, one per requested export type
+ * where these types may include patch, simulation, and / or agent. If no export file locations are
+ * specified, this facade acts as a no-op.</p>
  */
 public class CombinedExportFacade {
 

--- a/src/main/java/org/joshsim/lang/bridge/CombinedExportFacade.java
+++ b/src/main/java/org/joshsim/lang/bridge/CombinedExportFacade.java
@@ -1,0 +1,110 @@
+package org.joshsim.lang.bridge;
+
+import java.util.Optional;
+import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.simulation.TimeStep;
+import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.lang.export.ExportFacade;
+import org.joshsim.lang.export.ExportFacadeFactory;
+import org.joshsim.lang.export.ExportTarget;
+import org.joshsim.lang.export.ExportTargetParser;
+
+
+/**
+ * Convenience function that manages zero or more exports.
+ */
+public class CombinedExportFacade {
+
+  private final Optional<ExportFacade> patchExportFacade;
+
+  /**
+   * Constructs a facade to manage export operations across multiple export files.
+   *
+   * @param simEntity the mutable entity representing the simulation context, used to retrieve and
+   *     configure the patch export facade.
+   */
+  public CombinedExportFacade(MutableEntity simEntity) {
+    patchExportFacade = getPatchExportFacade(simEntity);
+  }
+
+  /**
+   * Write the result of a time step if requested.
+   *
+   * <p>Writes all entities from a given simulation time step to the export target, if the export
+   * facade for that type is present. Each patch entity is processed and serialized along with the
+   * time step number.</p>
+   *
+   * @param stepCompleted The completed time step containing the patches to be written
+   *     and the step number to associate with them.
+   */
+  public void write(TimeStep stepCompleted) {
+    patchExportFacade.ifPresent(exportFacade -> stepCompleted.getPatches().forEach(
+        (x) -> exportFacade.write(x, stepCompleted.getStep())
+    ));
+  }
+
+  /**
+   * Starts the export process for the requested export facades.
+   *
+   * <p>Invokes the start method on the underlying ExportFacade instance associated
+   * with the various export facades, if they exist. This triggers the dedicated writer
+   * threads to begin processing and serializing entities for export.</p>
+   */
+  public void start() {
+    patchExportFacade.ifPresent(ExportFacade::start);
+  }
+
+  /**
+   * Waits for the completion of the export process, if a patch export facade is present.
+   *
+   * <p>Invokes the join method on the various underlying ExportFacade instances behind this facade,
+   * ensuring all pending entities  in the export queue are processed and written before the
+   * dedicated writer threads terminate.</p>
+   */
+  public void join() {
+    patchExportFacade.ifPresent(ExportFacade::join);
+  }
+
+  /**
+   * Retrieves the patch-specific export facade based on the provided simulation entity.
+   *
+   * @param simEntity the mutable entity representing the simulation context. It is used to fetch
+   *     the attribute configuration and initialize the export facades.
+   * @return an Optional containing the relevant ExportFacade or an empty Optional if configuration
+   *     is not found.
+   */
+  private Optional<ExportFacade> getPatchExportFacade(MutableEntity simEntity) {
+    return getExportFacade(simEntity, "exportFiles.patch");
+  }
+
+  /**
+   * Retrieves an ExportFacade instance based on the given simulation entity and attribute.
+   *
+   * <p>This method starts a substep within the simulation entity, attempts to retrieve the
+   * attribute value specified by the given attribute name, and constructs an ExportFacade if the
+   * attribute value is valid. If no valid attribute value exists, an empty Optional is returned.
+   * The substep is ended after the processing is completed.</p>
+   *
+   * @param simEntity the mutable entity representing the simulation context from which
+   *     the attribute value is retrieved and the ExportFacade is constructed.
+   * @param attribute the name of the attribute used to determine the target export configuration.
+   * @return an Optional containing the constructed ExportFacade, or an empty Optional if
+   *     the attribute value is not present or invalid.
+   */
+  private Optional<ExportFacade> getExportFacade(MutableEntity simEntity, String attribute) {
+    simEntity.startSubstep("constant");
+    Optional<EngineValue> destination = simEntity.getAttributeValue(attribute);
+
+    Optional<ExportFacade> exportFacade;
+    if (destination.isPresent()) {
+      ExportTarget target = ExportTargetParser.parse(destination.get().getAsString());
+      exportFacade = Optional.of(ExportFacadeFactory.build(target));
+    } else {
+      exportFacade = Optional.empty();
+    }
+
+    simEntity.endSubstep();
+    return exportFacade;
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/bridge/ShadowingEntity.java
+++ b/src/main/java/org/joshsim/lang/bridge/ShadowingEntity.java
@@ -367,7 +367,7 @@ public class ShadowingEntity implements MutableEntity {
 
     // If failed to match, use prior
     if (executed) {
-      if (name.startsWith("assert.")) {
+      if (checkAssertions && name.startsWith("assert.")) {
         Optional<EngineValue> result = getAttributeValue(name);
         if (result.isPresent()) {
           boolean value = result.get().getAsBoolean();

--- a/src/main/java/org/joshsim/lang/bridge/SimulationStepper.java
+++ b/src/main/java/org/joshsim/lang/bridge/SimulationStepper.java
@@ -120,12 +120,10 @@ public class SimulationStepper {
   private MutableEntity updateEntity(MutableEntity target, String subStep) {
     target.startSubstep(subStep);
 
-    StreamSupport.stream(target.getAttributeNames().spliterator(), false)
-        .map((x) -> {
-          return target.getAttributeValue(x);
-        })
-        .filter((x) -> x.isPresent())
-        .map((x) -> x.get())
+    target.getAttributeNames().stream()
+        .map(target::getAttributeValue)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
         .filter((x) -> x.getLanguageType().containsAttributes())
         .forEach((x) -> {
           Optional<Integer> sizeMaybe = x.getSize();

--- a/src/main/java/org/joshsim/lang/export/CsvExportFacade.java
+++ b/src/main/java/org/joshsim/lang/export/CsvExportFacade.java
@@ -24,7 +24,7 @@ public class CsvExportFacade implements ExportFacade {
 
   private final OutputStreamStrategy outputStrategy;
 
-  private final Queue<Entity> entityQueue = new ConcurrentLinkedQueue<>();
+  private final Queue<Task> entityQueue = new ConcurrentLinkedQueue<>();
   private final ExecutorService executorService = Executors.newSingleThreadExecutor();
   private final AtomicBoolean active = new AtomicBoolean(false);
 
@@ -52,14 +52,19 @@ public class CsvExportFacade implements ExportFacade {
         ExportSerializeStrategy<Map<String, String>> serializeStrategy = new MapSerializeStrategy();
         ExportWriteStrategy<Map<String, String>> writeStrategy = new CsvWriteStrategy();
 
-        while (active.get() || !entityQueue.isEmpty()) {
-          Entity entity = entityQueue.poll();
-          if (entity == null) {
+        while (active.get()) {
+          Task task = entityQueue.poll();
+
+          if (task == null) {
             writeStrategy.flush();
             trySleep();
           } else {
+            Entity entity = task.getEntity();
+            long step = task.getStep();
+
             try {
               Map<String, String> serialized = serializeStrategy.getRecord(entity);
+              serialized.put("step", Long.toString(step));
               writeStrategy.write(serialized, outputStream);
             } catch (IOException e) {
               throw new RuntimeException("Error writing to output stream", e);
@@ -88,11 +93,23 @@ public class CsvExportFacade implements ExportFacade {
   }
 
   @Override
-  public void write(Entity entity) {
+  public void write(Entity entity, long step) {
+    Task task = new Task(entity, step);
+    write(task);
+  }
+
+  /**
+   * Adds a task to the queue for processing while ensuring the export process is active.
+   *
+   * @param task The task containing an entity and step value to be queued for export processing.
+   * @throws IllegalStateException If the export process is not active when this method is invoked.
+   */
+  public void write(Task task) {
     if (!active.get()) {
       throw new IllegalStateException("CsvExportFacade is not active. Cannot write entities.");
     }
-    entityQueue.add(entity);
+
+    entityQueue.add(task);
   }
 
   /**
@@ -105,6 +122,45 @@ public class CsvExportFacade implements ExportFacade {
       Thread.sleep(100);
     } catch (InterruptedException e) {
       throw new RuntimeException("Interrupted while sleeping", e);
+    }
+  }
+
+  /**
+   * Represents a task containing an entity and a step value.
+   */
+  public static class Task {
+
+    private final Entity entity;
+
+    private final long step;
+
+    /**
+     * Constructs a new Task with the specified entity and step value.
+     *
+     * @param entity The entity associated with this task.
+     * @param step   The step value representing additional metadata for this task.
+     */
+    public Task(Entity entity, long step) {
+      this.entity = entity;
+      this.step = step;
+    }
+
+    /**
+     * Get the entity associated with this task.
+     *
+     * @return The entity object.
+     */
+    public Entity getEntity() {
+      return entity;
+    }
+
+    /**
+     * Get the step value for this task.
+     *
+     * @return The step value as a long.
+     */
+    public long getStep() {
+      return step;
     }
   }
 }

--- a/src/main/java/org/joshsim/lang/export/CsvExportFacade.java
+++ b/src/main/java/org/joshsim/lang/export/CsvExportFacade.java
@@ -1,0 +1,110 @@
+/**
+ * Structures to simplify writing entities to CSV.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.export;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.joshsim.engine.entity.base.Entity;
+
+
+/**
+ * Strategy implementing ExportFacade which writes entities to CSV in a writer thread.
+ */
+public class CsvExportFacade implements ExportFacade {
+
+  private final OutputStreamStrategy outputStrategy;
+
+  private final Queue<Entity> entityQueue = new ConcurrentLinkedQueue<>();
+  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+  private final AtomicBoolean active = new AtomicBoolean(false);
+
+  /**
+   * Constructs a CsvExportFacade object with the specified export target / output stream strategy.
+   *
+   * @param outputStrategy The strategy to provide an output stream for writing the exported data.
+   */
+  public CsvExportFacade(OutputStreamStrategy outputStrategy) {
+    this.outputStrategy = outputStrategy;
+  }
+
+  @Override
+  public void start() {
+    if (active.compareAndSet(false, true)) {
+      executorService.submit(() -> {
+
+        OutputStream outputStream;
+        try {
+          outputStream = outputStrategy.open();
+        } catch (IOException e) {
+          throw new RuntimeException("Error opening output stream", e);
+        }
+
+        ExportSerializeStrategy<Map<String, String>> serializeStrategy = new MapSerializeStrategy();
+        ExportWriteStrategy<Map<String, String>> writeStrategy = new CsvWriteStrategy();
+
+        while (active.get() || !entityQueue.isEmpty()) {
+          Entity entity = entityQueue.poll();
+          if (entity == null) {
+            writeStrategy.flush();
+            trySleep();
+          } else {
+            try {
+              Map<String, String> serialized = serializeStrategy.getRecord(entity);
+              writeStrategy.write(serialized, outputStream);
+            } catch (IOException e) {
+              throw new RuntimeException("Error writing to output stream", e);
+            }
+          }
+        }
+
+        writeStrategy.flush();
+
+        try {
+          outputStream.close();
+        } catch (IOException e) {
+          throw new RuntimeException("Error closing output stream", e);
+        }
+      });
+    }
+  }
+
+  @Override
+  public void join() {
+    active.set(false);
+    executorService.shutdown();
+    while (!executorService.isTerminated()) {
+      trySleep();
+    }
+  }
+
+  @Override
+  public void write(Entity entity) {
+    if (!active.get()) {
+      throw new IllegalStateException("CsvExportFacade is not active. Cannot write entities.");
+    }
+    entityQueue.add(entity);
+  }
+
+  /**
+   * Causes the executing thread to sleep to avoid thrashing.
+   *
+   * @throws RuntimeException If the thread is interrupted during the sleep operation.
+   */
+  private void trySleep() {
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted while sleeping", e);
+    }
+  }
+}

--- a/src/main/java/org/joshsim/lang/export/CsvWriteStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/CsvWriteStrategy.java
@@ -1,3 +1,8 @@
+/**
+ * Logic to write CSV files.
+ *
+ * @license BSD-3-Clause
+ */
 
 package org.joshsim.lang.export;
 
@@ -10,33 +15,43 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 
 
+/**
+ * Implementation of the ExportWriteStrategy interface for writing CSV files.
+ *
+ * <p>Class  responsible for serializing a stream of records, where each record  is represented as a
+ * Map<String, String>, into a CSV format and writing it to an output stream. The first record in
+ * the stream is used to extract and define the CSV headers. The headers are determined by the keys
+ * of the map, and subsequent rows are written in the order of the corresponding values for the
+ * keys.</p>
+ */
 public class CsvWriteStrategy implements ExportWriteStrategy<Map<String, String>> {
 
   @Override
   public void write(Stream<Map<String, String>> records, OutputStream output) throws IOException {
-    try (OutputStreamWriter writer = new OutputStreamWriter(output);
-         CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT)) {
-      
-      // Get the first record to determine headers
-      Map<String, String> firstRecord = records.findFirst().orElse(null);
-      if (firstRecord == null) {
-        return;
-      }
-      
-      // Write headers
-      printer.printRecord(firstRecord.keySet());
-      
-      // Write first record
-      printer.printRecord(firstRecord.values());
-      
-      // Write remaining records
-      records.forEach(record -> {
-        try {
-          printer.printRecord(record.values());
-        } catch (IOException e) {
-          throw new RuntimeException("Failed to write CSV record due to: " + e);
+    try (OutputStreamWriter writer = new OutputStreamWriter(output)) {
+      try (CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT)) {
+
+        // Get the first record to determine headers
+        Map<String, String> firstRecord = records.findFirst().orElse(null);
+        if (firstRecord == null) {
+          return;
         }
-      });
+
+        // Write headers
+        printer.printRecord(firstRecord.keySet());
+
+        // Write first record
+        printer.printRecord(firstRecord.values());
+
+        // Write remaining records
+        records.forEach(record -> {
+          try {
+            printer.printRecord(record.values());
+          } catch (IOException e) {
+            throw new RuntimeException("Failed to write CSV record due to: " + e);
+          }
+        });
+      }
     }
   }
 }

--- a/src/main/java/org/joshsim/lang/export/CsvWriteStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/CsvWriteStrategy.java
@@ -1,0 +1,16 @@
+package org.joshsim.lang.export;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.stream.Stream;
+
+
+public class CsvWriteStrategy implements ExportWriteStrategy<Map<String, String>> {
+
+  @Override
+  public void write(Stream<Map<String, String>> records, OutputStream output) throws IOException {
+
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/export/CsvWriteStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/CsvWriteStrategy.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 
+
 public class CsvWriteStrategy implements ExportWriteStrategy<Map<String, String>> {
 
   @Override
@@ -18,22 +19,24 @@ public class CsvWriteStrategy implements ExportWriteStrategy<Map<String, String>
       
       // Get the first record to determine headers
       Map<String, String> firstRecord = records.findFirst().orElse(null);
-      if (firstRecord != null) {
-        // Write headers
-        printer.printRecord(firstRecord.keySet());
-        
-        // Write first record
-        printer.printRecord(firstRecord.values());
-        
-        // Write remaining records
-        records.forEach(record -> {
-          try {
-            printer.printRecord(record.values());
-          } catch (IOException e) {
-            throw new RuntimeException("Failed to write CSV record", e);
-          }
-        });
+      if (firstRecord == null) {
+        return;
       }
+      
+      // Write headers
+      printer.printRecord(firstRecord.keySet());
+      
+      // Write first record
+      printer.printRecord(firstRecord.values());
+      
+      // Write remaining records
+      records.forEach(record -> {
+        try {
+          printer.printRecord(record.values());
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to write CSV record due to: " + e);
+        }
+      });
     }
   }
 }

--- a/src/main/java/org/joshsim/lang/export/CsvWriteStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/CsvWriteStrategy.java
@@ -1,16 +1,39 @@
+
 package org.joshsim.lang.export;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.util.Map;
 import java.util.stream.Stream;
-
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 
 public class CsvWriteStrategy implements ExportWriteStrategy<Map<String, String>> {
 
   @Override
   public void write(Stream<Map<String, String>> records, OutputStream output) throws IOException {
-
+    try (OutputStreamWriter writer = new OutputStreamWriter(output);
+         CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT)) {
+      
+      // Get the first record to determine headers
+      Map<String, String> firstRecord = records.findFirst().orElse(null);
+      if (firstRecord != null) {
+        // Write headers
+        printer.printRecord(firstRecord.keySet());
+        
+        // Write first record
+        printer.printRecord(firstRecord.values());
+        
+        // Write remaining records
+        records.forEach(record -> {
+          try {
+            printer.printRecord(record.values());
+          } catch (IOException e) {
+            throw new RuntimeException("Failed to write CSV record", e);
+          }
+        });
+      }
+    }
   }
-
 }

--- a/src/main/java/org/joshsim/lang/export/CsvWriteStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/CsvWriteStrategy.java
@@ -10,47 +10,64 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.util.Map;
-import java.util.stream.Stream;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
-
 
 /**
  * Implementation of the ExportWriteStrategy interface for writing CSV files.
  *
  * <p>Class  responsible for serializing a stream of records, where each record  is represented as a
- * Map<String, String>, into a CSV format and writing it to an output stream. The first record in
+ * Map (String, String), into a CSV format and writing it to an output stream. The first record in
  * the stream is used to extract and define the CSV headers. The headers are determined by the keys
  * of the map, and subsequent rows are written in the order of the corresponding values for the
  * keys.</p>
  */
 public class CsvWriteStrategy implements ExportWriteStrategy<Map<String, String>> {
 
+  private boolean onFirstRecord;
+  private CSVPrinter printer;
+  private OutputStreamWriter writer;
+
+  /**
+   * Create a new CSV write strategy for Map inputs.
+   *
+   * <p>Constructs a CsvWriteStrategy instance which will use the first record provided to sniff and
+   * write a header row.</p>
+   */
+  public CsvWriteStrategy() {
+    this.onFirstRecord = true;
+    this.printer = null;
+    this.writer = null;
+  }
+
   @Override
-  public void write(Stream<Map<String, String>> records, OutputStream output) throws IOException {
-    try (OutputStreamWriter writer = new OutputStreamWriter(output)) {
-      try (CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT)) {
+  public void write(Map<String, String> record, OutputStream output) throws IOException {
+    if (onFirstRecord) {
+      this.writer = new OutputStreamWriter(output);
+      this.printer = new CSVPrinter(writer, CSVFormat.DEFAULT
+          .builder()
+          .setHeader(record.keySet().toArray(new String[0]))
+          .build());
+      onFirstRecord = false;
+    }
+    printer.printRecord(record.values());
+  }
 
-        // Get the first record to determine headers
-        Map<String, String> firstRecord = records.findFirst().orElse(null);
-        if (firstRecord == null) {
-          return;
-        }
+  @Override
+  public void flush() {
+    if (printer != null) {
+      try {
+        printer.flush();
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to flush CSVPrinter", e);
+      }
+    }
 
-        // Write headers
-        printer.printRecord(firstRecord.keySet());
-
-        // Write first record
-        printer.printRecord(firstRecord.values());
-
-        // Write remaining records
-        records.forEach(record -> {
-          try {
-            printer.printRecord(record.values());
-          } catch (IOException e) {
-            throw new RuntimeException("Failed to write CSV record due to: " + e);
-          }
-        });
+    if (writer != null) {
+      try {
+        writer.flush();
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to flush OutputStreamWriter", e);
       }
     }
   }

--- a/src/main/java/org/joshsim/lang/export/ExportFacade.java
+++ b/src/main/java/org/joshsim/lang/export/ExportFacade.java
@@ -37,7 +37,8 @@ public interface ExportFacade {
    * Adds the specified entity to the queue for processing and writing to the export target.
    *
    * @param target The entity to be serialized and written to the output.
+   * @param step The step number from the simulation from which this entity snapshot was created.
    */
-  void write(Entity target);
+  void write(Entity target, long step);
 
 }

--- a/src/main/java/org/joshsim/lang/export/ExportFacade.java
+++ b/src/main/java/org/joshsim/lang/export/ExportFacade.java
@@ -1,32 +1,43 @@
+/**
+ * Structures describing high level strategies to write entities to persistence.
+ *
+ * @license BSD-3-Clause
+ */
+
 package org.joshsim.lang.export;
 
+import org.joshsim.engine.entity.base.Entity;
 
-import java.io.OutputStream;
 
-public class ExportFacade {
+/**
+ * Strategy to serialize and write entities to persistence in a separate writer thread.
+ */
+public interface ExportFacade {
 
-  private final ExportSerializeStrategy<?> serializeStrategy;
-  private final ExportWriteStrategy<?> writeStrategy;
-  private final OutputStream outputStream;
+  /**
+   * Starts the export process in a dedicated writer thread.
+   *
+   * <p>Begin processing entities to be written to the export target in a writer thread which
+   * operates in the background, serializing and writing entities to the output location as they are
+   * added to the queue. If the export process is already active, calling this method has no effect.
+   * </p>
+   */
+  void start();
 
-  public ExportFacade(ExportTarget exportTarget) {
-    if (!exportTarget.getFormat().equalsIgnoreCase("CSV")) {
-      throw new IllegalArgumentException("ExportTarget must have CSV format.");
-    }
+  /**
+   * Stops the export process and waits for the completion of the writer thread.
+   *
+   * <p>Ensure that all pending entities in the queue are processed and written to the output
+   * before shutting down the writer thread, blocking until the writer thread is fully terminated
+   * which occurs when its queue is empty.</p>
+   */
+  void join();
 
-    this.serializeStrategy = new MapSerializeStrategy();
-    this.writeStrategy = new CsvWriteStrategy(); // Assuming CsvWriteStrategy is implemented.
-
-    if (!exportTarget.isLocalPath()) {
-      throw new IllegalArgumentException("ExportTarget must have a local path.");
-    }
-
-    try {
-      this.outputStream = new FileOutputStream(exportTarget.getPath());
-    } catch (IOException e) {
-      throw new IllegalArgumentException("Unable to open file for writing: " + exportTarget.getPath(), e);
-    }
-
-  }
+  /**
+   * Adds the specified entity to the queue for processing and writing to the export target.
+   *
+   * @param target The entity to be serialized and written to the output.
+   */
+  void write(Entity target);
 
 }

--- a/src/main/java/org/joshsim/lang/export/ExportFacade.java
+++ b/src/main/java/org/joshsim/lang/export/ExportFacade.java
@@ -1,0 +1,32 @@
+package org.joshsim.lang.export;
+
+
+import java.io.OutputStream;
+
+public class ExportFacade {
+
+  private final ExportSerializeStrategy<?> serializeStrategy;
+  private final ExportWriteStrategy<?> writeStrategy;
+  private final OutputStream outputStream;
+
+  public ExportFacade(ExportTarget exportTarget) {
+    if (!exportTarget.getFormat().equalsIgnoreCase("CSV")) {
+      throw new IllegalArgumentException("ExportTarget must have CSV format.");
+    }
+
+    this.serializeStrategy = new MapSerializeStrategy();
+    this.writeStrategy = new CsvWriteStrategy(); // Assuming CsvWriteStrategy is implemented.
+
+    if (!exportTarget.isLocalPath()) {
+      throw new IllegalArgumentException("ExportTarget must have a local path.");
+    }
+
+    try {
+      this.outputStream = new FileOutputStream(exportTarget.getPath());
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Unable to open file for writing: " + exportTarget.getPath(), e);
+    }
+
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/export/ExportFacadeFactory.java
+++ b/src/main/java/org/joshsim/lang/export/ExportFacadeFactory.java
@@ -1,0 +1,37 @@
+/**
+ * Logic to help construct ExportFacades.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.export;
+
+
+/**
+ * Factory responsible for creating instances of ExportFacade based on a provided target.
+ */
+public class ExportFacadeFactory {
+
+  /**
+   * Build an ExportFacade which is capable of writing to the given target.
+   *
+   * @param target Record describing where the export should be written and from which the format is
+   *     inferred.
+   * @return ExportFacade which, when given Entities, will write to the location described by
+   *     target.
+   */
+  public static ExportFacade build(ExportTarget target) {
+    if (!target.getFileType().equals("csv")) {
+      throw new IllegalArgumentException("Only CSV files are supported at this time.");
+    }
+
+    if (!target.getProtocol().equals("local")) {
+      throw new IllegalArgumentException("Only local file system is supported at this time.");
+    }
+
+    String path = target.getPath();
+    OutputStreamStrategy outputStreamStrategy = new LocalOutputStreamStrategy(path);
+    return new CsvExportFacade(outputStreamStrategy);
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/export/ExportFacadeFactory.java
+++ b/src/main/java/org/joshsim/lang/export/ExportFacadeFactory.java
@@ -25,7 +25,7 @@ public class ExportFacadeFactory {
       throw new IllegalArgumentException("Only CSV files are supported at this time.");
     }
 
-    if (!target.getProtocol().equals("local")) {
+    if (!target.getProtocol().isEmpty()) {
       throw new IllegalArgumentException("Only local file system is supported at this time.");
     }
 

--- a/src/main/java/org/joshsim/lang/export/ExportSerializeStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/ExportSerializeStrategy.java
@@ -1,0 +1,26 @@
+/**
+ * Definition of structures for exporting results from a simulation to a serialization format.
+ */
+
+package org.joshsim.lang.export;
+
+import java.util.stream.Stream;
+import org.joshsim.engine.entity.base.Entity;
+
+
+/**
+ * Strategy interface for exporting to a specific form before writing to persistence.
+ *
+ * @param <T> The serialization type to which entities should be converted.
+ */
+public interface ExportSerializeStrategy<T> {
+
+  /**
+   * Get the serialization-ready records for
+   *
+   * @param target The entities to be converted to the serialization form.
+   * @return Stream (for performance) over the serialized records ready to be written.
+   */
+  Stream<T> getRecords(Stream<Entity> target);
+
+}

--- a/src/main/java/org/joshsim/lang/export/ExportSerializeStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/ExportSerializeStrategy.java
@@ -6,7 +6,6 @@
 
 package org.joshsim.lang.export;
 
-import java.util.stream.Stream;
 import org.joshsim.engine.entity.base.Entity;
 
 
@@ -18,11 +17,11 @@ import org.joshsim.engine.entity.base.Entity;
 public interface ExportSerializeStrategy<T> {
 
   /**
-   * Get the serialization-ready records for
+   * Get the serialization-ready record for an entity.
    *
-   * @param target The entities to be converted to the serialization form.
-   * @return Stream (for performance) over the serialized records ready to be written.
+   * @param target The entity to be converted to the serialization form.
+   * @return Serialized record.
    */
-  Stream<T> getRecords(Stream<Entity> target);
+  T getRecord(Entity target);
 
 }

--- a/src/main/java/org/joshsim/lang/export/ExportSerializeStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/ExportSerializeStrategy.java
@@ -1,5 +1,7 @@
 /**
  * Definition of structures for exporting results from a simulation to a serialization format.
+ *
+ * @license BSD-3-Clause
  */
 
 package org.joshsim.lang.export;

--- a/src/main/java/org/joshsim/lang/export/ExportTarget.java
+++ b/src/main/java/org/joshsim/lang/export/ExportTarget.java
@@ -1,0 +1,103 @@
+/**
+ * Structures to describe output locations.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.export;
+
+
+/**
+ * Record describing where an export should be written.
+ */
+public class ExportTarget {
+
+  private final String protocol;
+  private final String host;
+  private final String path;
+
+  /**
+   * Constructs an ExportTarget object with the specified protocol, host, and path.
+   *
+   * @param protocol The protocol used for the export target (e.g., "minio", "local").
+   * @param host The host of the export target, typically representing the domain or IP address.
+   * @param path The path representing the location on the export target where the export should
+   *     occur.
+   */
+  public ExportTarget(String protocol, String host, String path) {
+    this.protocol = protocol;
+    this.host = host;
+    this.path = path;
+  }
+
+  /**
+   * Constructs a target with an empty host.
+   *
+   * @param protocol The protocol used for the export target (e.g., "minio", "local").
+   * @param path The path representing the location on the export target where the export should
+   *     occur.
+   */
+  public ExportTarget(String protocol, String path) {
+    this.protocol = protocol;
+    this.host = "";
+    this.path = path;
+  }
+
+  /**
+   * Constructs a local target with only a path.
+   *
+   * @param path The path representing the location on the export target where the export should
+   *     occur.
+   */
+  public ExportTarget(String path) {
+    this.protocol = "";
+    this.host = "";
+    this.path = path;
+  }
+
+  /**
+   * Get the protocol.
+   *
+   * @return the protocol used by this export target.
+   */
+  public String getProtocol() {
+    return protocol;
+  }
+
+  /**
+   * Get the host.
+   *
+   * @return the host of this export target.
+   */
+  public String getHost() {
+    return host;
+  }
+
+  /**
+   * Get the path.
+   *
+   * @return the path of this export target.
+   */
+  public String getPath() {
+    return path;
+  }
+
+  /**
+   * Get the file type (extension) from the end of the path.
+   *
+   * @return the file extension without a period, or an empty string if no extension is present.
+   */
+  public String getFileType() {
+    int lastDotIndex = path.lastIndexOf('.');
+    if (lastDotIndex == -1) {
+      return "";
+    }
+
+    if (lastDotIndex > path.length() - 1) {
+      return "";
+    }
+
+    return path.substring(lastDotIndex + 1);
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/export/ExportTarget.java
+++ b/src/main/java/org/joshsim/lang/export/ExportTarget.java
@@ -19,7 +19,7 @@ public class ExportTarget {
   /**
    * Constructs an ExportTarget object with the specified protocol, host, and path.
    *
-   * @param protocol The protocol used for the export target (e.g., "minio", "local").
+   * @param protocol The protocol used for the export target (e.g., "minio", "file").
    * @param host The host of the export target, typically representing the domain or IP address.
    * @param path The path representing the location on the export target where the export should
    *     occur.
@@ -33,7 +33,7 @@ public class ExportTarget {
   /**
    * Constructs a target with an empty host.
    *
-   * @param protocol The protocol used for the export target (e.g., "minio", "local").
+   * @param protocol The protocol used for the export target (e.g., "minio", "file").
    * @param path The path representing the location on the export target where the export should
    *     occur.
    */

--- a/src/main/java/org/joshsim/lang/export/ExportTargetParser.java
+++ b/src/main/java/org/joshsim/lang/export/ExportTargetParser.java
@@ -1,0 +1,45 @@
+/**
+ * Tools to parse an ExportTarget.
+ */
+
+package org.joshsim.lang.export;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+
+/**
+ * Utility class for parsing export target strings into structured ExportTarget objects.
+ *
+ * <p>This class provides functionality to interpret and validate string descriptions of export
+ * destinations, such as local paths or remote locations, and converts them into structured
+ * ExportTarget instances.</p>
+ */
+public class ExportTargetParser {
+
+  /**
+   * Parse an export target from a string describing the location where records should be written.
+   *
+   * @param target String description indicating where the file should be written. This could be,
+   *               for example, "local://path/to/file.geotiff" or "local:///path/to/file.avro" for
+   *               local or "minio://host-name/bucket/path.csv" minio remote.
+   * @return The parsed ExportTarget.
+   * @throws IllegalArgumentException if the target string is invalid or unsupported.
+   */
+  public static ExportTarget parse(String target) {
+    try {
+      URI uri = new URI(target);
+      String scheme = uri.getScheme();
+      if ("local".equalsIgnoreCase(scheme)) {
+        return new ExportTarget(uri.getPath());
+      } else if ("minio".equalsIgnoreCase(scheme)) {
+        return new ExportTarget("minio", uri.getHost(), uri.getPath());
+      } else {
+        throw new IllegalArgumentException("Unsupported target scheme: " + scheme);
+      }
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid target format: " + target, e);
+    }
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/export/ExportTargetParser.java
+++ b/src/main/java/org/joshsim/lang/export/ExportTargetParser.java
@@ -21,16 +21,17 @@ public class ExportTargetParser {
    * Parse an export target from a string describing the location where records should be written.
    *
    * @param target String description indicating where the file should be written. This could be,
-   *               for example, "local://path/to/file.geotiff" or "local:///path/to/file.avro" for
+   *               for example, "file://path/to/file.geotiff" or "file:///path/to/file.avro" for
    *               local or "minio://host-name/bucket/path.csv" minio remote.
    * @return The parsed ExportTarget.
    * @throws IllegalArgumentException if the target string is invalid or unsupported.
    */
   public static ExportTarget parse(String target) {
     try {
-      URI uri = new URI(target);
+      String targetClean = target.replaceAll("\"", "");
+      URI uri = new URI(targetClean);
       String scheme = uri.getScheme();
-      if ("local".equalsIgnoreCase(scheme)) {
+      if ("file".equalsIgnoreCase(scheme)) {
         return new ExportTarget(uri.getPath());
       } else if ("minio".equalsIgnoreCase(scheme)) {
         return new ExportTarget("minio", uri.getHost(), uri.getPath());

--- a/src/main/java/org/joshsim/lang/export/ExportWriteStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/ExportWriteStrategy.java
@@ -20,10 +20,10 @@ public interface ExportWriteStrategy<T> {
   /**
    * Write a record to the output stream.
    *
-   * @param records The record be written to the given output stream.
+   * @param record The record be written to the given output stream.
    * @param outputStream The stream to which the record as serialized should be written.
    */
-  void write(T records, OutputStream outputStream) throws IOException;
+  void write(T record, OutputStream outputStream) throws IOException;
 
   /**
    * Recommend flushing.

--- a/src/main/java/org/joshsim/lang/export/ExportWriteStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/ExportWriteStrategy.java
@@ -1,0 +1,16 @@
+package org.joshsim.lang.export;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.stream.Stream;
+
+
+/**
+ *
+ * @param <T>
+ */
+public interface ExportWriteStrategy<T> {
+
+  void write(Stream<T> records, OutputStream outputStream) throws IOException;
+
+}

--- a/src/main/java/org/joshsim/lang/export/ExportWriteStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/ExportWriteStrategy.java
@@ -1,3 +1,9 @@
+/**
+ * Structures to describe strategies for writing exports to an output stream.
+ *
+ * @license BSD-3-Clause
+ */
+
 package org.joshsim.lang.export;
 
 import java.io.IOException;

--- a/src/main/java/org/joshsim/lang/export/ExportWriteStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/ExportWriteStrategy.java
@@ -6,11 +6,18 @@ import java.util.stream.Stream;
 
 
 /**
+ * Strategy to write a serialized form to a persistence mechanism.
  *
- * @param <T>
+ * @param <T> The type of expected serialized form to be written.
  */
 public interface ExportWriteStrategy<T> {
 
+  /**
+   * Write the given set of records to the given output stream.
+   *
+   * @param records The collection of serialized records to be written to the given output stream.
+   * @param outputStream The stream to which the records as serialized should be written.
+   */
   void write(Stream<T> records, OutputStream outputStream) throws IOException;
 
 }

--- a/src/main/java/org/joshsim/lang/export/ExportWriteStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/ExportWriteStrategy.java
@@ -8,7 +8,6 @@ package org.joshsim.lang.export;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.stream.Stream;
 
 
 /**
@@ -19,11 +18,20 @@ import java.util.stream.Stream;
 public interface ExportWriteStrategy<T> {
 
   /**
-   * Write the given set of records to the given output stream.
+   * Write a record to the output stream.
    *
-   * @param records The collection of serialized records to be written to the given output stream.
-   * @param outputStream The stream to which the records as serialized should be written.
+   * @param records The record be written to the given output stream.
+   * @param outputStream The stream to which the record as serialized should be written.
    */
-  void write(Stream<T> records, OutputStream outputStream) throws IOException;
+  void write(T records, OutputStream outputStream) throws IOException;
+
+  /**
+   * Recommend flushing.
+   *
+   * <p>Recommend that the write strategy flushes any waiting data like when a batch of data is
+   * completed and there may be a delay before further records. This is optional and will be
+   * interpreted by different strategies</p>
+   */
+  void flush();
 
 }

--- a/src/main/java/org/joshsim/lang/export/LocalOutputStreamStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/LocalOutputStreamStrategy.java
@@ -1,0 +1,35 @@
+/**
+ * Logic to write to local files as part of Josh export.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.export;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+/**
+ * Strategy which opens an OutputStream to a local file.
+ */
+public class LocalOutputStreamStrategy implements OutputStreamStrategy {
+
+  private final String location;
+
+  /**
+   * Constructs a LocalOutputStreamStrategy with the specified file location.
+   *
+   * @param location The local file path where the OutputStream will write data.
+   */
+  public LocalOutputStreamStrategy(String location) {
+    this.location = location;
+  }
+
+  @Override
+  public OutputStream open() throws IOException {
+    return new FileOutputStream(location);
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/export/MapSerializeStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/MapSerializeStrategy.java
@@ -1,0 +1,30 @@
+package org.joshsim.lang.export;
+
+import org.joshsim.engine.entity.base.Entity;
+import org.joshsim.engine.value.type.EngineValue;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class MapSerializeStrategy implements ExportSerializeStrategy<Map<String, String>> {
+
+  @Override
+  public Stream<Map<String, String>> getRecords(Stream<Entity> target) {
+    return target.map(this::getMap);
+  }
+
+  private Map<String, String> getMap(Entity entity) {
+    return entity.getAttributeNames().stream()
+        .filter((x) -> x.startsWith("export."))
+        .collect(Collectors.toMap(
+            (x) -> x,
+            (x) -> {
+              Optional<EngineValue> value = entity.getAttributeValue(x);
+              return value.isPresent() ? value.get().getAsString() : "";
+            }
+        ));
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/export/MapSerializeStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/MapSerializeStrategy.java
@@ -1,13 +1,21 @@
+/**
+ * Strategy for table-like serialization.
+ *
+ * @license BSD-3-Clause
+ */
+
 package org.joshsim.lang.export;
 
 import org.joshsim.engine.entity.base.Entity;
 import org.joshsim.engine.value.type.EngineValue;
-
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Strategy to serialize Entities into a flat table-like structure.
+ */
 public class MapSerializeStrategy implements ExportSerializeStrategy<Map<String, String>> {
 
   @Override
@@ -15,6 +23,17 @@ public class MapSerializeStrategy implements ExportSerializeStrategy<Map<String,
     return target.map(this::getMap);
   }
 
+  /**
+   * Creates a map of attribute names and their corresponding string values from the given Entity.
+   *
+   * <p>Creates a map of attribute names and their corresponding string values from the given Entity
+   * where the attributes whose names start with "export." are included in the resulting map.</p>
+   *
+   * @param entity the Entity from which the attribute names and values are retrieved
+   * @return A map where the keys are attribute names starting with "export." and the values are
+   *     their corresponding string values. If the attribute value is missing, an empty string is
+   *     used.
+   */
   private Map<String, String> getMap(Entity entity) {
     return entity.getAttributeNames().stream()
         .filter((x) -> x.startsWith("export."))

--- a/src/main/java/org/joshsim/lang/export/MapSerializeStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/MapSerializeStrategy.java
@@ -6,12 +6,11 @@
 
 package org.joshsim.lang.export;
 
-import org.joshsim.engine.entity.base.Entity;
-import org.joshsim.engine.value.type.EngineValue;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import org.joshsim.engine.entity.base.Entity;
+import org.joshsim.engine.value.type.EngineValue;
 
 /**
  * Strategy to serialize Entities into a flat table-like structure.
@@ -19,22 +18,7 @@ import java.util.stream.Stream;
 public class MapSerializeStrategy implements ExportSerializeStrategy<Map<String, String>> {
 
   @Override
-  public Stream<Map<String, String>> getRecords(Stream<Entity> target) {
-    return target.map(this::getMap);
-  }
-
-  /**
-   * Creates a map of attribute names and their corresponding string values from the given Entity.
-   *
-   * <p>Creates a map of attribute names and their corresponding string values from the given Entity
-   * where the attributes whose names start with "export." are included in the resulting map.</p>
-   *
-   * @param entity the Entity from which the attribute names and values are retrieved
-   * @return A map where the keys are attribute names starting with "export." and the values are
-   *     their corresponding string values. If the attribute value is missing, an empty string is
-   *     used.
-   */
-  private Map<String, String> getMap(Entity entity) {
+  public Map<String, String> getRecord(Entity entity) {
     return entity.getAttributeNames().stream()
         .filter((x) -> x.startsWith("export."))
         .collect(Collectors.toMap(

--- a/src/main/java/org/joshsim/lang/export/MapSerializeStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/MapSerializeStrategy.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.joshsim.engine.entity.base.Entity;
+import org.joshsim.engine.geometry.EngineGeometry;
 import org.joshsim.engine.value.type.EngineValue;
 
 /**
@@ -19,15 +20,23 @@ public class MapSerializeStrategy implements ExportSerializeStrategy<Map<String,
 
   @Override
   public Map<String, String> getRecord(Entity entity) {
-    return entity.getAttributeNames().stream()
+    Map<String, String> result = entity.getAttributeNames().stream()
         .filter((x) -> x.startsWith("export."))
         .collect(Collectors.toMap(
-            (x) -> x,
+            (x) -> x.replaceFirst("export\\.", ""),
             (x) -> {
               Optional<EngineValue> value = entity.getAttributeValue(x);
               return value.isPresent() ? value.get().getAsString() : "";
             }
         ));
+
+    if (entity.getGeometry().isPresent()) {
+      EngineGeometry geometry = entity.getGeometry().get();
+      result.put("position.x", geometry.getCenterX().toString());
+      result.put("position.y", geometry.getCenterY().toString());
+    }
+
+    return result;
   }
 
 }

--- a/src/main/java/org/joshsim/lang/export/OutputStreamStrategy.java
+++ b/src/main/java/org/joshsim/lang/export/OutputStreamStrategy.java
@@ -1,0 +1,31 @@
+/**
+ * Structure to describe strategies for different kinds of output streams.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.export;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+/**
+ * Interface defining a strategy for providing an output stream for data writing purposes.
+ *
+ * <p>Implementations of this interface specify how and where to open an OutputStream for data
+ * writing, enabling flexibility in defining output destinations like for local file storage, cloud
+ * storage, or other persistence mechanisms.</p>
+ */
+public interface OutputStreamStrategy {
+
+  /**
+   * Opens a new OutputStream for writing data.
+   *
+   * @return an OutputStream instance ready for writing data which must be closed from outside this
+   *     strategy.
+   * @throws IOException if the stream cannot be opened or other I/O errors occur.
+   */
+  OutputStream open() throws IOException;
+
+}

--- a/src/test/java/org/joshsim/lang/export/CsvExportFacadeTest.java
+++ b/src/test/java/org/joshsim/lang/export/CsvExportFacadeTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.joshsim.engine.entity.base.Entity;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/joshsim/lang/export/CsvExportFacadeTest.java
+++ b/src/test/java/org/joshsim/lang/export/CsvExportFacadeTest.java
@@ -1,0 +1,98 @@
+/**
+ * Tests for CSV export logic.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.export;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.joshsim.engine.entity.base.Entity;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Unit test suite for the CsvExportFacade.
+ */
+class CsvExportFacadeTest {
+
+  @Test
+  void testStartWhenAlreadyActiveNoActionPerformed() {
+    // Arrange
+    OutputStreamStrategy outputStrategyMock = mock(OutputStreamStrategy.class);
+    CsvExportFacade csvExportFacade = new CsvExportFacade(outputStrategyMock);
+
+    AtomicBoolean activeState = getActiveState(csvExportFacade);
+    activeState.set(true); // Simulate active state
+
+    // Act
+    csvExportFacade.start();
+
+    // Assert
+    assertTrue(activeState.get(), "Facade should remain active");
+    try {
+      verify(outputStrategyMock, times(0)).open();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void testStartWhenInactiveOpensOutputStream() throws IOException {
+    // Arrange
+    OutputStreamStrategy outputStrategyMock = mock(OutputStreamStrategy.class);
+    OutputStream outputStreamMock = mock(OutputStream.class);
+
+    when(outputStrategyMock.open()).thenReturn(outputStreamMock);
+
+    CsvExportFacade csvExportFacade = new CsvExportFacade(outputStrategyMock);
+
+    // Act
+    csvExportFacade.start();
+    csvExportFacade.join(); // Ensure the background thread finishes
+
+    // Assert
+    verify(outputStrategyMock, times(1)).open();
+    verify(outputStreamMock, times(1)).close();
+  }
+
+  @Test
+  void testStartWritesEntitiesToOutputStreamAndFlushesSuccessfully() throws IOException {
+    // Arrange
+    OutputStreamStrategy outputStrategyMock = mock(OutputStreamStrategy.class);
+    OutputStream outputStreamMock = mock(OutputStream.class);
+    Entity entityMock = mock(Entity.class);
+
+    when(outputStrategyMock.open()).thenReturn(outputStreamMock);
+
+    CsvExportFacade csvExportFacade = new CsvExportFacade(outputStrategyMock);
+
+    // Act
+    csvExportFacade.start();
+    csvExportFacade.write(entityMock);
+    csvExportFacade.join(); // Ensure the operation completes
+
+    // Assert
+    verify(outputStrategyMock, times(1)).open();
+    verify(outputStreamMock, times(1)).close();
+  }
+
+  private AtomicBoolean getActiveState(CsvExportFacade csvExportFacade) {
+    try {
+      var activeField = CsvExportFacade.class.getDeclaredField("active");
+      activeField.setAccessible(true);
+      return (AtomicBoolean) activeField.get(csvExportFacade);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Could not access active field", e);
+    }
+  }
+
+}

--- a/src/test/java/org/joshsim/lang/export/CsvExportFacadeTest.java
+++ b/src/test/java/org/joshsim/lang/export/CsvExportFacadeTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.joshsim.engine.entity.base.Entity;
 import org.junit.jupiter.api.Test;
 
@@ -70,6 +71,7 @@ class CsvExportFacadeTest {
     OutputStreamStrategy outputStrategyMock = mock(OutputStreamStrategy.class);
     OutputStream outputStreamMock = mock(OutputStream.class);
     Entity entityMock = mock(Entity.class);
+    CsvExportFacade.Task task = new CsvExportFacade.Task(entityMock, 1L);
 
     when(outputStrategyMock.open()).thenReturn(outputStreamMock);
 
@@ -77,7 +79,7 @@ class CsvExportFacadeTest {
 
     // Act
     csvExportFacade.start();
-    csvExportFacade.write(entityMock);
+    csvExportFacade.write(task);
     csvExportFacade.join(); // Ensure the operation completes
 
     // Assert

--- a/src/test/java/org/joshsim/lang/export/CsvWriteStrategyTest.java
+++ b/src/test/java/org/joshsim/lang/export/CsvWriteStrategyTest.java
@@ -1,0 +1,102 @@
+/**
+ * Tests for CsvWriteStrategy.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.export;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.csv.CSVPrinter;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Test logic to write to a CSV file after serialization.
+ */
+class CsvWriteStrategyTest {
+
+  @Test
+  void shouldWriteSingleRecordToOutputStream() throws IOException {
+    // Given
+    CsvWriteStrategy strategy = new CsvWriteStrategy();
+    Map<String, String> record = new HashMap<>();
+    record.put("Name", "Nick");
+    record.put("Age", "30");
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    // When
+    strategy.write(record, output);
+    strategy.flush();
+
+    // Then
+    String result = output.toString();
+    assertTrue(result.contains("Name"));
+    assertTrue(result.contains("Age"));
+    assertTrue(result.contains("Nick"));
+    assertTrue(result.contains("30"));
+  }
+
+  @Test
+  void shouldWriteMultipleRecordsWithHeaders() throws IOException {
+    // Given
+    Map<String, String> record1 = new HashMap<>();
+    record1.put("Name", "Nick");
+    record1.put("Age", "30");
+
+    Map<String, String> record2 = new HashMap<>();
+    record2.put("Name", "Lucia");
+    record2.put("Age", "25");
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    CsvWriteStrategy strategy = new CsvWriteStrategy();
+
+    // When
+    strategy.write(record1, output);
+    strategy.write(record2, output);
+    strategy.flush();
+
+    // Then
+    String result = output.toString();
+    assertTrue(result.contains("Name"));
+    assertTrue(result.contains("Age"));
+    assertTrue(result.contains("Nick"));
+    assertTrue(result.contains("30"));
+    assertTrue(result.contains("Lucia"));
+    assertTrue(result.contains("25"));
+  }
+
+  @Test
+  void shouldThrowRuntimeExceptionWhenPrinterFailsToFlush() throws IOException {
+    // Given
+    CsvWriteStrategy strategy = new CsvWriteStrategy();
+    CSVPrinter mockPrinter = mock(CSVPrinter.class);
+    doThrow(IOException.class).when(mockPrinter).flush();
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    Map<String, String> record = new HashMap<>();
+    record.put("Name", "Test");
+    strategy.write(record, output);
+    strategy.flush();
+
+    try {
+      var printerField = CsvWriteStrategy.class.getDeclaredField("printer");
+      printerField.setAccessible(true);
+      printerField.set(strategy, mockPrinter);
+    } catch (Exception e) {
+      fail("Failed to inject mock CSVPrinter");
+    }
+
+    // When & Then
+    assertThrows(RuntimeException.class, strategy::flush);
+  }
+}

--- a/src/test/java/org/joshsim/lang/export/ExportTargetParserTest.java
+++ b/src/test/java/org/joshsim/lang/export/ExportTargetParserTest.java
@@ -1,0 +1,68 @@
+package org.joshsim.lang.export;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the `ExportTargetParser` class.
+ *
+ * <p>The `ExportTargetParser` class is responsible for parsing a target string into an
+ * `ExportTarget` object. Its `parse` method accepts a target string in URI format and determines
+ * the export target type based on the scheme of the URI. Supported schemes include `local` and
+ * `minio`. Any unsupported schemes or invalid URI formats result in an `IllegalArgumentException`.
+ * </p>
+ */
+public class ExportTargetParserTest {
+
+  @Test
+  public void testParse_ValidLocalScheme() {
+    String target = "local:/path/to/file";
+
+    ExportTarget result = ExportTargetParser.parse(target);
+
+    assertEquals("", result.getProtocol());
+    assertEquals("", result.getHost());
+    assertEquals("/path/to/file", result.getPath());
+  }
+
+  @Test
+  public void testParse_ValidMinioScheme() {
+    String target = "minio://bucket.example.com/path/to/resource";
+
+    ExportTarget result = ExportTargetParser.parse(target);
+
+    assertEquals("minio", result.getProtocol());
+    assertEquals("bucket.example.com", result.getHost());
+    assertEquals("/path/to/resource", result.getPath());
+  }
+
+  @Test
+  public void testParse_InvalidSchemeThrowsException() {
+    String target = "unsupported:/path/to/file";
+
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      ExportTargetParser.parse(target);
+    });
+
+    assertTrue(exception.getMessage().contains("Unsupported target scheme"));
+  }
+
+  @Test
+  public void testParse_InvalidURISyntaxThrowsException() {
+    String target = "invalid-uri-format";
+
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      ExportTargetParser.parse(target);
+    });
+  }
+
+  @Test
+  public void testParse_EmptyTargetThrowsException() {
+    String target = "";
+
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      ExportTargetParser.parse(target);
+    });
+  }
+}

--- a/src/test/java/org/joshsim/lang/export/ExportTargetParserTest.java
+++ b/src/test/java/org/joshsim/lang/export/ExportTargetParserTest.java
@@ -1,8 +1,17 @@
+/**
+ * Test for ExportTargetParser.
+ *
+ * @license BSD-3-Clause
+ */
+
 package org.joshsim.lang.export;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for the `ExportTargetParser` class.
@@ -16,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ExportTargetParserTest {
 
   @Test
-  public void testParse_ValidLocalScheme() {
+  public void testParseValidLocalScheme() {
     String target = "local:/path/to/file";
 
     ExportTarget result = ExportTargetParser.parse(target);
@@ -27,7 +36,7 @@ public class ExportTargetParserTest {
   }
 
   @Test
-  public void testParse_ValidMinioScheme() {
+  public void testParseValidMinioScheme() {
     String target = "minio://bucket.example.com/path/to/resource";
 
     ExportTarget result = ExportTargetParser.parse(target);
@@ -38,7 +47,7 @@ public class ExportTargetParserTest {
   }
 
   @Test
-  public void testParse_InvalidSchemeThrowsException() {
+  public void testParseInvalidSchemeThrowsException() {
     String target = "unsupported:/path/to/file";
 
     Exception exception = assertThrows(IllegalArgumentException.class, () -> {
@@ -49,7 +58,7 @@ public class ExportTargetParserTest {
   }
 
   @Test
-  public void testParse_InvalidURISyntaxThrowsException() {
+  public void testParseInvalidSyntaxThrowsException() {
     String target = "invalid-uri-format";
 
     Exception exception = assertThrows(IllegalArgumentException.class, () -> {
@@ -58,7 +67,7 @@ public class ExportTargetParserTest {
   }
 
   @Test
-  public void testParse_EmptyTargetThrowsException() {
+  public void testParseEmptyTargetThrowsException() {
     String target = "";
 
     Exception exception = assertThrows(IllegalArgumentException.class, () -> {

--- a/src/test/java/org/joshsim/lang/export/ExportTargetParserTest.java
+++ b/src/test/java/org/joshsim/lang/export/ExportTargetParserTest.java
@@ -26,7 +26,18 @@ public class ExportTargetParserTest {
 
   @Test
   public void testParseValidLocalScheme() {
-    String target = "local:/path/to/file";
+    String target = "file:/path/to/file";
+
+    ExportTarget result = ExportTargetParser.parse(target);
+
+    assertEquals("", result.getProtocol());
+    assertEquals("", result.getHost());
+    assertEquals("/path/to/file", result.getPath());
+  }
+
+  @Test
+  public void testParseValidLocalSchemeRoot() {
+    String target = "file:///path/to/file";
 
     ExportTarget result = ExportTargetParser.parse(target);
 

--- a/src/test/java/org/joshsim/lang/export/ExportTargetTest.java
+++ b/src/test/java/org/joshsim/lang/export/ExportTargetTest.java
@@ -1,0 +1,98 @@
+package org.joshsim.lang.export;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExportTargetTest {
+
+  /**
+   * Tests for the getFileType method in the ExportTarget class.
+   * This method retrieves the file type (extension) from the given path.
+   * It returns an empty string if no valid extension exists.
+   */
+
+  @Test
+  void testGetFileTypeWithValidExtension() {
+    // Arrange
+    ExportTarget exportTarget = new ExportTarget("local", "", "/files/document.txt");
+
+    // Act
+    String fileType = exportTarget.getFileType();
+
+    // Assert
+    assertEquals("txt", fileType);
+  }
+
+  @Test
+  void testGetFileTypeWithNoExtension() {
+    // Arrange
+    ExportTarget exportTarget = new ExportTarget("local", "/files/document");
+
+    // Act
+    String fileType = exportTarget.getFileType();
+
+    // Assert
+    assertEquals("", fileType);
+  }
+
+  @Test
+  void testGetFileTypeWithPathEndingWithDot() {
+    // Arrange
+    ExportTarget exportTarget = new ExportTarget("/files/document.");
+
+    // Act
+    String fileType = exportTarget.getFileType();
+
+    // Assert
+    assertEquals("", fileType);
+  }
+
+  @Test
+  void testGetFileTypeWithMultipleDots() {
+    // Arrange
+    ExportTarget exportTarget = new ExportTarget("local", "", "/files/archive.tar.gz");
+
+    // Act
+    String fileType = exportTarget.getFileType();
+
+    // Assert
+    assertEquals("gz", fileType);
+  }
+
+  @Test
+  void testGetFileTypeOnRootFile() {
+    // Arrange
+    ExportTarget exportTarget = new ExportTarget("local", "/document.pdf");
+
+    // Act
+    String fileType = exportTarget.getFileType();
+
+    // Assert
+    assertEquals("pdf", fileType);
+  }
+
+  @Test
+  void testGetFileTypeWithEmptyPath() {
+    // Arrange
+    ExportTarget exportTarget = new ExportTarget("local", "", "");
+
+    // Act
+    String fileType = exportTarget.getFileType();
+
+    // Assert
+    assertEquals("", fileType);
+  }
+
+  @Test
+  void testGetFileTypeWithPathOnlySlash() {
+    // Arrange
+    ExportTarget exportTarget = new ExportTarget("local", "", "/");
+
+    // Act
+    String fileType = exportTarget.getFileType();
+
+    // Assert
+    assertEquals("", fileType);
+  }
+}

--- a/src/test/java/org/joshsim/lang/export/ExportTargetTest.java
+++ b/src/test/java/org/joshsim/lang/export/ExportTargetTest.java
@@ -1,8 +1,8 @@
 package org.joshsim.lang.export;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 class ExportTargetTest {
 

--- a/src/test/java/org/joshsim/lang/export/LocalOutputStreamStrategyTest.java
+++ b/src/test/java/org/joshsim/lang/export/LocalOutputStreamStrategyTest.java
@@ -1,0 +1,42 @@
+/**
+ * Tests for LocalOutputStreamStrategy.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.export;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test a local file output stream.
+ */
+class LocalOutputStreamStrategyTest {
+
+  @Test
+  void testOpenMethodCreatesFileOutputStream() throws IOException {
+    // Arrange
+    String filePath = "/tmp/josh-open-test.txt";
+    File file = new File(filePath);
+    if (file.exists()) {
+      assertTrue(file.delete());
+    }
+    LocalOutputStreamStrategy strategy = new LocalOutputStreamStrategy(filePath);
+
+    // Act
+    OutputStream outputStream = strategy.open();
+
+    // Assert
+    assertNotNull(outputStream);
+    assertTrue(file.exists());
+    outputStream.close();
+    assertTrue(file.delete());
+  }
+
+}

--- a/src/test/java/org/joshsim/lang/export/MapSerializeStrategyTest.java
+++ b/src/test/java/org/joshsim/lang/export/MapSerializeStrategyTest.java
@@ -1,0 +1,89 @@
+/**
+ * Test for MapSerializeStrategy.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.export;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.joshsim.engine.entity.base.Entity;
+import org.joshsim.engine.value.type.EngineValue;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+
+/**
+ * Tests the getRecord method of MapSerializeStrategy, which filters attributes of an entity
+ * starting with "export." and maps those attributes and their values into a Map (String, String).
+ */
+class MapSerializeStrategyTest {
+
+  @Test
+  void testGetRecordWithExportAttributes() {
+    // Arrange
+    Entity entity = Mockito.mock(Entity.class);
+    MapSerializeStrategy mapSerializeStrategy = new MapSerializeStrategy();
+
+    Set<String> attributeNames = Set.of("export.name", "export.description", "other.attribute");
+    when(entity.getAttributeNames()).thenReturn(attributeNames);
+
+    EngineValue nameValue = Mockito.mock(EngineValue.class);
+    EngineValue descriptionValue = Mockito.mock(EngineValue.class);
+    when(nameValue.getAsString()).thenReturn("Sample Name");
+    when(descriptionValue.getAsString()).thenReturn("Sample Description");
+
+    when(entity.getAttributeValue("export.name")).thenReturn(Optional.of(nameValue));
+    when(entity.getAttributeValue("export.description")).thenReturn(
+        Optional.of(descriptionValue)
+    );
+    when(entity.getAttributeValue("other.attribute")).thenReturn(Optional.empty());
+
+    // Act
+    Map<String, String> result = mapSerializeStrategy.getRecord(entity);
+
+    // Assert
+    assertEquals(2, result.size());
+    assertEquals("Sample Name", result.get("export.name"));
+    assertEquals("Sample Description", result.get("export.description"));
+  }
+
+  @Test
+  void testGetRecordWithNoExportAttributes() {
+    // Arrange
+    Entity entity = Mockito.mock(Entity.class);
+    MapSerializeStrategy mapSerializeStrategy = new MapSerializeStrategy();
+
+    Set<String> attributeNames = Set.of("other.attribute1", "other.attribute2");
+    when(entity.getAttributeNames()).thenReturn(attributeNames);
+
+    when(entity.getAttributeValue(anyString())).thenReturn(Optional.empty());
+
+    // Act
+    Map<String, String> result = mapSerializeStrategy.getRecord(entity);
+
+    // Assert
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  void testGetRecordWithEmptyAttributes() {
+    // Arrange
+    Entity entity = Mockito.mock(Entity.class);
+    MapSerializeStrategy mapSerializeStrategy = new MapSerializeStrategy();
+
+    when(entity.getAttributeNames()).thenReturn(Set.of());
+
+    // Act
+    Map<String, String> result = mapSerializeStrategy.getRecord(entity);
+
+    // Assert
+    assertEquals(0, result.size());
+  }
+}

--- a/src/test/java/org/joshsim/lang/export/MapSerializeStrategyTest.java
+++ b/src/test/java/org/joshsim/lang/export/MapSerializeStrategyTest.java
@@ -7,13 +7,16 @@
 package org.joshsim.lang.export;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.joshsim.engine.entity.base.Entity;
+import org.joshsim.engine.geometry.EngineGeometry;
 import org.joshsim.engine.value.type.EngineValue;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -39,6 +42,7 @@ class MapSerializeStrategyTest {
     when(nameValue.getAsString()).thenReturn("Sample Name");
     when(descriptionValue.getAsString()).thenReturn("Sample Description");
 
+    when(entity.getGeometry()).thenReturn(Optional.empty());
     when(entity.getAttributeValue("export.name")).thenReturn(Optional.of(nameValue));
     when(entity.getAttributeValue("export.description")).thenReturn(
         Optional.of(descriptionValue)
@@ -49,9 +53,41 @@ class MapSerializeStrategyTest {
     Map<String, String> result = mapSerializeStrategy.getRecord(entity);
 
     // Assert
-    assertEquals(2, result.size());
-    assertEquals("Sample Name", result.get("export.name"));
-    assertEquals("Sample Description", result.get("export.description"));
+    assertEquals("Sample Name", result.get("name"));
+    assertEquals("Sample Description", result.get("description"));
+  }
+
+  @Test
+  void testGetRecordWithGeometry() {
+    // Arrange
+    Entity entity = Mockito.mock(Entity.class);
+    EngineGeometry geometry = Mockito.mock(EngineGeometry.class);
+    MapSerializeStrategy mapSerializeStrategy = new MapSerializeStrategy();
+
+    when(geometry.getCenterX()).thenReturn(BigDecimal.valueOf(12));
+    when(geometry.getCenterY()).thenReturn(BigDecimal.valueOf(34));
+
+    Set<String> attributeNames = Set.of("export.name", "export.description", "other.attribute");
+    when(entity.getAttributeNames()).thenReturn(attributeNames);
+
+    EngineValue nameValue = Mockito.mock(EngineValue.class);
+    EngineValue descriptionValue = Mockito.mock(EngineValue.class);
+    when(nameValue.getAsString()).thenReturn("Sample Name");
+    when(descriptionValue.getAsString()).thenReturn("Sample Description");
+
+    when(entity.getGeometry()).thenReturn(Optional.of(geometry));
+    when(entity.getAttributeValue("export.name")).thenReturn(Optional.of(nameValue));
+    when(entity.getAttributeValue("export.description")).thenReturn(
+        Optional.of(descriptionValue)
+    );
+    when(entity.getAttributeValue("other.attribute")).thenReturn(Optional.empty());
+
+    // Act
+    Map<String, String> result = mapSerializeStrategy.getRecord(entity);
+
+    // Assert
+    assertTrue(result.containsKey("position.x"));
+    assertTrue(result.containsKey("position.y"));
   }
 
   @Test


### PR DESCRIPTION
Adding CSV export just for patches for now to unblock folks. Will add for entity and simulation soon. CC @mzomer and @lucialayr. Note that this will write a CSV to `tmp` in integration test (`simple.josh`).