### PR TITLE
(Attempt 1) Unit tests for ANTLR visitor delegates.

### DIFF
--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitorTest.java
@@ -1,0 +1,286 @@
+package org.joshsim.lang.interpret.visitor.delegates;
+
+import org.antlr.v4.runtime.Token;
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.engine.EngineValueFactory;
+import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.lang.antlr.JoshLangParser;
+import org.joshsim.lang.interpret.action.EventHandlerAction;
+import org.joshsim.lang.interpret.fragment.ActionFragment;
+import org.joshsim.lang.interpret.fragment.Fragment;
+import org.joshsim.lang.interpret.machine.EventHandlerMachine;
+import org.joshsim.lang.interpret.visitor.JoshParserToMachineVisitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JoshDistributionVisitorTest {
+
+    private DelegateToolbox toolbox;
+    private JoshParserToMachineVisitor parent;
+    private JoshDistributionVisitor visitor;
+    private EngineValue mockSingleCount;
+
+    @BeforeEach
+    void setUp() {
+        toolbox = mock(DelegateToolbox.class);
+        parent = mock(JoshParserToMachineVisitor.class);
+        EngineValueFactory mockValueFactory = mock(EngineValueFactory.class);
+        mockSingleCount = mock(EngineValue.class);
+
+        when(toolbox.getParent()).thenReturn(parent);
+        when(toolbox.getValueFactory()).thenReturn(mockValueFactory);
+        when(mockValueFactory.build(1, Units.of("count"))).thenReturn(mockSingleCount);
+
+        visitor = new JoshDistributionVisitor(toolbox);
+    }
+
+    @Test
+    void testVisitSlice() {
+        // Mock
+        JoshLangParser.SliceContext context = mock(JoshLangParser.SliceContext.class);
+        context.subject = mock(JoshLangParser.ExpressionContext.class);
+        context.selection = mock(JoshLangParser.ExpressionContext.class);
+
+        Fragment subjectFragment = mock(Fragment.class);
+        Fragment selectionFragment = mock(Fragment.class);
+        EventHandlerAction subjectAction = mock(EventHandlerAction.class);
+        EventHandlerAction selectionAction = mock(EventHandlerAction.class);
+
+        when(context.subject.accept(parent)).thenReturn(subjectFragment);
+        when(context.selection.accept(parent)).thenReturn(selectionFragment);
+        when(subjectFragment.getCurrentAction()).thenReturn(subjectAction);
+        when(selectionFragment.getCurrentAction()).thenReturn(selectionAction);
+
+        // Test
+        Fragment result = visitor.visitSlice(context);
+
+        // Validate
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(subjectAction).apply(mockMachine);
+        verify(selectionAction).apply(mockMachine);
+        verify(mockMachine).slice();
+    }
+
+    @Test
+    void testVisitSampleSimple() {
+        // Mock
+        JoshLangParser.SampleSimpleContext context = mock(JoshLangParser.SampleSimpleContext.class);
+        context.target = mock(JoshLangParser.ExpressionContext.class);
+
+        Fragment targetFragment = mock(Fragment.class);
+        EventHandlerAction targetAction = mock(EventHandlerAction.class);
+
+        when(context.target.accept(parent)).thenReturn(targetFragment);
+        when(targetFragment.getCurrentAction()).thenReturn(targetAction);
+
+        // Test
+        Fragment result = visitor.visitSampleSimple(context);
+
+        // Validate
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(targetAction).apply(mockMachine);
+        verify(mockMachine).push(mockSingleCount); // Verifies push of the singleCount from constructor
+        verify(mockMachine).sample(false); // sampleSimple implies without replacement
+    }
+
+    @Test
+    void testVisitSampleParam() {
+        // Mock
+        JoshLangParser.SampleParamContext context = mock(JoshLangParser.SampleParamContext.class);
+        context.count = mock(JoshLangParser.ExpressionContext.class);
+        context.target = mock(JoshLangParser.ExpressionContext.class);
+
+        Fragment countFragment = mock(Fragment.class);
+        Fragment targetFragment = mock(Fragment.class);
+        EventHandlerAction countAction = mock(EventHandlerAction.class);
+        EventHandlerAction targetAction = mock(EventHandlerAction.class);
+
+        when(context.count.accept(parent)).thenReturn(countFragment);
+        when(context.target.accept(parent)).thenReturn(targetFragment);
+        when(countFragment.getCurrentAction()).thenReturn(countAction);
+        when(targetFragment.getCurrentAction()).thenReturn(targetAction);
+
+        // Test
+        Fragment result = visitor.visitSampleParam(context);
+
+        // Validate
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(countAction).apply(mockMachine);
+        verify(targetAction).apply(mockMachine);
+        verify(mockMachine).sample(false); // sampleParam implies without replacement by default
+    }
+
+    @Test
+    void testVisitSampleParamReplacement_withReplacement() {
+        // Mock
+        JoshLangParser.SampleParamReplacementContext context = mock(JoshLangParser.SampleParamReplacementContext.class);
+        context.count = mock(JoshLangParser.ExpressionContext.class);
+        context.target = mock(JoshLangParser.ExpressionContext.class);
+        context.replace = mock(Token.class);
+
+        Fragment countFragment = mock(Fragment.class);
+        Fragment targetFragment = mock(Fragment.class);
+        EventHandlerAction countAction = mock(EventHandlerAction.class);
+        EventHandlerAction targetAction = mock(EventHandlerAction.class);
+
+        when(context.count.accept(parent)).thenReturn(countFragment);
+        when(context.target.accept(parent)).thenReturn(targetFragment);
+        when(countFragment.getCurrentAction()).thenReturn(countAction);
+        when(targetFragment.getCurrentAction()).thenReturn(targetAction);
+        when(context.replace.getText()).thenReturn("with");
+
+
+        // Test
+        Fragment result = visitor.visitSampleParamReplacement(context);
+
+        // Validate
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(countAction).apply(mockMachine);
+        verify(targetAction).apply(mockMachine);
+        verify(mockMachine).sample(true); // "with" replacement
+    }
+
+    @Test
+    void testVisitSampleParamReplacement_withoutReplacement() {
+        // Mock
+        JoshLangParser.SampleParamReplacementContext context = mock(JoshLangParser.SampleParamReplacementContext.class);
+        context.count = mock(JoshLangParser.ExpressionContext.class);
+        context.target = mock(JoshLangParser.ExpressionContext.class);
+        context.replace = mock(Token.class);
+
+        Fragment countFragment = mock(Fragment.class);
+        Fragment targetFragment = mock(Fragment.class);
+        EventHandlerAction countAction = mock(EventHandlerAction.class);
+        EventHandlerAction targetAction = mock(EventHandlerAction.class);
+
+        when(context.count.accept(parent)).thenReturn(countFragment);
+        when(context.target.accept(parent)).thenReturn(targetFragment);
+        when(countFragment.getCurrentAction()).thenReturn(countAction);
+        when(targetFragment.getCurrentAction()).thenReturn(targetAction);
+        when(context.replace.getText()).thenReturn("without");
+
+
+        // Test
+        Fragment result = visitor.visitSampleParamReplacement(context);
+
+        // Validate
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(countAction).apply(mockMachine);
+        verify(targetAction).apply(mockMachine);
+        verify(mockMachine).sample(false); // "without" replacement
+    }
+
+
+    @Test
+    void testVisitUniformSample() {
+        // Mock
+        JoshLangParser.UniformSampleContext context = mock(JoshLangParser.UniformSampleContext.class);
+        context.low = mock(JoshLangParser.ExpressionContext.class);
+        context.high = mock(JoshLangParser.ExpressionContext.class);
+
+        Fragment lowFragment = mock(Fragment.class);
+        Fragment highFragment = mock(Fragment.class);
+        EventHandlerAction lowAction = mock(EventHandlerAction.class);
+        EventHandlerAction highAction = mock(EventHandlerAction.class);
+
+        when(context.low.accept(parent)).thenReturn(lowFragment);
+        when(context.high.accept(parent)).thenReturn(highFragment);
+        when(lowFragment.getCurrentAction()).thenReturn(lowAction);
+        when(highFragment.getCurrentAction()).thenReturn(highAction);
+
+        // Test
+        Fragment result = visitor.visitUniformSample(context);
+
+        // Validate
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(lowAction).apply(mockMachine);
+        verify(highAction).apply(mockMachine);
+        verify(mockMachine).randUniform();
+    }
+
+    @Test
+    void testVisitNormalSample() {
+        // Mock
+        JoshLangParser.NormalSampleContext context = mock(JoshLangParser.NormalSampleContext.class);
+        context.mean = mock(JoshLangParser.ExpressionContext.class);
+        context.stdev = mock(JoshLangParser.ExpressionContext.class);
+
+        Fragment meanFragment = mock(Fragment.class);
+        Fragment stdevFragment = mock(Fragment.class);
+        EventHandlerAction meanAction = mock(EventHandlerAction.class);
+        EventHandlerAction stdevAction = mock(EventHandlerAction.class);
+
+        when(context.mean.accept(parent)).thenReturn(meanFragment);
+        when(context.stdev.accept(parent)).thenReturn(stdevFragment);
+        when(meanFragment.getCurrentAction()).thenReturn(meanAction);
+        when(stdevFragment.getCurrentAction()).thenReturn(stdevAction);
+
+        // Test
+        Fragment result = visitor.visitNormalSample(context);
+
+        // Validate
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(meanAction).apply(mockMachine);
+        verify(stdevAction).apply(mockMachine);
+        verify(mockMachine).randNormal();
+    }
+}

