### PR TITLE
Add support for legacy browsers.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,12 +120,12 @@ jobs:
         run: mkdir -p build/libs; mv joshsim-fat.jar build/libs/joshsim-fat.jar
       - name: Run examples
         run: bash examples/test.sh
-  buildWasm:
+  buildWeb:
     needs: [ checkJava, buildJava, testJava, validateExamples, runTests ]
     environment: Build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
-    name: Build WASM
+    name: Build for Browser
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy to SFTP
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
-    needs: [checkJava, buildJava, testJava, validateExamples, runTests, buildWasm]
+    needs: [checkJava, buildJava, testJava, validateExamples, runTests, buildWeb]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,11 @@ dependencies {
 }
 
 teavm {
+  js {
+    mainClass = "org.joshsim.JoshJsSimFacade"
+    addedToWebApp = true
+    moduleType = org.teavm.gradle.api.JSModuleType.NONE
+  }
   wasmGC {
     mainClass = "org.joshsim.JoshJsSimFacade"
     addedToWebApp = true

--- a/editor/js/wasm.worker.js
+++ b/editor/js/wasm.worker.js
@@ -1,4 +1,4 @@
-
+importScripts("/war/js/JoshSim.js");
 importScripts("/war/wasm-gc/JoshSim.wasm-runtime.js");
 
 let wasmLayer = null;
@@ -14,7 +14,17 @@ self.onmessage = async function(e) {
   postMessage = (x) => self.postMessage(x);
   
   if (type === "init") {
-    wasmLayer = await TeaVM.wasmGC.load("/war/wasm-gc/JoshSim.wasm");
+    try {
+      wasmLayer = await TeaVM.wasmGC.load("/war/wasm-gc/JoshSim.wasm");
+      console.log("Started engine thread with WASM.");
+    } catch {
+      wasmLayer = {"exports": {
+        "validate": validate,
+        "getSimulations": getSimulations,
+        "runSimulation": runSimulation
+      }};
+      console.log("Started ending thread with JS fallback.");
+    }
     self.postMessage({ type: "init", success: true });
     return;
   }


### PR DESCRIPTION
WASM is faster but I did some testing on BrowserStack with older browsers and am convinced that using TeaVM’s fallback JS target for browsers not supporting WASM is a good move. It will test to see if the browser supports wasm first and, if not, it will fall back to the JS target.