### PR TITLE
Fix status code breaking streaming.

### DIFF
--- a/editor/js/parse.js
+++ b/editor/js/parse.js
@@ -75,9 +75,18 @@ function parseEngineResponse(source) {
     return null;
   }
 
+  const errorMatch = source.match(/^\[error\] (.+)$/);
+  if (errorMatch) {
+    return {
+      replicate: -1,
+      type: "error",
+      message: errorMatch[1]
+    };
+  }
+
   const match = source.match(/^\[(\d+)\] (.+)$/);
   if (!match) {
-    throw "Got malformed engine response.";
+    throw "Got malformed engine response: " + source;
   }
 
   const replicate = parseInt(match[1], 10);

--- a/editor/js/parse.js
+++ b/editor/js/parse.js
@@ -86,14 +86,14 @@ function parseEngineResponse(source) {
 
   const match = source.match(/^\[(\d+)\] (.+)$/);
   if (!match) {
-    throw "Got malformed engine response: " + source;
+    throw "Got error engine response: " + source;
   }
 
   const replicate = parseInt(match[1], 10);
   const data = parseDatum(match[2]);
   
   if (!data) {
-    throw "Got malformed engine response.";
+    throw "Got error engine response.";
   }
 
   return {

--- a/editor/js/wire.js
+++ b/editor/js/wire.js
@@ -114,6 +114,8 @@ class ResponseReader {
           );
         }
         self._onReplicateExternal(self._completedReplicates);
+      } else if (intermediate["type"] === "error") {
+        self._onError("Server error: " + intermediate["message"]);
       }
     });
   }

--- a/src/main/java/org/joshsim/cloud/JoshSimLeaderHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimLeaderHandler.java
@@ -185,16 +185,14 @@ public class JoshSimLeaderHandler implements HttpHandler {
           }
         } catch (Exception e) {
           hasErrors = true;
+          System.err.println("Exception in replicate execution: " 
+              + e.getClass().getSimpleName() + ": " + e.getMessage());
           // Extract meaningful error message from the exception
           String errorMessage = extractErrorMessage(e);
           String errorOutput = String.format("[error] %s\n", errorMessage);
           httpServerExchange.getOutputStream().write(errorOutput.getBytes());
           httpServerExchange.getOutputStream().flush();
         }
-      }
-      
-      if (hasErrors) {
-        httpServerExchange.setStatusCode(500);
       }
       
       httpServerExchange.endExchange();
@@ -336,6 +334,8 @@ public class JoshSimLeaderHandler implements HttpHandler {
     try {
       response = client.send(request, HttpResponse.BodyHandlers.ofString());
     } catch (IOException | InterruptedException e) {
+      System.err.println("Worker connection failed for replicate " + replicateNumber 
+          + " to " + urlToWorker + ": " + e.getMessage());
       throw new RuntimeException("Encountered issue in worker thread: " + e);
     }
 

--- a/src/main/java/org/joshsim/command/ServerCommand.java
+++ b/src/main/java/org/joshsim/command/ServerCommand.java
@@ -82,8 +82,12 @@ public class ServerCommand implements Callable<Integer> {
                 + processedWorkerUrl);
           }
         } catch (MalformedURLException e) {
-          System.err.println("Warning: Could not parse worker URL for port update: " 
-              + e.getMessage());
+          String message = String.format(
+              "Warning: Could not parse worker URL: %s. Using %s.",
+              e.getMessage(),
+              processedWorkerUrl
+          );
+          System.out.println(message);
         }
       }
       

--- a/src/main/java/org/joshsim/command/ServerCommand.java
+++ b/src/main/java/org/joshsim/command/ServerCommand.java
@@ -66,10 +66,23 @@ public class ServerCommand implements Callable<Integer> {
         workers = workerUrl.contains("0.0.0.0") ? 1 : numProcessors - 1;
       }
 
+      // Fix worker URL: replace 0.0.0.0 with localhost and update port to match server port
+      String processedWorkerUrl = workerUrl.replaceAll("\"", "").trim();
+      if (processedWorkerUrl.contains("0.0.0.0")) {
+        processedWorkerUrl = processedWorkerUrl.replace("0.0.0.0", "localhost");
+        System.out.println("Updated worker URL from 0.0.0.0 to localhost");
+      }
+      
+      // Update port in worker URL to match server port
+      if (processedWorkerUrl.contains("localhost") && processedWorkerUrl.contains(":8085/")) {
+        processedWorkerUrl = processedWorkerUrl.replace(":8085/", ":" + port + "/");
+        System.out.println("Updated worker URL port to match server port: " + processedWorkerUrl);
+      }
+      
       JoshSimServer server = new JoshSimServer(
           new EnvCloudApiDataLayer(),
           useHttp2,
-          workerUrl.replaceAll("\"", "").trim(),
+          processedWorkerUrl,
           port,
           workers,
           serialPatches

--- a/src/main/java/org/joshsim/command/ServerCommand.java
+++ b/src/main/java/org/joshsim/command/ServerCommand.java
@@ -76,10 +76,18 @@ public class ServerCommand implements Callable<Integer> {
         try {
           URL url = new URL(processedWorkerUrl);
           if (url.getPort() != port) {
-            processedWorkerUrl = String.format("%s://%s:%d%s", 
-                url.getProtocol(), url.getHost(), port, url.getPath());
-            System.out.println("Updated worker URL port to match server port: " 
-                + processedWorkerUrl);
+            processedWorkerUrl = String.format(
+                "%s://%s:%d%s", 
+                url.getProtocol(),
+                url.getHost(),
+                port,
+                url.getPath()
+            );
+            String message = String.format(
+                "Updated worker URL port to match server port: %s",
+                processedWorkerUrl
+            );
+            System.out.println(message);
           }
         } catch (MalformedURLException e) {
           String message = String.format(


### PR DESCRIPTION
We do streaming responses due to large payloads but this is causing our error reporting to fail on setting status code. We should remove status code set but still indicate error to preserve performance. Closes #234.