### PR TITLE
Add flash animation to progress bar

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -178,7 +178,7 @@
                     <span class="status-text">Please wait...</span>
                   </div>
                   <div class="progress-container">
-                    <progress class="step-progress-bar" value="0" max="100"></progress>
+                    <progress class="step-progress-bar flash" value="0" max="100"></progress>
                   </div>
                 </div>
                 <div class="error-display status-display">

--- a/editor/style/style.css
+++ b/editor/style/style.css
@@ -291,9 +291,17 @@ main {
   background-color: #F0F0F0;
 }
 
+.step-progress-bar.flash {
+  animation: progress-flash 3s ease-in-out;
+}
+
 .step-progress-bar::-webkit-progress-bar {
   background-color: #F0F0F0;
   border-radius: 5px;
+}
+
+.step-progress-bar.flash::-webkit-progress-bar {
+  animation: progress-flash 3s ease-in-out;
 }
 
 .step-progress-bar::-webkit-progress-value {
@@ -604,4 +612,11 @@ main {
   a[role="tab"][aria-selected="true"], a:link[role="tab"][aria-selected="true"], a:visited[role="tab"][aria-selected="true"] {
     color: #202070;
   }
+}
+
+@keyframes progress-flash {
+  0% { background-color: #F0F0F0; }           /* Initial state */
+  66.67% { background-color: #F0F0F0; }       /* Hold for 2 seconds */
+  83.33% { background-color: white; }         /* Fade to white (0.5s) */
+  100% { background-color: #F0F0F0; }         /* Fade back (0.5s) */
 }


### PR DESCRIPTION
Add an infrequent brief "flash to white" animation to the progress bar background color to show the user that the page is not frozen.