### PR TITLE
Fix some issues with slow string formatting.

### DIFF
--- a/src/main/java/org/joshsim/engine/entity/handler/EventKey.java
+++ b/src/main/java/org/joshsim/engine/entity/handler/EventKey.java
@@ -6,7 +6,6 @@
 
 package org.joshsim.engine.entity.handler;
 
-
 import org.joshsim.compat.CompatibilityLayerKeeper;
 import org.joshsim.compat.CompatibleStringJoiner;
 

--- a/src/main/java/org/joshsim/engine/entity/handler/EventKey.java
+++ b/src/main/java/org/joshsim/engine/entity/handler/EventKey.java
@@ -7,6 +7,9 @@
 package org.joshsim.engine.entity.handler;
 
 
+import org.joshsim.compat.CompatibilityLayerKeeper;
+import org.joshsim.compat.CompatibleStringJoiner;
+
 /**
  * Composite key for mapping state, attribute, and event.
  */
@@ -97,6 +100,10 @@ public class EventKey {
   }
 
   private String generateStringRepresentation() {
-    return String.format("EventKey(%s, %s, %s)", state, attribute, event);
+    CompatibleStringJoiner joiner = CompatibilityLayerKeeper.get().createStringJoiner(",");
+    joiner.add(state);
+    joiner.add(attribute);
+    joiner.add(event);
+    return joiner.toString();
   }
 }

--- a/src/main/java/org/joshsim/engine/value/engine/EngineValueTuple.java
+++ b/src/main/java/org/joshsim/engine/value/engine/EngineValueTuple.java
@@ -6,6 +6,8 @@
 
 package org.joshsim.engine.value.engine;
 
+import org.joshsim.compat.CompatibilityLayerKeeper;
+import org.joshsim.compat.CompatibleStringJoiner;
 import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.type.EngineValue;
 import org.joshsim.engine.value.type.LanguageType;
@@ -141,7 +143,10 @@ public class EngineValueTuple {
      * @returns string representation using root types.
      */
     public String toRootString() {
-      return String.format("types: %s, %s", first.getRootType(), second.getRootType());
+      CompatibleStringJoiner joiner = CompatibilityLayerKeeper.get().createStringJoiner(",");
+      joiner.add(first.getRootType());
+      joiner.add(second.getRootType());
+      return joiner.toString();
     }
 
     /**

--- a/src/main/java/org/joshsim/engine/value/type/Scalar.java
+++ b/src/main/java/org/joshsim/engine/value/type/Scalar.java
@@ -44,9 +44,8 @@ public abstract class Scalar extends EngineValue implements Comparable<Scalar> {
    */
   @Override
   public Distribution getAsDistribution() {
-    EngineValueFactory factory = new EngineValueFactory();
     List<EngineValue> values = List.of(this);
-    return factory.buildRealizedDistribution(values, getUnits());
+    return new RealizedDistribution(caster, values, getUnits());
   }
 
   /**


### PR DESCRIPTION
Found some time getting spent in `String.format` and an uncessary factory init. Altogether, shaves about 5% off in simple scripts though, in testing, this is shaving off up to 10% running time in scripts with lots of agents.