--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshFunctionVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshFunctionVisitorTest.java
@@ -1,0 +1,381 @@
+package org.joshsim.lang.interpret.visitor.delegates;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.joshsim.engine.entity.handler.EventHandlerGroup;
+import org.joshsim.engine.entity.handler.EventKey;
+import org.joshsim.engine.func.CompiledCallable;
+import org.joshsim.engine.func.CompiledSelector;
+import org.joshsim.lang.antlr.JoshLangParser;
+import org.joshsim.lang.interpret.BridgeGetter;
+import org.joshsim.lang.interpret.action.EventHandlerAction;
+import org.joshsim.lang.interpret.fragment.ActionFragment;
+import org.joshsim.lang.interpret.fragment.CompiledCallableFragment;
+import org.joshsim.lang.interpret.fragment.EventHandlerGroupFragment;
+import org.joshsim.lang.interpret.fragment.Fragment;
+import org.joshsim.lang.interpret.machine.EventHandlerMachine;
+import org.joshsim.lang.interpret.misc.ReservedWordChecker;
+import org.joshsim.lang.interpret.visitor.JoshParserToMachineVisitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JoshFunctionVisitorTest {
+
+    private DelegateToolbox toolbox;
+    private JoshParserToMachineVisitor parent;
+    private BridgeGetter bridgeGetter;
+    private JoshFunctionVisitor visitor;
+
+    @BeforeEach
+    void setUp() {
+        toolbox = mock(DelegateToolbox.class);
+        parent = mock(JoshParserToMachineVisitor.class);
+        bridgeGetter = mock(BridgeGetter.class);
+
+        when(toolbox.getParent()).thenReturn(parent);
+        when(toolbox.getBridgeGetter()).thenReturn(bridgeGetter);
+
+        visitor = new JoshFunctionVisitor(toolbox);
+    }
+
+    @Test
+    void testVisitLambda() {
+        JoshLangParser.LambdaContext context = mock(JoshLangParser.LambdaContext.class);
+        ParseTree childExpression = mock(ParseTree.class); // e.g., fullBody or expression
+        Fragment expressionFragment = mock(Fragment.class);
+        EventHandlerAction expressionAction = mock(EventHandlerAction.class);
+
+        when(context.getChild(0)).thenReturn(childExpression);
+        when(childExpression.accept(parent)).thenReturn(expressionFragment);
+        when(expressionFragment.getCurrentAction()).thenReturn(expressionAction);
+
+        Fragment result = visitor.visitLambda(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction finalAction = result.getCurrentAction();
+        assertNotNull(finalAction);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        finalAction.apply(mockMachine);
+
+        verify(expressionAction).apply(mockMachine);
+        verify(mockMachine).end();
+    }
+
+    @Test
+    void testVisitReturnStatement() {
+        JoshLangParser.ReturnStatementContext context = mock(JoshLangParser.ReturnStatementContext.class);
+        JoshLangParser.ExpressionContext expressionContext = mock(JoshLangParser.ExpressionContext.class);
+        Fragment expressionFragment = mock(Fragment.class);
+        EventHandlerAction expressionAction = mock(EventHandlerAction.class);
+
+        when(context.expression()).thenReturn(expressionContext); // Assuming 'expression()' is the method to get the child
+        when(expressionContext.accept(parent)).thenReturn(expressionFragment);
+        when(expressionFragment.getCurrentAction()).thenReturn(expressionAction);
+
+        // For return statement, context.getChild(1) would be expression if 'return' is child 0
+        // Using context.expression() is more robust if ANTLR grammar defines it
+        // If context.expression() is not available, will revert to getChild(1)
+        // Based on typical grammar: 'return' expression ';'
+        // child 0 = 'return', child 1 = expression, child 2 = ';'
+        // So, if using getChild, it would be getChild(1)
+        // Let's assume context.expression() is canonical. If build fails, this is a likely place to adjust.
+
+        Fragment result = visitor.visitReturnStatement(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction finalAction = result.getCurrentAction();
+        assertNotNull(finalAction);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        finalAction.apply(mockMachine);
+
+        verify(expressionAction).apply(mockMachine);
+        verify(mockMachine).end();
+    }
+
+    @Test
+    void testVisitFullBody_EndsCorrectly() {
+        JoshLangParser.FullBodyContext context = mock(JoshLangParser.FullBodyContext.class);
+        JoshLangParser.StatementContext stmt1Context = mock(JoshLangParser.StatementContext.class);
+        JoshLangParser.StatementContext stmt2Context = mock(JoshLangParser.StatementContext.class); // This one will end
+
+        Fragment stmt1Fragment = mock(Fragment.class);
+        EventHandlerAction stmt1Action = mock(EventHandlerAction.class);
+        Fragment stmt2Fragment = mock(Fragment.class);
+        EventHandlerAction stmt2Action = mock(EventHandlerAction.class);
+
+        when(context.getChildCount()).thenReturn(2);
+        when(context.getChild(0)).thenReturn(stmt1Context);
+        when(context.getChild(1)).thenReturn(stmt2Context);
+
+        when(stmt1Context.accept(parent)).thenReturn(stmt1Fragment);
+        when(stmt1Fragment.getCurrentAction()).thenReturn(stmt1Action);
+        when(stmt2Context.accept(parent)).thenReturn(stmt2Fragment);
+        when(stmt2Fragment.getCurrentAction()).thenReturn(stmt2Action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        when(mockMachine.isEnded()).thenReturn(false).thenReturn(true); // false after stmt1, true after stmt2
+
+        Fragment result = visitor.visitFullBody(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+
+        result.getCurrentAction().apply(mockMachine);
+
+        verify(stmt1Action).apply(mockMachine);
+        verify(stmt2Action).apply(mockMachine);
+        verify(mockMachine, times(2)).isEnded(); // Called after each statement
+    }
+
+    @Test
+    void testVisitFullBody_ThrowsIfNotEnded() {
+        JoshLangParser.FullBodyContext context = mock(JoshLangParser.FullBodyContext.class);
+        JoshLangParser.StatementContext stmt1Context = mock(JoshLangParser.StatementContext.class);
+
+        Fragment stmt1Fragment = mock(Fragment.class);
+        EventHandlerAction stmt1Action = mock(EventHandlerAction.class);
+
+        when(context.getChildCount()).thenReturn(1);
+        when(context.getChild(0)).thenReturn(stmt1Context);
+        when(stmt1Context.accept(parent)).thenReturn(stmt1Fragment);
+        when(stmt1Fragment.getCurrentAction()).thenReturn(stmt1Action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        when(mockMachine.isEnded()).thenReturn(false); // Never ends
+
+        Fragment result = visitor.visitFullBody(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+
+        EventHandlerAction actionToTest = result.getCurrentAction();
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> {
+            actionToTest.apply(mockMachine);
+        });
+        assertEquals("Body did not end with a return statement or an expression.", thrown.getMessage());
+        verify(stmt1Action).apply(mockMachine);
+        verify(mockMachine).isEnded();
+    }
+
+
+    @Test
+    void testVisitEventHandlerGroupMemberInner() {
+        JoshLangParser.EventHandlerGroupMemberInnerContext context = mock(JoshLangParser.EventHandlerGroupMemberInnerContext.class);
+        JoshLangParser.FullBodyContext targetBodyContext = mock(JoshLangParser.FullBodyContext.class); // Assuming inner is a FullBody
+        Fragment targetFragment = mock(Fragment.class); // This will be an ActionFragment from visitFullBody
+        EventHandlerAction targetAction = mock(EventHandlerAction.class);
+
+        when(context.fullBody()).thenReturn(targetBodyContext); // Assuming fullBody() is the accessor
+        when(targetBodyContext.accept(visitor)).thenReturn(targetFragment); // Corrected: should be visited by *this* visitor
+        when(targetFragment.getCurrentAction()).thenReturn(targetAction);
+
+        Fragment result = visitor.visitEventHandlerGroupMemberInner(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment); // visitEventHandlerGroupMemberInner wraps the action from fullBody
+        assertNotNull(result.getCurrentAction());
+
+        // Test the action produced by visitEventHandlerGroupMemberInner
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        result.getCurrentAction().apply(mockMachine); // This applies the wrapped action
+        verify(targetAction).apply(mockMachine); // Verifying the original action from fullBody was called
+    }
+
+    @Test
+    void testVisitConditionalIfEventHandlerGroupMember() {
+        JoshLangParser.ConditionalIfEventHandlerGroupMemberContext context = mock(JoshLangParser.ConditionalIfEventHandlerGroupMemberContext.class);
+        JoshLangParser.ExpressionContext conditionContext = mock(JoshLangParser.ExpressionContext.class);
+        JoshLangParser.EventHandlerGroupMemberInnerContext innerContext = mock(JoshLangParser.EventHandlerGroupMemberInnerContext.class);
+
+        Fragment conditionFragment = mock(Fragment.class);
+        EventHandlerAction conditionAction = mock(EventHandlerAction.class); // Action for the condition
+        Fragment innerFragment = mock(Fragment.class); // ActionFragment from visitEventHandlerGroupMemberInner
+        EventHandlerAction innerAction = mock(EventHandlerAction.class); // Action for the body
+
+        when(context.expression()).thenReturn(conditionContext);
+        when(context.eventHandlerGroupMemberInner()).thenReturn(innerContext);
+
+        when(conditionContext.accept(parent)).thenReturn(conditionFragment);
+        when(conditionFragment.getCurrentAction()).thenReturn(conditionAction);
+
+        when(innerContext.accept(visitor)).thenReturn(innerFragment); // Inner is visited by *this* visitor
+        when(innerFragment.getCurrentAction()).thenReturn(innerAction);
+
+
+        Fragment result = visitor.visitConditionalIfEventHandlerGroupMember(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof CompiledCallableFragment);
+        CompiledCallableFragment ccf = (CompiledCallableFragment) result;
+        assertNotNull(ccf.getCompiledCallable());
+        assertTrue(ccf.getCompiledSelector().isPresent());
+        assertNotNull(ccf.getCompiledSelector().get());
+
+        // To verify the selector and callable would require deeper testing of PushDownMachineCallable/Selector
+        // For now, ensuring they are created is sufficient as per typical visitor tests.
+    }
+
+    @Test
+    void testVisitConditionalElifEventHandlerGroupMember() {
+        JoshLangParser.ConditionalElifEventHandlerGroupMemberContext context = mock(JoshLangParser.ConditionalElifEventHandlerGroupMemberContext.class);
+        JoshLangParser.ExpressionContext conditionContext = mock(JoshLangParser.ExpressionContext.class);
+        JoshLangParser.EventHandlerGroupMemberInnerContext innerContext = mock(JoshLangParser.EventHandlerGroupMemberInnerContext.class);
+
+        Fragment conditionFragment = mock(Fragment.class);
+        EventHandlerAction conditionAction = mock(EventHandlerAction.class);
+        Fragment innerFragment = mock(Fragment.class);
+        EventHandlerAction innerAction = mock(EventHandlerAction.class);
+
+        when(context.expression()).thenReturn(conditionContext);
+        when(context.eventHandlerGroupMemberInner()).thenReturn(innerContext);
+
+        when(conditionContext.accept(parent)).thenReturn(conditionFragment);
+        when(conditionFragment.getCurrentAction()).thenReturn(conditionAction);
+        when(innerContext.accept(visitor)).thenReturn(innerFragment); // Visited by this visitor
+        when(innerFragment.getCurrentAction()).thenReturn(innerAction);
+
+        Fragment result = visitor.visitConditionalElifEventHandlerGroupMember(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof CompiledCallableFragment);
+        CompiledCallableFragment ccf = (CompiledCallableFragment) result;
+        assertNotNull(ccf.getCompiledCallable());
+        assertTrue(ccf.getCompiledSelector().isPresent());
+        assertNotNull(ccf.getCompiledSelector().get());
+    }
+
+    @Test
+    void testVisitConditionalElseEventHandlerGroupMember() {
+        JoshLangParser.ConditionalElseEventHandlerGroupMemberContext context = mock(JoshLangParser.ConditionalElseEventHandlerGroupMemberContext.class);
+        JoshLangParser.EventHandlerGroupMemberInnerContext innerContext = mock(JoshLangParser.EventHandlerGroupMemberInnerContext.class);
+
+        Fragment innerFragment = mock(Fragment.class);
+        EventHandlerAction innerAction = mock(EventHandlerAction.class);
+
+        when(context.eventHandlerGroupMemberInner()).thenReturn(innerContext);
+        when(innerContext.accept(visitor)).thenReturn(innerFragment); // Visited by this visitor
+        when(innerFragment.getCurrentAction()).thenReturn(innerAction);
+
+        Fragment result = visitor.visitConditionalElseEventHandlerGroupMember(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof CompiledCallableFragment);
+        CompiledCallableFragment ccf = (CompiledCallableFragment) result;
+        assertNotNull(ccf.getCompiledCallable());
+        assertFalse(ccf.getCompiledSelector().isPresent()); // Else has no selector
+    }
+
+    @Test
+    void testVisitEventHandlerGroupSingle() {
+        JoshLangParser.EventHandlerGroupSingleContext context = mock(JoshLangParser.EventHandlerGroupSingleContext.class);
+        JoshLangParser.EventHandlerGroupMemberContext memberContext = mock(JoshLangParser.EventHandlerGroupMemberContext.class);
+        CompiledCallableFragment memberFragment = mock(CompiledCallableFragment.class);
+        CompiledCallable mockCallable = mock(CompiledCallable.class);
+
+        when(context.name).thenReturn(mock(org.antlr.v4.runtime.Token.class));
+        when(context.name.getText()).thenReturn("attribute.event");
+        when(context.eventHandlerGroupMember()).thenReturn(memberContext);
+        when(memberContext.accept(visitor)).thenReturn(memberFragment); // Visited by this visitor
+        when(memberFragment.getCompiledCallable()).thenReturn(mockCallable);
+        when(memberFragment.getCompiledSelector()).thenReturn(Optional.empty());
+
+
+        Fragment result = visitor.visitEventHandlerGroupSingle(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof EventHandlerGroupFragment);
+        EventHandlerGroupFragment ehgf = (EventHandlerGroupFragment) result;
+        EventHandlerGroup group = ehgf.getEventHandlerGroup();
+        assertNotNull(group);
+
+        assertEquals("attribute", group.getEventKey().getAttributeName());
+        assertEquals("event", group.getEventKey().getEventName());
+        assertEquals(1, group.getHandlers().size());
+    }
+
+    @Test
+    void testVisitEventHandlerGroupMultiple_WithAndWithoutSelector() {
+        JoshLangParser.EventHandlerGroupMultipleContext context = mock(JoshLangParser.EventHandlerGroupMultipleContext.class);
+        JoshLangParser.ConditionalEventHandlerGroupMemberContext condMemberCtx1 = mock(JoshLangParser.ConditionalEventHandlerGroupMemberContext.class);
+        JoshLangParser.ConditionalEventHandlerGroupMemberContext condMemberCtx2 = mock(JoshLangParser.ConditionalEventHandlerGroupMemberContext.class);
+
+        CompiledCallableFragment ccf1 = mock(CompiledCallableFragment.class);
+        CompiledCallable callable1 = mock(CompiledCallable.class);
+        CompiledSelector selector1 = mock(CompiledSelector.class);
+
+        CompiledCallableFragment ccf2 = mock(CompiledCallableFragment.class);
+        CompiledCallable callable2 = mock(CompiledCallable.class);
+
+
+        when(context.name).thenReturn(mock(org.antlr.v4.runtime.Token.class));
+        when(context.name.getText()).thenReturn("myGroup.myEvent");
+
+        when(context.conditionalEventHandlerGroupMember()).thenReturn(Arrays.asList(condMemberCtx1, condMemberCtx2));
+        when(condMemberCtx1.accept(visitor)).thenReturn(ccf1);
+        when(ccf1.getCompiledCallable()).thenReturn(callable1);
+        when(ccf1.getCompiledSelector()).thenReturn(Optional.of(selector1));
+
+        when(condMemberCtx2.accept(visitor)).thenReturn(ccf2);
+        when(ccf2.getCompiledCallable()).thenReturn(callable2);
+        when(ccf2.getCompiledSelector()).thenReturn(Optional.empty()); // No selector for the second one (like an else)
+
+        Fragment result = visitor.visitEventHandlerGroupMultiple(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof EventHandlerGroupFragment);
+        EventHandlerGroupFragment ehgf = (EventHandlerGroupFragment) result;
+        EventHandlerGroup group = ehgf.getEventHandlerGroup();
+        assertNotNull(group);
+
+        assertEquals("myGroup", group.getEventKey().getAttributeName());
+        assertEquals("myEvent", group.getEventKey().getEventName());
+        assertEquals(2, group.getHandlers().size()); // Two handlers added
+        // Could add more detailed assertions about the Handlers if needed
+    }
+
+    @Test
+    void testVisitEventHandlerGeneral() {
+        // Prepare static mock for ReservedWordChecker IF direct verification is needed
+        // For "successful path", we just ensure no error for a valid name.
+        JoshLangParser.EventHandlerGeneralContext context = mock(JoshLangParser.EventHandlerGeneralContext.class);
+        JoshLangParser.EventHandlerGroupContext groupContext = mock(JoshLangParser.EventHandlerGroupContext.class); // The child is an eventHandlerGroup
+        EventHandlerGroupFragment groupFragment = mock(EventHandlerGroupFragment.class);
+        EventHandlerGroup eventHandlerGroup = mock(EventHandlerGroup.class);
+
+        String validName = "myCustomEventHandler";
+        when(context.name).thenReturn(mock(org.antlr.v4.runtime.Token.class));
+        when(context.name.getText()).thenReturn(validName);
+
+        // The child of eventHandlerGeneral is eventHandlerGroup.
+        // It's not context.getChild(0) directly but context.eventHandlerGroup()
+        when(context.eventHandlerGroup()).thenReturn(groupContext);
+        when(groupContext.accept(visitor)).thenReturn(groupFragment); // Visited by this visitor
+        when(groupFragment.getEventHandlerGroup()).thenReturn(eventHandlerGroup);
+
+        // Test that ReservedWordChecker.checkVariableDeclaration doesn't throw for a valid name
+        // This happens implicitly. If it threw, the test would fail.
+        // For explicit verification (if it were not a static method or if we wanted to ensure it *was* called):
+        // mockStatic(ReservedWordChecker.class) then verify static. But not strictly needed for "successful path".
+
+        Fragment result = visitor.visitEventHandlerGeneral(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(mockMachine).putAttribute(eq(validName), eq(eventHandlerGroup));
+    }
+}

--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshLogicalVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshLogicalVisitorTest.java
@@ -1,0 +1,337 @@
+package org.joshsim.lang.interpret.visitor.delegates;
+
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.engine.EngineValueFactory;
+import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.lang.antlr.JoshLangParser;
+import org.joshsim.lang.interpret.action.ChaniningConditionalBuilder;
+import org.joshsim.lang.interpret.action.ConditionalAction;
+import org.joshsim.lang.interpret.action.EventHandlerAction;
+import org.joshsim.lang.interpret.fragment.ActionFragment;
+import org.joshsim.lang.interpret.fragment.Fragment;
+import org.joshsim.lang.interpret.machine.EventHandlerMachine;
+import org.joshsim.lang.interpret.visitor.JoshParserToMachineVisitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JoshLogicalVisitorTest {
+
+    private DelegateToolbox toolbox;
+    private JoshParserToMachineVisitor parent;
+    private EngineValueFactory engineValueFactory;
+    private EngineValue trueValue;
+    private JoshLogicalVisitor visitor;
+
+    @BeforeEach
+    void setUp() {
+        toolbox = mock(DelegateToolbox.class);
+        parent = mock(JoshParserToMachineVisitor.class);
+        engineValueFactory = mock(EngineValueFactory.class);
+        trueValue = mock(EngineValue.class);
+
+        when(toolbox.getParent()).thenReturn(parent);
+        when(toolbox.getValueFactory()).thenReturn(engineValueFactory);
+        when(engineValueFactory.build(true, Units.EMPTY)).thenReturn(trueValue);
+
+        visitor = new JoshLogicalVisitor(toolbox);
+    }
+
+    @Test
+    void testVisitLogicalExpression_And() {
+        JoshLangParser.LogicalExpressionContext context = mock(JoshLangParser.LogicalExpressionContext.class);
+        context.left = mock(JoshLangParser.ExpressionContext.class);
+        context.right = mock(JoshLangParser.ExpressionContext.class);
+        context.op = mock(Token.class);
+
+        Fragment leftFragment = mock(Fragment.class);
+        EventHandlerAction leftAction = mock(EventHandlerAction.class);
+        Fragment rightFragment = mock(Fragment.class);
+        EventHandlerAction rightAction = mock(EventHandlerAction.class);
+
+        when(context.op.getText()).thenReturn("and");
+        when(context.left.accept(parent)).thenReturn(leftFragment);
+        when(leftFragment.getCurrentAction()).thenReturn(leftAction);
+        when(context.right.accept(parent)).thenReturn(rightFragment);
+        when(rightFragment.getCurrentAction()).thenReturn(rightAction);
+
+        Fragment result = visitor.visitLogicalExpression(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(leftAction).apply(mockMachine);
+        verify(rightAction).apply(mockMachine);
+        verify(mockMachine).and();
+    }
+
+    @Test
+    void testVisitCondition_Equals() {
+        JoshLangParser.ConditionContext context = mock(JoshLangParser.ConditionContext.class);
+        context.left = mock(JoshLangParser.ExpressionContext.class);
+        context.right = mock(JoshLangParser.ExpressionContext.class);
+        context.op = mock(Token.class);
+
+        Fragment leftFragment = mock(Fragment.class);
+        EventHandlerAction leftAction = mock(EventHandlerAction.class);
+        Fragment rightFragment = mock(Fragment.class);
+        EventHandlerAction rightAction = mock(EventHandlerAction.class);
+
+        when(context.op.getText()).thenReturn("==");
+        when(context.left.accept(parent)).thenReturn(leftFragment);
+        when(leftFragment.getCurrentAction()).thenReturn(leftAction);
+        when(context.right.accept(parent)).thenReturn(rightFragment);
+        when(rightFragment.getCurrentAction()).thenReturn(rightAction);
+
+        Fragment result = visitor.visitCondition(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(leftAction).apply(mockMachine);
+        verify(rightAction).apply(mockMachine);
+        verify(mockMachine).eq();
+    }
+
+    @Test
+    void testVisitConditional() {
+        JoshLangParser.ConditionalContext context = mock(JoshLangParser.ConditionalContext.class);
+        JoshLangParser.ExpressionContext condExpr = mock(JoshLangParser.ExpressionContext.class);
+        JoshLangParser.ExpressionContext posExpr = mock(JoshLangParser.ExpressionContext.class);
+        JoshLangParser.ExpressionContext negExpr = mock(JoshLangParser.ExpressionContext.class);
+
+        Fragment condFragment = mock(Fragment.class);
+        EventHandlerAction condAction = mock(EventHandlerAction.class);
+        Fragment posFragment = mock(Fragment.class);
+        EventHandlerAction posAction = mock(EventHandlerAction.class);
+        Fragment negFragment = mock(Fragment.class);
+        EventHandlerAction negAction = mock(EventHandlerAction.class);
+
+        when(context.cond).thenReturn(condExpr);
+        when(context.pos).thenReturn(posExpr);
+        when(context.neg).thenReturn(negExpr);
+
+        when(condExpr.accept(parent)).thenReturn(condFragment);
+        when(condFragment.getCurrentAction()).thenReturn(condAction);
+        when(posExpr.accept(parent)).thenReturn(posFragment);
+        when(posFragment.getCurrentAction()).thenReturn(posAction);
+        when(negExpr.accept(parent)).thenReturn(negFragment);
+        when(negFragment.getCurrentAction()).thenReturn(negAction);
+
+        Fragment result = visitor.visitConditional(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+        assertTrue(action instanceof ConditionalAction);
+
+        // To verify behavior of ConditionalAction (successful path)
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+
+        // Scenario 1: Condition is true
+        doAnswer(invocation -> {
+            invocation.getArgument(0, EventHandlerMachine.class).push(trueValue); // Simulate condAction pushing true
+            return null;
+        }).when(condAction).apply(any(EventHandlerMachine.class));
+        when(mockMachine.pop(Boolean.class)).thenReturn(true); // Machine pops true
+
+        action.apply(mockMachine);
+        verify(condAction).apply(mockMachine);
+        verify(posAction).apply(mockMachine);
+        verify(negAction, never()).apply(mockMachine); // Negative branch not taken
+
+        // Scenario 2: Condition is false
+        reset(condAction, posAction, negAction, mockMachine); // Reset mocks for new scenario
+        doAnswer(invocation -> {
+            invocation.getArgument(0, EventHandlerMachine.class).push(mock(EngineValue.class)); // Simulate condAction pushing false
+            return null;
+        }).when(condAction).apply(any(EventHandlerMachine.class));
+        when(mockMachine.pop(Boolean.class)).thenReturn(false); // Machine pops false
+
+        action.apply(mockMachine);
+        verify(condAction).apply(mockMachine);
+        verify(negAction).apply(mockMachine);
+        verify(posAction, never()).apply(mockMachine); // Positive branch not taken
+    }
+
+    @Test
+    void testVisitFullConditional() {
+        JoshLangParser.FullConditionalContext context = mock(JoshLangParser.FullConditionalContext.class);
+        JoshLangParser.ExpressionContext condExpr = mock(JoshLangParser.ExpressionContext.class);
+        JoshLangParser.ExpressionContext targetExpr = mock(JoshLangParser.ExpressionContext.class); // Target for the 'if'
+        JoshLangParser.FullElifBranchContext elifBranchCtx = mock(JoshLangParser.FullElifBranchContext.class); // One elif branch
+
+        Fragment condFragment = mock(Fragment.class);
+        EventHandlerAction condAction = mock(EventHandlerAction.class); // Action for initial if's condition
+        Fragment targetFragmentIf = mock(Fragment.class);
+        EventHandlerAction targetActionIf = mock(EventHandlerAction.class); // Action for initial if's body
+
+        ActionFragment elifFragment = mock(ActionFragment.class); // Fragment from visiting elifBranchCtx
+        ConditionalAction elifConditionalAction = mock(ConditionalAction.class); // Action from elifFragment
+
+        when(context.cond).thenReturn(condExpr);
+        when(context.target).thenReturn(targetExpr);
+        when(condExpr.accept(parent)).thenReturn(condFragment);
+        when(condFragment.getCurrentAction()).thenReturn(condAction);
+        when(targetExpr.accept(parent)).thenReturn(targetFragmentIf);
+        when(targetFragmentIf.getCurrentAction()).thenReturn(targetActionIf);
+
+        when(context.fullElifBranch()).thenReturn(java.util.Collections.singletonList(elifBranchCtx));
+        when(context.fullElseBranch()).thenReturn(null);
+        when(elifBranchCtx.accept(visitor)).thenReturn(elifFragment);
+        when(elifFragment.getCurrentAction()).thenReturn(elifConditionalAction);
+
+        EventHandlerAction finalChainedAction = mock(EventHandlerAction.class);
+
+        // Use mockConstruction for ChaniningConditionalBuilder
+        try (var mockedBuilderConstruction = mockConstruction(ChaniningConditionalBuilder.class,
+                (mock, constructionContext) -> {
+                    when(mock.build()).thenReturn(finalChainedAction);
+                })) {
+
+            Fragment result = visitor.visitFullConditional(context);
+
+            assertNotNull(result);
+            assertTrue(result instanceof ActionFragment);
+            assertEquals(finalChainedAction, result.getCurrentAction());
+
+            // Verify interactions with the constructed ChaniningConditionalBuilder instance
+            assertEquals(1, mockedBuilderConstruction.constructed().size());
+            ChaniningConditionalBuilder instantiatedBuilder = mockedBuilderConstruction.constructed().get(0);
+
+            verify(instantiatedBuilder).add(eq(condAction), eq(targetActionIf));
+            verify(instantiatedBuilder).add(eq(elifConditionalAction));
+            verify(instantiatedBuilder).build();
+
+        } // MockedConstruction closes automatically
+    }
+
+
+    @Test
+    void testVisitFullElifBranch() {
+        JoshLangParser.FullElifBranchContext context = mock(JoshLangParser.FullElifBranchContext.class);
+        JoshLangParser.ExpressionContext condExpr = mock(JoshLangParser.ExpressionContext.class);
+        JoshLangParser.ExpressionContext targetExpr = mock(JoshLangParser.ExpressionContext.class);
+
+        Fragment condFragment = mock(Fragment.class);
+        EventHandlerAction condAction = mock(EventHandlerAction.class);
+        Fragment targetFragment = mock(Fragment.class);
+        EventHandlerAction targetAction = mock(EventHandlerAction.class);
+
+        when(context.cond).thenReturn(condExpr);
+        when(context.target).thenReturn(targetExpr);
+        when(condExpr.accept(parent)).thenReturn(condFragment);
+        when(condFragment.getCurrentAction()).thenReturn(condAction);
+        when(targetExpr.accept(parent)).thenReturn(targetFragment);
+        when(targetFragment.getCurrentAction()).thenReturn(targetAction);
+
+        Fragment result = visitor.visitFullElifBranch(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+        assertTrue(action instanceof ConditionalAction); // Expecting a ConditionalAction for the elif body
+    }
+
+    @Test
+    void testVisitFullElseBranch() {
+        JoshLangParser.FullElseBranchContext context = mock(JoshLangParser.FullElseBranchContext.class);
+        JoshLangParser.ExpressionContext targetExpr = mock(JoshLangParser.ExpressionContext.class);
+
+        Fragment targetFragment = mock(Fragment.class);
+        EventHandlerAction targetAction = mock(EventHandlerAction.class); // Action for the else body
+
+        when(context.target).thenReturn(targetExpr);
+        when(targetExpr.accept(parent)).thenReturn(targetFragment);
+        when(targetFragment.getCurrentAction()).thenReturn(targetAction);
+
+        // Capture the arguments to ConditionalAction constructor
+        ArgumentCaptor<EventHandlerAction> condActionCaptor = ArgumentCaptor.forClass(EventHandlerAction.class);
+        ArgumentCaptor<EventHandlerAction> posActionCaptor = ArgumentCaptor.forClass(EventHandlerAction.class);
+        ArgumentCaptor<EventHandlerAction> negActionCaptor = ArgumentCaptor.forClass(EventHandlerAction.class);
+
+        // Use mockConstruction for ConditionalAction to capture its constructor arguments
+        try (var mockedConditionalAction = mockConstruction(ConditionalAction.class,
+            (mock, constructionContext) -> {
+                // No specific stubbing needed for mock ConditionalAction instance itself for this test
+            })) {
+
+            Fragment result = visitor.visitFullElseBranch(context);
+
+            assertNotNull(result);
+            assertTrue(result instanceof ActionFragment);
+            EventHandlerAction action = result.getCurrentAction();
+            assertNotNull(action);
+            assertTrue(action instanceof ConditionalAction); // Should be one of the mocked instances
+
+            // Verify the constructor of ConditionalAction was called once, and get that instance
+            assertEquals(1, mockedConditionalAction.constructed().size());
+            ConditionalAction instantiatedCondAction = mockedConditionalAction.constructed().get(0);
+
+            // Verify that our 'action' is indeed the one that was constructed
+            assertSame(instantiatedCondAction, action);
+
+            // Now, verify the arguments passed to its constructor by capturing them.
+            // This requires ConditionalAction constructor to be called in a verifiable way.
+            // The actual call is `new ConditionalAction(condAction, actualAction, null)`
+            // We need to find which constructor call in the production code this corresponds to.
+            // For this, we'd typically verify the call on a *mock* of ConditionalAction if it were injected.
+            // With mockConstruction, we verify the arguments on the construction context if needed,
+            // or capture from the mocked instance if it stores them.
+            // Here, we will test the *behavior* of the captured condAction.
+
+            // The ConditionalAction constructor is called with 3 args: cond, positive, negative.
+            // We need to capture these from the construction context during the 'new ConditionalAction(...)' call.
+            // This is tricky if ConditionalAction doesn't store these args publicly.
+            // Let's assume the first argument to the constructor is the 'condition' action.
+            // This part of the test is complex with mockConstruction if we don't know the exact order/type of args.
+
+            // Alternative: Test the captured condAction directly if possible.
+            // The real ConditionalAction is created with a lambda: (machine) -> machine.push(this.trueValue)
+            // We need to get this lambda.
+            // For now, let's assume the ConditionalAction was formed correctly and its condAction would push trueValue.
+            // A simpler behavioral test: the 'targetAction' for an else should always execute.
+            EventHandlerMachine testMachine = mock(EventHandlerMachine.class);
+            when(testMachine.pop(Boolean.class)).thenReturn(true); // Simulate the 'true' condition from else
+
+            action.apply(testMachine); // Apply the actual ConditionalAction returned by visitor
+
+            // This verifies that if the condition part of the ConditionalAction results in true,
+            // the positive action (targetAction for else) is called.
+            // It doesn't directly verify that trueValue was pushed by the condition lambda itself.
+            verify(targetAction).apply(testMachine);
+
+
+            // To directly test the condAction:
+            // Requires ConditionalAction to be created via a factory, or have getters for its actions,
+            // or use ArgumentCaptor on a mocked factory method.
+            // With mockConstruction, you can provide an answer for the constructor:
+            // E.g., store the passed condAction in a test-visible field.
+
+            // For this test, we'll rely on the above behavioral verification combined with knowing
+            // that `trueValue` is correctly initialized in `setUp`.
+            // A more direct verification of the lambda `(m) -> m.push(trueValue)`:
+            // If we could somehow get a handle to this lambda (e.g. if ConditionalAction stored it)
+            // EventHandlerAction elseCondAction = ((ConditionalAction)action).getCondAction(); // Fictional getter
+            // elseCondAction.apply(testMachine);
+            // verify(testMachine).push(eq(trueValue));
+        }
+    }
+}

--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshMathematicsVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshMathematicsVisitorTest.java
@@ -1,0 +1,325 @@
+package org.joshsim.lang.interpret.visitor.delegates;
+
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.engine.EngineValueFactory;
+import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.lang.antlr.JoshLangParser;
+import org.joshsim.lang.interpret.action.EventHandlerAction;
+import org.joshsim.lang.interpret.fragment.ActionFragment;
+import org.joshsim.lang.interpret.fragment.Fragment;
+import org.joshsim.lang.interpret.machine.EventHandlerMachine;
+import org.joshsim.lang.interpret.visitor.JoshParserToMachineVisitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JoshMathematicsVisitorTest {
+
+    private DelegateToolbox toolbox;
+    private JoshParserToMachineVisitor parent;
+    private EngineValueFactory engineValueFactory;
+    private JoshMathematicsVisitor visitor;
+    private EngineValue mockTrueValueEmptyUnits;
+
+
+    @BeforeEach
+    void setUp() {
+        toolbox = mock(DelegateToolbox.class);
+        parent = mock(JoshParserToMachineVisitor.class);
+        engineValueFactory = mock(EngineValueFactory.class);
+        mockTrueValueEmptyUnits = mock(EngineValue.class);
+
+        when(toolbox.getParent()).thenReturn(parent);
+        when(toolbox.getValueFactory()).thenReturn(engineValueFactory);
+        when(engineValueFactory.build(true, Units.EMPTY)).thenReturn(mockTrueValueEmptyUnits);
+
+        visitor = new JoshMathematicsVisitor(toolbox);
+    }
+
+    private EventHandlerAction mockActionForExpression(JoshLangParser.ExpressionContext exprCtx) {
+        Fragment fragment = mock(Fragment.class);
+        EventHandlerAction action = mock(EventHandlerAction.class);
+        when(exprCtx.accept(parent)).thenReturn(fragment);
+        when(fragment.getCurrentAction()).thenReturn(action);
+        return action;
+    }
+
+    @Test
+    void testVisitMapLinear() {
+        JoshLangParser.MapLinearContext context = mock(JoshLangParser.MapLinearContext.class);
+        context.operand = mock(JoshLangParser.ExpressionContext.class);
+        context.fromLow = mock(JoshLangParser.ExpressionContext.class);
+        context.fromHigh = mock(JoshLangParser.ExpressionContext.class);
+        context.toLow = mock(JoshLangParser.ExpressionContext.class);
+        context.toHigh = mock(JoshLangParser.ExpressionContext.class);
+
+        EventHandlerAction operandAction = mockActionForExpression(context.operand);
+        EventHandlerAction fromLowAction = mockActionForExpression(context.fromLow);
+        EventHandlerAction fromHighAction = mockActionForExpression(context.fromHigh);
+        EventHandlerAction toLowAction = mockActionForExpression(context.toLow);
+        EventHandlerAction toHighAction = mockActionForExpression(context.toHigh);
+
+        Fragment result = visitor.visitMapLinear(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(operandAction).apply(mockMachine);
+        verify(fromLowAction).apply(mockMachine);
+        verify(fromHighAction).apply(mockMachine);
+        verify(toLowAction).apply(mockMachine);
+        verify(toHighAction).apply(mockMachine);
+        verify(mockMachine).push(mockTrueValueEmptyUnits); // for clamp = true
+        verify(mockMachine).applyMap("linear");
+    }
+
+    @Test
+    void testVisitMapParam() {
+        JoshLangParser.MapParamContext context = mock(JoshLangParser.MapParamContext.class);
+        context.operand = mock(JoshLangParser.ExpressionContext.class);
+        context.from = mock(JoshLangParser.ExpressionContext.class);
+        context.to = mock(JoshLangParser.ExpressionContext.class);
+        context.method = mock(Token.class);
+
+        when(context.method.getText()).thenReturn("testMethod");
+        EventHandlerAction operandAction = mockActionForExpression(context.operand);
+        EventHandlerAction fromAction = mockActionForExpression(context.from);
+        EventHandlerAction toAction = mockActionForExpression(context.to);
+
+        Fragment result = visitor.visitMapParam(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(operandAction).apply(mockMachine);
+        verify(fromAction).apply(mockMachine);
+        verify(toAction).apply(mockMachine);
+        verify(mockMachine).push(mockTrueValueEmptyUnits); // for clamp = true
+        verify(mockMachine).applyMap("testMethod");
+    }
+
+    @Test
+    void testVisitMapParamParam() {
+        JoshLangParser.MapParamParamContext context = mock(JoshLangParser.MapParamParamContext.class);
+        context.operand = mock(JoshLangParser.ExpressionContext.class);
+        context.from = mock(JoshLangParser.ExpressionContext.class);
+        context.to = mock(JoshLangParser.ExpressionContext.class);
+        context.param = mock(JoshLangParser.ExpressionContext.class);
+        context.method = mock(Token.class);
+
+        when(context.method.getText()).thenReturn("testMethodWithParam");
+        EventHandlerAction operandAction = mockActionForExpression(context.operand);
+        EventHandlerAction fromAction = mockActionForExpression(context.from);
+        EventHandlerAction toAction = mockActionForExpression(context.to);
+        EventHandlerAction paramAction = mockActionForExpression(context.param);
+
+        Fragment result = visitor.visitMapParamParam(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(operandAction).apply(mockMachine);
+        verify(fromAction).apply(mockMachine);
+        verify(toAction).apply(mockMachine);
+        verify(paramAction).apply(mockMachine); // Param is applied before map
+        verify(mockMachine).applyMap("testMethodWithParam");
+    }
+
+
+    @Test
+    void testVisitAdditionExpression_Add() {
+        JoshLangParser.AdditionExpressionContext context = mock(JoshLangParser.AdditionExpressionContext.class);
+        context.left = mock(JoshLangParser.ExpressionContext.class);
+        context.right = mock(JoshLangParser.ExpressionContext.class);
+        context.op = mock(Token.class);
+        when(context.op.getText()).thenReturn("+");
+
+        EventHandlerAction leftAction = mockActionForExpression(context.left);
+        EventHandlerAction rightAction = mockActionForExpression(context.right);
+
+        Fragment result = visitor.visitAdditionExpression(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(leftAction).apply(mockMachine);
+        verify(rightAction).apply(mockMachine);
+        verify(mockMachine).add();
+    }
+
+    @Test
+    void testVisitMultiplyExpression_Multiply() {
+        JoshLangParser.MultiplyExpressionContext context = mock(JoshLangParser.MultiplyExpressionContext.class);
+        context.left = mock(JoshLangParser.ExpressionContext.class);
+        context.right = mock(JoshLangParser.ExpressionContext.class);
+        context.op = mock(Token.class);
+        when(context.op.getText()).thenReturn("*");
+
+        EventHandlerAction leftAction = mockActionForExpression(context.left);
+        EventHandlerAction rightAction = mockActionForExpression(context.right);
+
+        Fragment result = visitor.visitMultiplyExpression(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(leftAction).apply(mockMachine);
+        verify(rightAction).apply(mockMachine);
+        verify(mockMachine).multiply();
+    }
+
+    @Test
+    void testVisitPowExpression() {
+        JoshLangParser.PowExpressionContext context = mock(JoshLangParser.PowExpressionContext.class);
+        context.left = mock(JoshLangParser.ExpressionContext.class);
+        context.right = mock(JoshLangParser.ExpressionContext.class);
+
+        EventHandlerAction leftAction = mockActionForExpression(context.left);
+        EventHandlerAction rightAction = mockActionForExpression(context.right);
+
+        Fragment result = visitor.visitPowExpression(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(leftAction).apply(mockMachine);
+        verify(rightAction).apply(mockMachine);
+        verify(mockMachine).pow();
+    }
+
+    @Test
+    void testVisitParenExpression() {
+        JoshLangParser.ParenExpressionContext context = mock(JoshLangParser.ParenExpressionContext.class);
+        ParseTree childExpressionNode = mock(ParseTree.class); // Typically an ExpressionContext
+        Fragment expectedFragment = mock(Fragment.class);
+
+        when(context.getChild(1)).thenReturn(childExpressionNode); // '(' is child 0, expr is child 1, ')' is child 2
+        when(childExpressionNode.accept(parent)).thenReturn(expectedFragment);
+
+        Fragment actualFragment = visitor.visitParenExpression(context);
+        assertSame(expectedFragment, actualFragment);
+    }
+
+    @Test
+    void testVisitLimitBoundExpression() {
+        JoshLangParser.LimitBoundExpressionContext context = mock(JoshLangParser.LimitBoundExpressionContext.class);
+        context.operand = mock(JoshLangParser.ExpressionContext.class);
+        context.low = mock(JoshLangParser.ExpressionContext.class);
+        context.high = mock(JoshLangParser.ExpressionContext.class);
+
+        EventHandlerAction operandAction = mockActionForExpression(context.operand);
+        EventHandlerAction lowAction = mockActionForExpression(context.low);
+        EventHandlerAction highAction = mockActionForExpression(context.high);
+
+        Fragment result = visitor.visitLimitBoundExpression(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(operandAction).apply(mockMachine);
+        verify(lowAction).apply(mockMachine);
+        verify(highAction).apply(mockMachine);
+        verify(mockMachine).bound(true, true);
+    }
+
+    @Test
+    void testVisitLimitMinExpression() {
+        JoshLangParser.LimitMinExpressionContext context = mock(JoshLangParser.LimitMinExpressionContext.class);
+        context.operand = mock(JoshLangParser.ExpressionContext.class);
+        context.limit = mock(JoshLangParser.ExpressionContext.class);
+
+        EventHandlerAction operandAction = mockActionForExpression(context.operand);
+        EventHandlerAction limitAction = mockActionForExpression(context.limit);
+
+        Fragment result = visitor.visitLimitMinExpression(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(operandAction).apply(mockMachine);
+        verify(limitAction).apply(mockMachine);
+        verify(mockMachine).bound(true, false);
+    }
+
+    @Test
+    void testVisitLimitMaxExpression() {
+        JoshLangParser.LimitMaxExpressionContext context = mock(JoshLangParser.LimitMaxExpressionContext.class);
+        context.operand = mock(JoshLangParser.ExpressionContext.class);
+        context.limit = mock(JoshLangParser.ExpressionContext.class);
+
+        EventHandlerAction operandAction = mockActionForExpression(context.operand);
+        EventHandlerAction limitAction = mockActionForExpression(context.limit);
+
+        Fragment result = visitor.visitLimitMaxExpression(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(operandAction).apply(mockMachine);
+        verify(limitAction).apply(mockMachine);
+        verify(mockMachine).bound(false, true);
+    }
+
+    @Test
+    void testVisitSingleParamFunctionCall_Abs() {
+        JoshLangParser.SingleParamFunctionCallContext context = mock(JoshLangParser.SingleParamFunctionCallContext.class);
+        context.operand = mock(JoshLangParser.ExpressionContext.class);
+        context.name = mock(Token.class);
+        when(context.name.getText()).thenReturn("abs");
+
+        EventHandlerAction operandAction = mockActionForExpression(context.operand);
+
+        Fragment result = visitor.visitSingleParamFunctionCall(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(operandAction).apply(mockMachine);
+        verify(mockMachine).abs();
+    }
+}

--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshStanzaVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshStanzaVisitorTest.java
@@ -1,0 +1,266 @@
+package org.joshsim.lang.interpret.visitor.delegates;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.joshsim.engine.doc.EntityType;
+import org.joshsim.engine.entity.EntityBuilder;
+import org.joshsim.engine.entity.EntityPrototype;
+import org.joshsim.engine.entity.handler.EventHandlerGroup;
+import org.joshsim.engine.entity.handler.EventHandlerGroupBuilder;
+import org.joshsim.engine.entity.handler.EventKey;
+import org.joshsim.engine.value.converter.Conversion;
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.function.ValueFunction;
+import org.joshsim.lang.antlr.JoshLangParser;
+import org.joshsim.lang.interpret.ProgramBuilder;
+import org.joshsim.lang.interpret.fragment.*;
+import org.joshsim.lang.interpret.visitor.JoshParserToMachineVisitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JoshStanzaVisitorTest {
+
+    private DelegateToolbox toolbox;
+    private JoshParserToMachineVisitor parent;
+    private JoshStanzaVisitor visitor;
+
+    @BeforeEach
+    void setUp() {
+        toolbox = mock(DelegateToolbox.class);
+        parent = mock(JoshParserToMachineVisitor.class);
+        when(toolbox.getParent()).thenReturn(parent);
+        visitor = new JoshStanzaVisitor(toolbox);
+    }
+
+    @Test
+    void testVisitStateStanza() {
+        JoshLangParser.StateStanzaContext context = mock(JoshLangParser.StateStanzaContext.class);
+        ParseTree stateNameNode = mock(ParseTree.class);
+        ParseTree eventHandlerGroupNode = mock(ParseTree.class);
+        Fragment groupFragment = mock(Fragment.class);
+        EventHandlerGroupBuilder mockGroupBuilder = mock(EventHandlerGroupBuilder.class);
+        String stateName = "myState";
+
+        // "state" stateName eventHandlerGroup* "end"
+        // Child 0: "state" token
+        // Child 1: stateName (IDENTIFIER token) - but grammar shows it as part of stateName: name=IDENTIFIER
+        // Let's assume grammar is `stateStanza: K_STATE name=IDENTIFIER eventHandlerGroup* K_END;`
+        // Then `ctx.name.getText()` would be stateName.
+        // If it is `stateStanza: K_STATE IDENTIFIER eventHandlerGroup* K_END;`
+        // Then `ctx.getChild(1).getText()`
+        // The provided code uses `ctx.getChild(2).getText()`, which implies a structure like
+        // `K_STATE SOMETHING IDENTIFIER ...` - let's stick to the prompt's structure.
+        // The original code for JoshStanzaVisitor is: `String stateName = ctx.getChild(2).getText();`
+        // And loop from `i = 3` to `ctx.getChildCount() - 2`.
+        // This means: child 0=K_STATE, child 1=???, child 2=stateName, child 3...n-2 = groups, child n-1=K_END
+
+        when(context.getChild(2)).thenReturn(stateNameNode);
+        when(stateNameNode.getText()).thenReturn(stateName);
+        when(context.getChildCount()).thenReturn(5); // state, ?, stateName, group, end
+        when(context.getChild(3)).thenReturn(eventHandlerGroupNode);
+        when(eventHandlerGroupNode.accept(parent)).thenReturn(groupFragment);
+        when(groupFragment.getEventHandlerGroup()).thenReturn(mockGroupBuilder);
+
+        Fragment result = visitor.visitStateStanza(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof StateFragment);
+        StateFragment stateFragment = (StateFragment) result;
+
+        assertEquals(1, stateFragment.getEventHandlerGroupBuilders().size());
+        assertSame(mockGroupBuilder, stateFragment.getEventHandlerGroupBuilders().get(0));
+        verify(mockGroupBuilder).setState(stateName);
+    }
+
+    @Test
+    void testVisitEntityStanza_SuccessfulPath() {
+        JoshLangParser.EntityStanzaContext context = mock(JoshLangParser.EntityStanzaContext.class);
+        ParseTree entityTypeNode = mock(ParseTree.class); // e.g., "agent"
+        ParseTree entityIdentifierNode = mock(ParseTree.class); // e.g., "myAgent"
+        ParseTree entityBodyNode = mock(ParseTree.class); // Contains event handler groups
+        ParseTree closeEntityTypeNode = mock(ParseTree.class); // e.g., "agent"
+
+        String entityTypeStr = "agent";
+        String entityIdentifierStr = "myAgent";
+
+        // Structure: K_ENTITY entityType IDENTIFIER entityBody K_END closeEntityType
+        // Child 0: K_ENTITY
+        // Child 1: entityType (e.g. "agent")
+        // Child 2: IDENTIFIER (name)
+        // Child 3: entityBody (contains list of event handler groups)
+        // Child 4: K_END
+        // Child 5: closeEntityType (e.g. "agent")
+        when(context.getChild(1)).thenReturn(entityTypeNode);
+        when(entityTypeNode.getText()).thenReturn(entityTypeStr);
+        when(context.getChild(2)).thenReturn(entityIdentifierNode);
+        when(entityIdentifierNode.getText()).thenReturn(entityIdentifierStr);
+        when(context.getChild(3)).thenReturn(entityBodyNode); // This is the one that returns groups
+        when(context.getChild(5)).thenReturn(closeEntityTypeNode);
+        when(closeEntityTypeNode.getText()).thenReturn(entityTypeStr); // Matching type for success
+        when(context.getChildCount()).thenReturn(6);
+
+
+        Fragment bodyFragment = mock(Fragment.class); // Fragment from visiting entityBodyNode
+        EventHandlerGroupBuilder mockGroupBuilder = mock(EventHandlerGroupBuilder.class);
+        EventKey mockEventKey = mock(EventKey.class);
+        EventHandlerGroup mockGroup = mock(EventHandlerGroup.class);
+
+        when(entityBodyNode.accept(parent)).thenReturn(bodyFragment);
+        when(bodyFragment.getEventHandlerGroups()).thenReturn(Collections.singletonList(mockGroupBuilder));
+        when(mockGroupBuilder.buildKey(anyString(), any(EntityType.class))).thenReturn(mockEventKey);
+        when(mockGroupBuilder.build(any(EventKey.class))).thenReturn(mockGroup);
+
+        EntityBuilder mockEntityBuilder = mock(EntityBuilder.class);
+        when(mockEntityBuilder.build(anyString(), any(EntityType.class))).thenReturn(mock(EntityPrototype.class));
+
+
+        try (MockedConstruction<EntityBuilder> mockedEntityBuilderConstruction =
+                     mockConstruction(EntityBuilder.class, (mock, constructionContext) -> {
+                         when(mock.build(anyString(), any(EntityType.class))).thenReturn(mock(EntityPrototype.class));
+                         // Stub addEventHandlerGroup if needed, or verify on the captured mock
+                     })) {
+
+            Fragment result = visitor.visitEntityStanza(context);
+
+            assertNotNull(result);
+            assertTrue(result instanceof EntityFragment);
+            EntityFragment entityFragment = (EntityFragment) result;
+            EntityPrototype prototype = entityFragment.getEntityPrototype();
+            assertNotNull(prototype);
+
+            // Verify interactions on the constructed EntityBuilder
+            assertEquals(1, mockedEntityBuilderConstruction.constructed().size());
+            EntityBuilder instantiatedEntityBuilder = mockedEntityBuilderConstruction.constructed().get(0);
+
+            verify(instantiatedEntityBuilder).build(entityIdentifierStr, EntityType.AGENT);
+            verify(instantiatedEntityBuilder).addEventHandlerGroup(mockGroup);
+            verify(mockGroupBuilder).buildKey(entityIdentifierStr, EntityType.AGENT);
+            verify(mockGroupBuilder).build(mockEventKey);
+
+        }
+    }
+
+    @Test
+    void testVisitEntityStanza_ThrowsOnMismatch() {
+        JoshLangParser.EntityStanzaContext context = mock(JoshLangParser.EntityStanzaContext.class);
+        ParseTree entityTypeNode = mock(ParseTree.class);
+        ParseTree entityIdentifierNode = mock(ParseTree.class); // Needed for getEntityType
+        ParseTree closeEntityTypeNode = mock(ParseTree.class);
+
+        when(context.getChild(1)).thenReturn(entityTypeNode);
+        when(entityTypeNode.getText()).thenReturn("agent");
+        when(context.getChild(2)).thenReturn(entityIdentifierNode); // For getEntityType
+        when(entityIdentifierNode.getText()).thenReturn("someAgent");
+        when(context.getChild(5)).thenReturn(closeEntityTypeNode); // Assuming 6 children for mismatch test too
+        when(closeEntityTypeNode.getText()).thenReturn("behavior"); // Mismatch
+        when(context.getChildCount()).thenReturn(6);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            visitor.visitEntityStanza(context);
+        });
+        assertTrue(exception.getMessage().contains("Entity close type 'behavior' does not match open type 'agent'"));
+    }
+
+
+    @Test
+    void testVisitUnitStanza() {
+        JoshLangParser.UnitStanzaContext context = mock(JoshLangParser.UnitStanzaContext.class);
+        ParseTree sourceUnitNameNode = mock(ParseTree.class);
+        ParseTree conversionRuleNode = mock(ParseTree.class); // Represents a conversion rule line
+        Fragment ruleFragment = mock(Fragment.class); // Fragment from visiting conversionRuleNode
+        Conversion incompleteConversion = mock(Conversion.class); // Incomplete conv from ruleFragment
+
+        String sourceUnitName = "meter";
+        Units destinationUnits = Units.of("kilometer");
+        ValueFunction conversionCallable = mock(ValueFunction.class);
+
+        // K_UNITS IDENTIFIER conversionRule* K_END
+        // Child 0: K_UNITS
+        // Child 1: IDENTIFIER (source unit name)
+        // Child 2 to n-2: conversionRule
+        // Child n-1: K_END
+        // Original code: String sourceUnitName = ctx.getChild(2).getText(); loop i=3 to count-2
+        // This implies structure: K_UNITS ? IDENTIFIER ...
+        // Let's follow the prompt: ctx.getChild(2).getText() for sourceUnitName
+        when(context.getChild(2)).thenReturn(sourceUnitNameNode);
+        when(sourceUnitNameNode.getText()).thenReturn(sourceUnitName);
+        when(context.getChildCount()).thenReturn(5); // units, ?, meter, rule, end
+        when(context.getChild(3)).thenReturn(conversionRuleNode);
+
+        when(conversionRuleNode.accept(parent)).thenReturn(ruleFragment);
+        when(ruleFragment.getConversion()).thenReturn(incompleteConversion);
+        when(incompleteConversion.getDestinationUnits()).thenReturn(destinationUnits);
+        when(incompleteConversion.getConversionCallable()).thenReturn(conversionCallable);
+
+        Fragment result = visitor.visitUnitStanza(context);
+
+        assertNotNull(result);
+        assertTrue(result instanceof ConversionsFragment);
+        ConversionsFragment conversionsFragment = (ConversionsFragment) result;
+        List<Conversion> conversions = conversionsFragment.getConversions();
+        assertEquals(1, conversions.size());
+        Conversion actualConversion = conversions.get(0);
+
+        assertEquals(Units.of(sourceUnitName), actualConversion.getSourceUnits());
+        assertEquals(destinationUnits, actualConversion.getDestinationUnits());
+        assertSame(conversionCallable, actualConversion.getConversionCallable());
+    }
+
+
+    @Test
+    void testVisitConfigStatement_ThrowsException() {
+        JoshLangParser.ConfigStatementContext context = mock(JoshLangParser.ConfigStatementContext.class);
+        assertThrows(RuntimeException.class, () -> {
+            visitor.visitConfigStatement(context);
+        });
+    }
+
+    @Test
+    void testVisitImportStatement_ThrowsException() {
+        JoshLangParser.ImportStatementContext context = mock(JoshLangParser.ImportStatementContext.class);
+        assertThrows(RuntimeException.class, () -> {
+            visitor.visitImportStatement(context);
+        });
+    }
+
+    @Test
+    void testVisitProgram() {
+        JoshLangParser.ProgramContext context = mock(JoshLangParser.ProgramContext.class);
+        ParseTree childStatementNode = mock(ParseTree.class);
+        Fragment childFragment = mock(Fragment.class); // Fragment from visiting childStatementNode
+
+        when(context.getChildCount()).thenReturn(1); // One statement/stanza in the program
+        when(context.getChild(0)).thenReturn(childStatementNode);
+        when(childStatementNode.accept(parent)).thenReturn(childFragment);
+
+        ProgramBuilder finalProgramBuilderMock = mock(ProgramBuilder.class); // Final builder to be in fragment
+
+
+        try (MockedConstruction<ProgramBuilder> mockedBuilderConstruction =
+                     mockConstruction(ProgramBuilder.class, (mock, constructionContext) -> {
+                         // 'mock' is the ProgramBuilder instance created by 'new ProgramBuilder()'
+                         // No specific stubbing needed on 'mock' for this test,
+                         // as we'll verify add() on it and then check the ProgramFragment contains it.
+                     })) {
+
+            Fragment result = visitor.visitProgram(context);
+
+            assertNotNull(result);
+            assertTrue(result instanceof ProgramFragment);
+            ProgramFragment programFragment = (ProgramFragment) result;
+
+            assertEquals(1, mockedBuilderConstruction.constructed().size());
+            ProgramBuilder instantiatedBuilder = mockedBuilderConstruction.constructed().get(0);
+
+            assertSame(instantiatedBuilder, programFragment.getProgramBuilder());
+            verify(instantiatedBuilder).add(childFragment);
+
+        }
+    }
+}

--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshTypesUnitsVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshTypesUnitsVisitorTest.java
@@ -1,0 +1,369 @@
+package org.joshsim.lang.interpret.visitor.delegates;
+
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.joshsim.engine.value.ValueResolver;
+import org.joshsim.engine.value.converter.Conversion;
+import org.joshsim.engine.value.converter.DirectConversion;
+import org.joshsim.engine.value.converter.NoopConversion;
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.engine.EngineValueFactory;
+import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.engine.value.function.CompiledCallable;
+import org.joshsim.lang.antlr.JoshLangParser;
+import org.joshsim.lang.interpret.BridgeGetter;
+import org.joshsim.lang.interpret.action.EventHandlerAction;
+import org.joshsim.lang.interpret.fragment.ActionFragment;
+import org.joshsim.lang.interpret.fragment.ConversionFragment;
+import org.joshsim.lang.interpret.fragment.Fragment;
+import org.joshsim.lang.interpret.machine.EventHandlerMachine;
+import org.joshsim.lang.interpret.visitor.JoshParserToMachineVisitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JoshTypesUnitsVisitorTest {
+
+    private DelegateToolbox toolbox;
+    private JoshParserToMachineVisitor parent;
+    private EngineValueFactory engineValueFactory;
+    private BridgeGetter bridgeGetter;
+    private EngineValue singleCount;
+    private JoshTypesUnitsVisitor visitor;
+    private EngineValue mockEngineValueForPosition;
+
+
+    @BeforeEach
+    void setUp() {
+        toolbox = mock(DelegateToolbox.class);
+        parent = mock(JoshParserToMachineVisitor.class);
+        engineValueFactory = mock(EngineValueFactory.class);
+        bridgeGetter = mock(BridgeGetter.class);
+        singleCount = mock(EngineValue.class);
+        mockEngineValueForPosition = mock(EngineValue.class); // For the build(anyString(), Units.of(""))
+
+        when(toolbox.getParent()).thenReturn(parent);
+        when(toolbox.getValueFactory()).thenReturn(engineValueFactory);
+        when(toolbox.getBridgeGetter()).thenReturn(bridgeGetter);
+        when(engineValueFactory.build(1, Units.of("count"))).thenReturn(singleCount);
+        when(engineValueFactory.build(anyString(), eq(Units.of("")))).thenReturn(mockEngineValueForPosition);
+
+
+        visitor = new JoshTypesUnitsVisitor(toolbox);
+    }
+
+    private EventHandlerAction mockActionForExpression(JoshLangParser.ExpressionContext exprCtx) {
+        Fragment fragment = mock(Fragment.class);
+        EventHandlerAction action = mock(EventHandlerAction.class);
+        when(exprCtx.accept(parent)).thenReturn(fragment);
+        when(fragment.getCurrentAction()).thenReturn(action);
+        return action;
+    }
+
+    @Test
+    void testVisitCast() {
+        JoshLangParser.CastContext context = mock(JoshLangParser.CastContext.class);
+        context.operand = mock(JoshLangParser.ExpressionContext.class);
+        context.target = mock(Token.class);
+        String targetUnitsStr = "meter";
+        Units expectedUnits = Units.of(targetUnitsStr);
+
+        EventHandlerAction operandAction = mockActionForExpression(context.operand);
+        when(context.target.getText()).thenReturn(targetUnitsStr);
+
+        Fragment result = visitor.visitCast(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(operandAction).apply(mockMachine);
+        verify(mockMachine).cast(expectedUnits, false);
+    }
+
+    @Test
+    void testVisitCastForce() {
+        JoshLangParser.CastForceContext context = mock(JoshLangParser.CastForceContext.class);
+        context.operand = mock(JoshLangParser.ExpressionContext.class);
+        context.target = mock(Token.class);
+        String targetUnitsStr = "second";
+        Units expectedUnits = Units.of(targetUnitsStr);
+
+        EventHandlerAction operandAction = mockActionForExpression(context.operand);
+        when(context.target.getText()).thenReturn(targetUnitsStr);
+
+        Fragment result = visitor.visitCastForce(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(operandAction).apply(mockMachine);
+        verify(mockMachine).cast(expectedUnits, true);
+    }
+
+    @Test
+    void testVisitNoopConversion() {
+        JoshLangParser.NoopConversionContext context = mock(JoshLangParser.NoopConversionContext.class);
+        ParseTree aliasNode = mock(ParseTree.class);
+        String aliasName = "myUnit";
+        Units expectedUnits = Units.of(aliasName);
+
+        // K_PASS IDENTIFIER
+        when(context.getChild(1)).thenReturn(aliasNode);
+        when(aliasNode.getText()).thenReturn(aliasName);
+
+        Fragment result = visitor.visitNoopConversion(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ConversionFragment);
+        ConversionFragment cf = (ConversionFragment) result;
+        Conversion conversion = cf.getConversion();
+        assertNotNull(conversion);
+        assertTrue(conversion instanceof NoopConversion);
+        assertEquals(expectedUnits, conversion.getSourceUnits()); // NoopConversion sets source and dest the same
+        assertEquals(expectedUnits, conversion.getDestinationUnits());
+    }
+
+    @Test
+    void testVisitActiveConversion() {
+        JoshLangParser.ActiveConversionContext context = mock(JoshLangParser.ActiveConversionContext.class);
+        ParseTree destUnitsNode = mock(ParseTree.class);
+        JoshLangParser.ExpressionContext exprNode = mock(JoshLangParser.ExpressionContext.class); // Child 2 is expression for callable
+
+        String destUnitsStr = "kilometer";
+        Units expectedDestUnits = Units.of(destUnitsStr);
+        EventHandlerAction callableAction = mockActionForExpression(exprNode);
+
+        // IDENTIFIER K_TO expression
+        when(context.getChild(0)).thenReturn(destUnitsNode);
+        when(destUnitsNode.getText()).thenReturn(destUnitsStr);
+        when(context.getChild(2)).thenReturn(exprNode); // This is the expression for the callable
+
+        Fragment result = visitor.visitActiveConversion(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ConversionFragment);
+        ConversionFragment cf = (ConversionFragment) result;
+        Conversion conversion = cf.getConversion();
+        assertNotNull(conversion);
+        assertTrue(conversion instanceof DirectConversion);
+        assertEquals(expectedDestUnits, conversion.getDestinationUnits());
+        assertNull(conversion.getSourceUnits()); // Source units not defined by this rule, set by parent UnitStanza
+
+        CompiledCallable compiledCallable = ((DirectConversion)conversion).getConversionCallable();
+        assertNotNull(compiledCallable);
+        // To test compiledCallable, one would call its execute method,
+        // which should involve bridgeGetter and the callableAction.
+        // For this unit test, ensuring it's created is often sufficient.
+    }
+
+    @Test
+    void testVisitCreateVariableExpression() {
+        JoshLangParser.CreateVariableExpressionContext context = mock(JoshLangParser.CreateVariableExpressionContext.class);
+        context.count = mock(JoshLangParser.ExpressionContext.class);
+        context.target = mock(Token.class);
+        String entityName = "myEntity";
+
+        EventHandlerAction countAction = mockActionForExpression(context.count);
+        when(context.target.getText()).thenReturn(entityName);
+
+        Fragment result = visitor.visitCreateVariableExpression(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(countAction).apply(mockMachine);
+        verify(mockMachine).createEntity(entityName);
+    }
+
+    @Test
+    void testVisitAttrExpression() {
+        JoshLangParser.AttrExpressionContext context = mock(JoshLangParser.AttrExpressionContext.class);
+        JoshLangParser.ExpressionContext exprCtx = mock(JoshLangParser.ExpressionContext.class); // Child 0
+        ParseTree attrNameNode = mock(ParseTree.class); // Child 2
+
+        String attrName = "health";
+        EventHandlerAction exprAction = mockActionForExpression(exprCtx);
+
+        when(context.getChild(0)).thenReturn(exprCtx);
+        when(context.getChild(2)).thenReturn(attrNameNode);
+        when(attrNameNode.getText()).thenReturn(attrName);
+
+        ValueResolver mockResolver = mock(ValueResolver.class);
+
+        try (MockedConstruction<ValueResolver> mockedResolverConstruction =
+                     mockConstruction(ValueResolver.class, (mock, constructionContext) -> {
+                         // Assert constructor arguments if possible/needed
+                         // For now, just ensure our mockResolver is used in pushAttribute
+                         // This is tricky because the mock created by mockConstruction is what's used.
+                     })) {
+
+            Fragment result = visitor.visitAttrExpression(context);
+            assertNotNull(result);
+            assertTrue(result instanceof ActionFragment);
+            EventHandlerAction action = result.getCurrentAction();
+            assertNotNull(action);
+
+            EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+            action.apply(mockMachine);
+
+            assertEquals(1, mockedResolverConstruction.constructed().size());
+            ValueResolver instantiatedResolver = mockedResolverConstruction.constructed().get(0);
+
+            verify(exprAction).apply(mockMachine);
+            verify(mockMachine).pushAttribute(instantiatedResolver);
+            // To verify ValueResolver constructor:
+            // assertEquals(engineValueFactory, constructionContext.arguments().get(0));
+            // assertEquals(attrName, constructionContext.arguments().get(1));
+            // This depends on argument order and type, may need specific constructor context.
+        }
+    }
+
+    @Test
+    void testVisitSpatialQuery() {
+        JoshLangParser.SpatialQueryContext context = mock(JoshLangParser.SpatialQueryContext.class);
+        context.target = mock(Token.class); // Assuming target is a simple token for the query string
+        context.distance = mock(JoshLangParser.ExpressionContext.class);
+        String targetQueryString = "nearest(agent)"; // Example query string
+
+        EventHandlerAction distanceAction = mockActionForExpression(context.distance);
+        // The visitor uses ctx.target.toString() which might be different from getText() if target is complex
+        // For a simple Token, getText() is often what's intended if toString() isn't overridden meaningfully.
+        // Let's assume ctx.target.getText() for clarity, or mock toString() if that's truly used.
+        // The production code uses `ctx.target.getText()`, so this is correct.
+        when(context.target.getText()).thenReturn(targetQueryString);
+
+        try (MockedConstruction<ValueResolver> mockedResolverConstruction =
+                     mockConstruction(ValueResolver.class)) {
+
+            Fragment result = visitor.visitSpatialQuery(context);
+            assertNotNull(result);
+            assertTrue(result instanceof ActionFragment);
+            EventHandlerAction action = result.getCurrentAction();
+            assertNotNull(action);
+
+            EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+            action.apply(mockMachine);
+
+            assertEquals(1, mockedResolverConstruction.constructed().size());
+            ValueResolver instantiatedResolver = mockedResolverConstruction.constructed().get(0);
+
+            verify(distanceAction).apply(mockMachine);
+            verify(mockMachine).executeSpatialQuery(instantiatedResolver);
+            // Can verify ValueResolver constructor args here too if needed
+        }
+    }
+
+    @Test
+    void testVisitPosition() {
+        JoshLangParser.PositionContext context = mock(JoshLangParser.PositionContext.class);
+        JoshLangParser.ExpressionContext unitsExpr1 = mock(JoshLangParser.ExpressionContext.class); // child 0
+        ParseTree typeNode1 = mock(ParseTree.class); // child 1
+        JoshLangParser.ExpressionContext unitsExpr2 = mock(JoshLangParser.ExpressionContext.class); // child 3
+        ParseTree typeNode2 = mock(ParseTree.class); // child 4
+
+        String type1 = "cartesian";
+        String type2 = "polar";
+
+        EventHandlerAction unitsAction1 = mockActionForExpression(unitsExpr1);
+        EventHandlerAction unitsAction2 = mockActionForExpression(unitsExpr2);
+
+        when(context.getChild(0)).thenReturn(unitsExpr1);
+        when(context.getChild(1)).thenReturn(typeNode1);
+        when(typeNode1.getText()).thenReturn(type1);
+        // child 2 is ','
+        when(context.getChild(3)).thenReturn(unitsExpr2);
+        when(context.getChild(4)).thenReturn(typeNode2);
+        when(typeNode2.getText()).thenReturn(type2);
+
+        Fragment result = visitor.visitPosition(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        // Order of operations is important
+        ArgumentCaptor<EventHandlerAction> machineActions = ArgumentCaptor.forClass(EventHandlerAction.class);
+        // This captures individual pushes and makePosition. More complex to verify sequence this way.
+        // Let's verify step-by-step.
+
+        // A better way to verify sequence with Mockito is InOrder
+        org.mockito.InOrder inOrder = inOrder(mockMachine, unitsAction1, unitsAction2);
+
+        inOrder.verify(unitsAction1).apply(mockMachine);
+        inOrder.verify(mockMachine).push(mockEngineValueForPosition); // From engineFactory.build(type1, Units.of(""))
+        inOrder.verify(unitsAction2).apply(mockMachine);
+        inOrder.verify(mockMachine).push(mockEngineValueForPosition); // From engineFactory.build(type2, Units.of(""))
+        inOrder.verify(mockMachine).makePosition();
+
+        verify(engineValueFactory).build(type1, Units.of(""));
+        verify(engineValueFactory).build(type2, Units.of(""));
+    }
+
+    @Test
+    void testVisitCreateSingleExpression() {
+        JoshLangParser.CreateSingleExpressionContext context = mock(JoshLangParser.CreateSingleExpressionContext.class);
+        context.target = mock(Token.class);
+        String entityName = "anotherEntity";
+        when(context.target.getText()).thenReturn(entityName);
+
+        Fragment result = visitor.visitCreateSingleExpression(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        org.mockito.InOrder inOrder = inOrder(mockMachine);
+        inOrder.verify(mockMachine).push(singleCount);
+        inOrder.verify(mockMachine).createEntity(entityName);
+    }
+
+    @Test
+    void testVisitAssignment() {
+        JoshLangParser.AssignmentContext context = mock(JoshLangParser.AssignmentContext.class);
+        ParseTree identifierNode = mock(ParseTree.class); // child 1
+        context.val = mock(JoshLangParser.ExpressionContext.class); // child 3 is val, child 2 is '='
+
+        String identifierName = "myVar"; // A valid, non-reserved name
+        EventHandlerAction valAction = mockActionForExpression(context.val);
+
+        when(context.getChild(1)).thenReturn(identifierNode);
+        when(identifierNode.getText()).thenReturn(identifierName);
+        // Assuming grammar: K_LET IDENTIFIER K_ASSIGN expression
+        // Child 0: K_LET, Child 1: IDENTIFIER, Child 2: K_ASSIGN, Child 3: expression
+        // The visitor code uses: ctx.getChild(1).getText(), ctx.val.accept(parent)
+        // So, this mocking aligns.
+
+        Fragment result = visitor.visitAssignment(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(valAction).apply(mockMachine);
+        verify(mockMachine).saveLocalVariable(identifierName);
+        // Implicitly tests ReservedWordChecker.checkVariableDeclaration did not throw
+    }
+}

--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshValueVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshValueVisitorTest.java
@@ -1,0 +1,270 @@
+package org.joshsim.lang.interpret.visitor.delegates;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.joshsim.engine.value.ValueResolver;
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.engine.EngineValueFactory;
+import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.lang.antlr.JoshLangParser;
+import org.joshsim.lang.interpret.action.EventHandlerAction;
+import org.joshsim.lang.interpret.fragment.ActionFragment;
+import org.joshsim.lang.interpret.fragment.Fragment;
+import org.joshsim.lang.interpret.machine.EventHandlerMachine;
+import org.joshsim.lang.interpret.visitor.JoshParserToMachineVisitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JoshValueVisitorTest {
+
+    private DelegateToolbox toolbox;
+    private JoshParserToMachineVisitor parent; // Not directly used by JoshValueVisitor methods, but part of toolbox
+    private EngineValueFactory engineValueFactory;
+    private EngineValue allString;
+    private JoshValueVisitor visitor;
+
+    @BeforeEach
+    void setUp() {
+        toolbox = mock(DelegateToolbox.class);
+        parent = mock(JoshParserToMachineVisitor.class);
+        engineValueFactory = mock(EngineValueFactory.class);
+        allString = mock(EngineValue.class);
+
+        when(toolbox.getParent()).thenReturn(parent);
+        when(toolbox.getValueFactory()).thenReturn(engineValueFactory);
+        when(engineValueFactory.build("all", Units.of(""))).thenReturn(allString);
+
+        visitor = new JoshValueVisitor(toolbox);
+    }
+
+    @Test
+    void testVisitIdentifier() {
+        JoshLangParser.IdentifierContext context = mock(JoshLangParser.IdentifierContext.class);
+        String identifierName = "myVariable";
+        when(context.getText()).thenReturn(identifierName);
+
+        try (MockedConstruction<ValueResolver> mockedResolverConstruction =
+                     mockConstruction(ValueResolver.class)) {
+
+            Fragment result = visitor.visitIdentifier(context);
+            assertNotNull(result);
+            assertTrue(result instanceof ActionFragment);
+            EventHandlerAction action = result.getCurrentAction();
+            assertNotNull(action);
+
+            EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+            action.apply(mockMachine);
+
+            assertEquals(1, mockedResolverConstruction.constructed().size());
+            ValueResolver instantiatedResolver = mockedResolverConstruction.constructed().get(0);
+            // Verify constructor arguments on ValueResolver
+            // In ValueResolver constructor: ValueResolver(EngineValueFactory factory, String identifier)
+            // constructionContext.arguments() would give [engineValueFactory, identifierName]
+            // This can be verified if mockConstruction is set up with an Answer to check args.
+            // For now, verifying the push is key.
+            verify(mockMachine).push(instantiatedResolver);
+        }
+    }
+
+    @Test
+    void testVisitNumber() {
+        JoshLangParser.NumberContext context = mock(JoshLangParser.NumberContext.class);
+        ParseTree numberNode = mock(ParseTree.class);
+        String numberStr = "123.45";
+        EngineValue mockNumericValue = mock(EngineValue.class);
+
+        when(context.getChild(0)).thenReturn(numberNode);
+        when(numberNode.getText()).thenReturn(numberStr);
+        when(engineValueFactory.parseNumber(numberStr, Units.of("count"))).thenReturn(mockNumericValue);
+
+        Fragment result = visitor.visitNumber(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(mockMachine).push(mockNumericValue);
+    }
+
+    @Test
+    void testVisitUnitsValue_IntegerWithUnits() {
+        JoshLangParser.UnitsValueContext context = mock(JoshLangParser.UnitsValueContext.class);
+        ParseTree numberNode = mock(ParseTree.class); // Child 0: NUMBER
+        ParseTree unitsNode = mock(ParseTree.class);  // Child 1: IDENTIFIER (for units)
+
+        String numberStr = "5";
+        String unitsStr = "km";
+        EngineValue mockUnitsValue = mock(EngineValue.class);
+
+        when(context.getChild(0)).thenReturn(numberNode);
+        when(numberNode.getText()).thenReturn(numberStr);
+        when(context.getChild(1)).thenReturn(unitsNode);
+        when(unitsNode.getText()).thenReturn(unitsStr);
+
+        // Logic from parseUnitsValue for integer with units:
+        when(engineValueFactory.build(5L, Units.of("km"))).thenReturn(mockUnitsValue);
+
+        Fragment result = visitor.visitUnitsValue(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(mockMachine).push(mockUnitsValue);
+    }
+
+    @Test
+    void testVisitUnitsValue_Percentage() {
+        JoshLangParser.UnitsValueContext context = mock(JoshLangParser.UnitsValueContext.class);
+        ParseTree numberNode = mock(ParseTree.class);
+        ParseTree unitsNode = mock(ParseTree.class);
+
+        String numberStr = "25"; // 25 percent
+        String unitsStr = "percent";
+        EngineValue mockPercentageValue = mock(EngineValue.class);
+
+        when(context.getChild(0)).thenReturn(numberNode);
+        when(numberNode.getText()).thenReturn(numberStr);
+        when(context.getChild(1)).thenReturn(unitsNode);
+        when(unitsNode.getText()).thenReturn(unitsStr);
+
+        // Logic from parseUnitsValue for percentage:
+        when(engineValueFactory.buildForNumber(0.25, Units.of("count"))).thenReturn(mockPercentageValue);
+
+        Fragment result = visitor.visitUnitsValue(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(mockMachine).push(mockPercentageValue);
+    }
+
+
+    @Test
+    void testVisitString() {
+        JoshLangParser.StringContext context = mock(JoshLangParser.StringContext.class);
+        String rawString = "\"hello world\""; // String with quotes
+        String actualString = "hello world";   // String without quotes
+        EngineValue mockStringValue = mock(EngineValue.class);
+
+        when(context.getText()).thenReturn(rawString);
+        when(engineValueFactory.build(actualString, Units.of(""))).thenReturn(mockStringValue);
+
+        Fragment result = visitor.visitString(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(mockMachine).push(mockStringValue);
+    }
+
+    @Test
+    void testVisitBool_True() {
+        JoshLangParser.BoolContext context = mock(JoshLangParser.BoolContext.class);
+        ParseTree boolNode = mock(ParseTree.class);
+        EngineValue mockBoolValue = mock(EngineValue.class);
+
+        when(context.getChild(0)).thenReturn(boolNode);
+        when(boolNode.getText()).thenReturn("true");
+        when(engineValueFactory.build(true, Units.of(""))).thenReturn(mockBoolValue);
+
+        Fragment result = visitor.visitBool(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(mockMachine).push(mockBoolValue);
+    }
+
+    @Test
+    void testVisitAllExpression() {
+        JoshLangParser.AllExpressionContext context = mock(JoshLangParser.AllExpressionContext.class);
+        // allString is already mocked and configured in setUp
+
+        Fragment result = visitor.visitAllExpression(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        action.apply(mockMachine);
+
+        verify(mockMachine).push(allString);
+    }
+
+    @Test
+    void testVisitExternalValue() {
+        JoshLangParser.ExternalValueContext context = mock(JoshLangParser.ExternalValueContext.class);
+        String externalName = "env_temp";
+        long stepCount = 15L;
+
+        // Assuming ctx.name is a Token for the IDENTIFIER
+        org.antlr.v4.runtime.Token nameToken = mock(org.antlr.v4.runtime.Token.class);
+        when(context.name).thenReturn(nameToken);
+        when(nameToken.getText()).thenReturn(externalName);
+
+        Fragment result = visitor.visitExternalValue(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        when(mockMachine.getStepCount()).thenReturn(stepCount); // Mock machine's response
+
+        action.apply(mockMachine);
+
+        verify(mockMachine).getStepCount();
+        verify(mockMachine).pushExternal(externalName, stepCount);
+    }
+
+    @Test
+    void testVisitExternalValueAtTime() {
+        JoshLangParser.ExternalValueAtTimeContext context = mock(JoshLangParser.ExternalValueAtTimeContext.class);
+        ParseTree nameNode = mock(ParseTree.class);
+        String externalName = "temp_at_time";
+        // Assuming grammar: K_EXTERNAL_TIME IDENTIFIER expression
+        // Child 0: K_EXTERNAL_TIME, Child 1: IDENTIFIER, Child 2: expression (for time)
+        // The visitor code: String name = ctx.getChild(1).getText();
+        // Action is (machine) -> {}
+
+        when(context.getChild(1)).thenReturn(nameNode);
+        when(nameNode.getText()).thenReturn(externalName);
+        // Expression for time (child 2) is not used in the current empty action.
+
+        Fragment result = visitor.visitExternalValueAtTime(context);
+        assertNotNull(result);
+        assertTrue(result instanceof ActionFragment);
+        EventHandlerAction action = result.getCurrentAction();
+        assertNotNull(action);
+
+        EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+        EventHandlerMachine returnedMachine = action.apply(mockMachine); // Apply the action
+
+        assertSame(mockMachine, returnedMachine); // Action is (machine) -> { return machine; } (or just machine -> {})
+        verifyNoMoreInteractions(mockMachine); // Verify no push, pop, or specific method calls
+                                               // (other than what might be default like toString if logging)
+    }
+}


### PR DESCRIPTION
(Test drive of Jules)

I created JUnit 5 tests for the following Josh ANTLR visitor delegate classes:

- JoshDistributionVisitor
- JoshFunctionVisitor
- JoshLogicalVisitor
- JoshMathematicsVisitor
- JoshStanzaVisitor
- JoshTypesUnitsVisitor
- JoshValueVisitor

The tests are modeled after the existing JoshStringOperationVisitorTest.java, focusing on testing the successful path of public methods. Mockito was used for mocking dependencies. Each visitor's test class is located in `src/test/java/org/joshsim/lang/interpret/visitor/delegates/`.

Note: I was unable to verify changes because of a pre-existing issue with the ANTLR source generation step in the Gradle build. The ANTLR generated files are not being placed where the compileJava task expects them, preventing full build and test execution.