### PR TITLE
Hotfix for config improperly reading percents as counts:

### DIFF
--- a/src/main/java/org/joshsim/engine/entity/base/EntityBuilder.java
+++ b/src/main/java/org/joshsim/engine/entity/base/EntityBuilder.java
@@ -26,7 +26,6 @@ import org.joshsim.engine.simulation.Simulation;
 import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.EngineValueFactory;
 import org.joshsim.engine.value.type.EngineValue;
-import org.joshsim.engine.value.type.StringScalar;
 
 /**
  * Builder to assist in constructing entities.

--- a/src/main/java/org/joshsim/lang/interpret/visitor/JoshConfigParserVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/JoshConfigParserVisitor.java
@@ -87,18 +87,35 @@ public class JoshConfigParserVisitor extends JoshConfigBaseVisitor<JshcFragment>
   public JshcFragment visitValue(JoshConfigParser.ValueContext ctx) {
     JshcFragment numberFragment = ctx.number().accept(this);
     String numberText = numberFragment.getNumber().toString();
-    // The identifier (units) may be omitted if the value has no units
-    String unitsText = ctx.identifier() != null ? ctx.identifier().accept(this).getUnits() : "";
+
+    // Check for percent: either PERCENT_ token (%) or identifier "percent"
+    boolean isPercent = ctx.PERCENT_() != null;
+    String unitsText = "";
+    if (ctx.identifier() != null) {
+      unitsText = ctx.identifier().accept(this).getUnits();
+      if (unitsText.equals("percent")) {
+        isPercent = true;
+      }
+    } else if (isPercent) {
+      unitsText = "%";
+    }
 
     try {
       // Parse the number
       BigDecimal number = numberFragment.getNumber();
 
-      // Create units object
-      Units units = unitsText.isEmpty() ? Units.EMPTY : Units.of(unitsText);
-
-      // Create EngineValue
-      EngineValue engineValue = valueFactory.parseNumber(numberText, units);
+      EngineValue engineValue;
+      if (isPercent) {
+        // Convert percent to decimal (8 percent -> 0.08) and use count units
+        // This matches the behavior in JoshValueVisitor.parseUnitsValue()
+        double converted = number.doubleValue() / 100.0;
+        engineValue = valueFactory.buildForNumber(converted, Units.of("count"));
+      } else {
+        // Create units object
+        Units units = unitsText.isEmpty() ? Units.EMPTY : Units.of(unitsText);
+        // Create EngineValue
+        engineValue = valueFactory.parseNumber(numberText, units);
+      }
 
       return new JshcValueFragment(number, unitsText, engineValue);
     } catch (NumberFormatException e) {

--- a/src/test/java/org/joshsim/engine/value/type/ExternalRatioComparisonIntegrationTest.java
+++ b/src/test/java/org/joshsim/engine/value/type/ExternalRatioComparisonIntegrationTest.java
@@ -1,8 +1,8 @@
 /**
  * Integration tests for external ratio data comparison with literal numbers.
  *
- * This test investigates the reported bug where external data with "ratio" units
- * compared against literal numbers always evaluates to the same result for all patches.
+ * <p>This test investigates the reported bug where external data with "ratio" units
+ * compared against literal numbers always evaluates to the same result for all patches.</p>
  *
  * @license BSD-3-Clause
  */
@@ -56,7 +56,7 @@ class ExternalRatioComparisonIntegrationTest {
    * This mimics the bug report scenario: "testValue > 0.5" where testValue has ratio units.
    */
   @Test
-  void testRatioExternalVsLiteralComparison_ValueAboveThreshold() {
+  void testRatioExternalVsLiteralComparisonValueAboveThreshold() {
     // Setup: External data returns 0.7 ratio (above threshold)
     EngineValue externalValue = factory.buildForNumber(0.7, Units.of("ratio"));
 
@@ -81,7 +81,7 @@ class ExternalRatioComparisonIntegrationTest {
   }
 
   @Test
-  void testRatioExternalVsLiteralComparison_ValueBelowThreshold() {
+  void testRatioExternalVsLiteralComparisonValueBelowThreshold() {
     // Setup: External data returns 0.3 ratio (below threshold)
     EngineValue externalValue = factory.buildForNumber(0.3, Units.of("ratio"));
 
@@ -158,15 +158,11 @@ class ExternalRatioComparisonIntegrationTest {
 
     for (int i = 0; i < externalValues.length; i++) {
       double value = externalValues[i];
-      String expected = expectedResults[i];
 
       // External data with ratio units
       EngineValue externalValue = factory.buildForNumber(value, Units.of("ratio"));
       // Literal threshold with count/empty units
       EngineValue literalValue = factory.buildForNumber(0.5, Units.of("count"));
-      // String results
-      EngineValue highValue = factory.build("high", Units.EMPTY);
-      EngineValue lowValue = factory.build("low", Units.EMPTY);
 
       // Create machine for condition evaluation
       SingleThreadEventHandlerMachine condMachine = new SingleThreadEventHandlerMachine(
@@ -188,6 +184,9 @@ class ExternalRatioComparisonIntegrationTest {
           mockBridge, mockScope
       );
 
+      // Declare string values close to their usage
+      EngineValue highValue = factory.build("high", Units.EMPTY);
+      EngineValue lowValue = factory.build("low", Units.EMPTY);
       if (conditionResult.getAsBoolean()) {
         resultMachine.push(highValue);
       } else {
@@ -197,6 +196,8 @@ class ExternalRatioComparisonIntegrationTest {
       resultMachine.end();
       EngineValue result = resultMachine.getResult();
 
+      // Get expected value close to assertion
+      final String expected = expectedResults[i];
       assertEquals(expected, result.getAsString(),
           String.format("For value %f, expected '%s' but got '%s'", value, expected,
               result.getAsString()));
@@ -228,7 +229,7 @@ class ExternalRatioComparisonIntegrationTest {
   }
 
   @Test
-  void testCountVsCountComparison_ShouldAlwaysWork() {
+  void testCountVsCountComparisonShouldAlwaysWork() {
     // The bug report says count comparisons work - verify this
     EngineValue value1 = factory.buildForNumber(2.0, Units.of("count"));
     EngineValue value2 = factory.buildForNumber(1.0, Units.of("count"));

--- a/src/test/java/org/joshsim/engine/value/type/ExternalRatioComparisonIntegrationTest.java
+++ b/src/test/java/org/joshsim/engine/value/type/ExternalRatioComparisonIntegrationTest.java
@@ -1,0 +1,266 @@
+/**
+ * Integration tests for external ratio data comparison with literal numbers.
+ *
+ * This test investigates the reported bug where external data with "ratio" units
+ * compared against literal numbers always evaluates to the same result for all patches.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.engine.value.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+
+import org.joshsim.engine.func.Scope;
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.engine.EngineValueFactory;
+import org.joshsim.lang.bridge.EngineBridge;
+import org.joshsim.lang.interpret.machine.SingleThreadEventHandlerMachine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Integration tests that simulate the bug scenario: comparing external ratio data with literals.
+ */
+@ExtendWith(MockitoExtension.class)
+class ExternalRatioComparisonIntegrationTest {
+
+  @Mock private EngineBridge mockBridge;
+  @Mock private Scope mockScope;
+
+  private EngineValueFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    factory = new EngineValueFactory();
+    lenient().when(mockBridge.getEngineValueFactory()).thenReturn(factory);
+    // Mock the convert method to return the value with new units (NoopConversion behavior)
+    lenient().when(mockBridge.convert(any(EngineValue.class), any(Units.class)))
+        .thenAnswer(invocation -> {
+          EngineValue value = invocation.getArgument(0);
+          Units newUnits = invocation.getArgument(1);
+          return value.replaceUnits(newUnits);
+        });
+  }
+
+  /**
+   * Test that simulates comparing external ratio data with a literal number.
+   * This mimics the bug report scenario: "testValue > 0.5" where testValue has ratio units.
+   */
+  @Test
+  void testRatioExternalVsLiteralComparison_ValueAboveThreshold() {
+    // Setup: External data returns 0.7 ratio (above threshold)
+    EngineValue externalValue = factory.buildForNumber(0.7, Units.of("ratio"));
+
+    // Literal value 0.5 with count/empty units
+    EngineValue literalValue = factory.buildForNumber(0.5, Units.of("count"));
+
+    // Create machine and simulate the comparison
+    SingleThreadEventHandlerMachine machine = new SingleThreadEventHandlerMachine(
+        mockBridge, mockScope
+    );
+
+    // Simulate: push external value, push literal, call gt()
+    machine.push(externalValue);
+    machine.push(literalValue);
+    machine.gt();
+    machine.end();
+
+    // Verify: 0.7 > 0.5 should be true
+    EngineValue result = machine.getResult();
+    assertNotNull(result, "Comparison result should not be null");
+    assertTrue(result.getAsBoolean(), "0.7 ratio > 0.5 should be true");
+  }
+
+  @Test
+  void testRatioExternalVsLiteralComparison_ValueBelowThreshold() {
+    // Setup: External data returns 0.3 ratio (below threshold)
+    EngineValue externalValue = factory.buildForNumber(0.3, Units.of("ratio"));
+
+    // Literal value 0.5 with count/empty units
+    EngineValue literalValue = factory.buildForNumber(0.5, Units.of("count"));
+
+    // Create machine and simulate the comparison
+    SingleThreadEventHandlerMachine machine = new SingleThreadEventHandlerMachine(
+        mockBridge, mockScope
+    );
+
+    // Simulate: push external value, push literal, call gt()
+    machine.push(externalValue);
+    machine.push(literalValue);
+    machine.gt();
+    machine.end();
+
+    // Verify: 0.3 > 0.5 should be false
+    EngineValue result = machine.getResult();
+    assertNotNull(result, "Comparison result should not be null");
+    assertFalse(result.getAsBoolean(), "0.3 ratio > 0.5 should be false");
+  }
+
+  @Test
+  void testMultiplePatchesWithDifferentRatioValues() {
+    // Simulate multiple patches with different external data values
+    double[] externalValues = {0.1, 0.3, 0.5, 0.7, 0.9};
+    double threshold = 0.5;
+
+    int trueCount = 0;
+    int falseCount = 0;
+
+    for (double value : externalValues) {
+      // Setup external data for this "patch"
+      EngineValue externalValue = factory.buildForNumber(value, Units.of("ratio"));
+      EngineValue literalValue = factory.buildForNumber(threshold, Units.of("count"));
+
+      // Create a new machine for each patch (simulating per-patch evaluation)
+      SingleThreadEventHandlerMachine machine = new SingleThreadEventHandlerMachine(
+          mockBridge, mockScope
+      );
+
+      machine.push(externalValue);
+      machine.push(literalValue);
+      machine.gt();
+      machine.end();
+
+      EngineValue result = machine.getResult();
+      boolean actual = result.getAsBoolean();
+      boolean expected = value > threshold;
+
+      assertEquals(expected, actual,
+          String.format("Comparison %f ratio > %f count should be %s", value, threshold, expected));
+
+      if (actual) {
+        trueCount++;
+      } else {
+        falseCount++;
+      }
+    }
+
+    // Verify we got different results
+    assertTrue(trueCount > 0, "Should have some true results (values above threshold)");
+    assertTrue(falseCount > 0, "Should have some false results (values below threshold)");
+    assertEquals(2, trueCount, "Should have 2 values > 0.5 (0.7 and 0.9)");
+    assertEquals(3, falseCount, "Should have 3 values <= 0.5 (0.1, 0.3, 0.5)");
+  }
+
+  @Test
+  void testConditionalExpressionWithRatioComparison() {
+    // Test the full conditional expression: "high" if testValue > 0.5 else "low"
+    double[] externalValues = {0.2, 0.8};
+    String[] expectedResults = {"low", "high"};
+
+    for (int i = 0; i < externalValues.length; i++) {
+      double value = externalValues[i];
+      String expected = expectedResults[i];
+
+      // External data with ratio units
+      EngineValue externalValue = factory.buildForNumber(value, Units.of("ratio"));
+      // Literal threshold with count/empty units
+      EngineValue literalValue = factory.buildForNumber(0.5, Units.of("count"));
+      // String results
+      EngineValue highValue = factory.build("high", Units.EMPTY);
+      EngineValue lowValue = factory.build("low", Units.EMPTY);
+
+      // Create machine for condition evaluation
+      SingleThreadEventHandlerMachine condMachine = new SingleThreadEventHandlerMachine(
+          mockBridge, mockScope
+      );
+
+      // Simulate the conditional: "high" if testValue > 0.5 else "low"
+      // First, evaluate the condition
+      condMachine.push(externalValue);
+      condMachine.push(literalValue);
+      condMachine.gt();
+      condMachine.end();
+
+      // Get the condition result
+      EngineValue conditionResult = condMachine.getResult();
+
+      // Now simulate branching based on condition
+      SingleThreadEventHandlerMachine resultMachine = new SingleThreadEventHandlerMachine(
+          mockBridge, mockScope
+      );
+
+      if (conditionResult.getAsBoolean()) {
+        resultMachine.push(highValue);
+      } else {
+        resultMachine.push(lowValue);
+      }
+
+      resultMachine.end();
+      EngineValue result = resultMachine.getResult();
+
+      assertEquals(expected, result.getAsString(),
+          String.format("For value %f, expected '%s' but got '%s'", value, expected,
+              result.getAsString()));
+    }
+  }
+
+  @Test
+  void testConversionGroupWithMixedUnits() {
+    // Test that conversion group handling works correctly with ratio vs count units
+    EngineValue ratioValue = factory.buildForNumber(0.6, Units.of("ratio"));
+    EngineValue countValue = factory.buildForNumber(0.5, Units.of("count"));
+
+    SingleThreadEventHandlerMachine machine = new SingleThreadEventHandlerMachine(
+        mockBridge, mockScope
+    );
+
+    // The conversion group logic in gt() should:
+    // 1. Pop countValue (0.5, count/empty units) - sets conversionTarget to empty
+    // 2. Pop ratioValue (0.6, ratio units) - converts to empty (NoopConversion)
+    // 3. Compare 0.6 > 0.5 = true
+    machine.push(ratioValue);
+    machine.push(countValue);
+    machine.gt();
+    machine.end();
+
+    EngineValue result = machine.getResult();
+    assertTrue(result.getAsBoolean(),
+        "After conversion group handling, 0.6 ratio > 0.5 count should be true");
+  }
+
+  @Test
+  void testCountVsCountComparison_ShouldAlwaysWork() {
+    // The bug report says count comparisons work - verify this
+    EngineValue value1 = factory.buildForNumber(2.0, Units.of("count"));
+    EngineValue value2 = factory.buildForNumber(1.0, Units.of("count"));
+
+    SingleThreadEventHandlerMachine machine = new SingleThreadEventHandlerMachine(
+        mockBridge, mockScope
+    );
+
+    machine.push(value1);
+    machine.push(value2);
+    machine.gt();
+    machine.end();
+
+    assertTrue(machine.getResult().getAsBoolean(), "2 count > 1 count should be true");
+  }
+
+  @Test
+  void testEmptyUnitsAsCountAlias() {
+    // Verify that Units.of("count") produces empty/blank units
+    Units countUnits = Units.of("count");
+    assertTrue(countUnits.toString().isBlank(),
+        "count units should be blank (count is alias for empty)");
+    assertEquals(Units.EMPTY, countUnits, "Units.of('count') should equal Units.EMPTY");
+  }
+
+  @Test
+  void testRatioUnitsAreNotEmpty() {
+    // Verify that ratio units are NOT empty
+    Units ratioUnits = Units.of("ratio");
+    assertFalse(ratioUnits.toString().isBlank(),
+        "ratio units should not be blank");
+    assertEquals("ratio", ratioUnits.toString(),
+        "ratio units should have 'ratio' as string representation");
+  }
+}

--- a/src/test/java/org/joshsim/engine/value/type/RatioComparisonTest.java
+++ b/src/test/java/org/joshsim/engine/value/type/RatioComparisonTest.java
@@ -1,9 +1,9 @@
 /**
  * Tests for ratio unit comparison with literal numbers.
  *
- * This test is designed to investigate a bug where external data with
+ * <p>This test is designed to investigate a bug where external data with
  * "ratio" units compared against literal numbers always evaluates to
- * the same result regardless of the actual data values.
+ * the same result regardless of the actual data values.</p>
  *
  * @license BSD-3-Clause
  */
@@ -45,7 +45,7 @@ class RatioComparisonTest {
   }
 
   @Test
-  void testRatioVsCountComparison_GreaterThan() {
+  void testRatioVsCountComparisonGreaterThan() {
     // Simulate external data with ratio units
     EngineValue ratioValue = new DoubleScalar(caster, 0.6, Units.of("ratio"));
 
@@ -58,7 +58,7 @@ class RatioComparisonTest {
   }
 
   @Test
-  void testRatioVsCountComparison_GreaterThan_False() {
+  void testRatioVsCountComparisonGreaterThanFalse() {
     // Simulate external data with ratio units
     EngineValue ratioValue = new DoubleScalar(caster, 0.3, Units.of("ratio"));
 
@@ -71,7 +71,7 @@ class RatioComparisonTest {
   }
 
   @Test
-  void testRatioVsEmptyComparison_GreaterThan() {
+  void testRatioVsEmptyComparisonGreaterThan() {
     // Simulate external data with ratio units
     EngineValue ratioValue = new DoubleScalar(caster, 0.6, Units.of("ratio"));
 
@@ -84,7 +84,7 @@ class RatioComparisonTest {
   }
 
   @Test
-  void testRatioVsEmptyComparison_GreaterThan_False() {
+  void testRatioVsEmptyComparisonGreaterThanFalse() {
     // Simulate external data with ratio units
     EngineValue ratioValue = new DoubleScalar(caster, 0.3, Units.of("ratio"));
 
@@ -97,7 +97,7 @@ class RatioComparisonTest {
   }
 
   @Test
-  void testCountVsCountComparison_GreaterThan() {
+  void testCountVsCountComparisonGreaterThan() {
     // Both with count units (should work as per bug report)
     EngineValue count1 = new DoubleScalar(caster, 2.0, Units.of("count"));
     EngineValue count2 = new DoubleScalar(caster, 1.0, Units.of("count"));
@@ -108,7 +108,7 @@ class RatioComparisonTest {
   }
 
   @Test
-  void testRatioVsRatioComparison_GreaterThan() {
+  void testRatioVsRatioComparisonGreaterThan() {
     // Both with ratio units
     EngineValue ratio1 = new DoubleScalar(caster, 0.6, Units.of("ratio"));
     EngineValue ratio2 = new DoubleScalar(caster, 0.5, Units.of("ratio"));
@@ -119,7 +119,7 @@ class RatioComparisonTest {
   }
 
   @Test
-  void testRatioVsRatioComparison_GreaterThan_False() {
+  void testRatioVsRatioComparisonGreaterThanFalse() {
     // Both with ratio units
     EngineValue ratio1 = new DoubleScalar(caster, 0.3, Units.of("ratio"));
     EngineValue ratio2 = new DoubleScalar(caster, 0.5, Units.of("ratio"));

--- a/src/test/java/org/joshsim/engine/value/type/RatioComparisonTest.java
+++ b/src/test/java/org/joshsim/engine/value/type/RatioComparisonTest.java
@@ -1,0 +1,182 @@
+/**
+ * Tests for ratio unit comparison with literal numbers.
+ *
+ * This test is designed to investigate a bug where external data with
+ * "ratio" units compared against literal numbers always evaluates to
+ * the same result regardless of the actual data values.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.engine.value.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.engine.EngineValueCaster;
+import org.joshsim.engine.value.engine.EngineValueFactory;
+import org.joshsim.engine.value.engine.EngineValueWideningCaster;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for comparing values with ratio units against values with count/empty units.
+ */
+class RatioComparisonTest {
+
+  private EngineValueCaster caster;
+  private EngineValueFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    factory = new EngineValueFactory();
+    caster = new EngineValueWideningCaster(factory);
+  }
+
+  @Test
+  void testRatioUnitsAreCreated() {
+    Units ratioUnits = Units.of("ratio");
+    Units countUnits = Units.of("count");
+
+    assertEquals("ratio", ratioUnits.toString());
+    assertTrue(countUnits.toString().isBlank(), "count units should be blank");
+  }
+
+  @Test
+  void testRatioVsCountComparison_GreaterThan() {
+    // Simulate external data with ratio units
+    EngineValue ratioValue = new DoubleScalar(caster, 0.6, Units.of("ratio"));
+
+    // Simulate literal number with count/empty units (how Josh parses "0.5")
+    EngineValue countValue = new DoubleScalar(caster, 0.5, Units.of("count"));
+
+    // 0.6 > 0.5 should be true
+    EngineValue result = ratioValue.greaterThan(countValue);
+    assertTrue(result.getAsBoolean(), "0.6 ratio > 0.5 count should be true");
+  }
+
+  @Test
+  void testRatioVsCountComparison_GreaterThan_False() {
+    // Simulate external data with ratio units
+    EngineValue ratioValue = new DoubleScalar(caster, 0.3, Units.of("ratio"));
+
+    // Simulate literal number with count/empty units
+    EngineValue countValue = new DoubleScalar(caster, 0.5, Units.of("count"));
+
+    // 0.3 > 0.5 should be false
+    EngineValue result = ratioValue.greaterThan(countValue);
+    assertFalse(result.getAsBoolean(), "0.3 ratio > 0.5 count should be false");
+  }
+
+  @Test
+  void testRatioVsEmptyComparison_GreaterThan() {
+    // Simulate external data with ratio units
+    EngineValue ratioValue = new DoubleScalar(caster, 0.6, Units.of("ratio"));
+
+    // Simulate literal number with empty units
+    EngineValue emptyValue = new DoubleScalar(caster, 0.5, Units.EMPTY);
+
+    // 0.6 > 0.5 should be true
+    EngineValue result = ratioValue.greaterThan(emptyValue);
+    assertTrue(result.getAsBoolean(), "0.6 ratio > 0.5 empty should be true");
+  }
+
+  @Test
+  void testRatioVsEmptyComparison_GreaterThan_False() {
+    // Simulate external data with ratio units
+    EngineValue ratioValue = new DoubleScalar(caster, 0.3, Units.of("ratio"));
+
+    // Simulate literal number with empty units
+    EngineValue emptyValue = new DoubleScalar(caster, 0.5, Units.EMPTY);
+
+    // 0.3 > 0.5 should be false
+    EngineValue result = ratioValue.greaterThan(emptyValue);
+    assertFalse(result.getAsBoolean(), "0.3 ratio > 0.5 empty should be false");
+  }
+
+  @Test
+  void testCountVsCountComparison_GreaterThan() {
+    // Both with count units (should work as per bug report)
+    EngineValue count1 = new DoubleScalar(caster, 2.0, Units.of("count"));
+    EngineValue count2 = new DoubleScalar(caster, 1.0, Units.of("count"));
+
+    // 2 > 1 should be true
+    EngineValue result = count1.greaterThan(count2);
+    assertTrue(result.getAsBoolean(), "2 count > 1 count should be true");
+  }
+
+  @Test
+  void testRatioVsRatioComparison_GreaterThan() {
+    // Both with ratio units
+    EngineValue ratio1 = new DoubleScalar(caster, 0.6, Units.of("ratio"));
+    EngineValue ratio2 = new DoubleScalar(caster, 0.5, Units.of("ratio"));
+
+    // 0.6 > 0.5 should be true
+    EngineValue result = ratio1.greaterThan(ratio2);
+    assertTrue(result.getAsBoolean(), "0.6 ratio > 0.5 ratio should be true");
+  }
+
+  @Test
+  void testRatioVsRatioComparison_GreaterThan_False() {
+    // Both with ratio units
+    EngineValue ratio1 = new DoubleScalar(caster, 0.3, Units.of("ratio"));
+    EngineValue ratio2 = new DoubleScalar(caster, 0.5, Units.of("ratio"));
+
+    // 0.3 > 0.5 should be false
+    EngineValue result = ratio1.greaterThan(ratio2);
+    assertFalse(result.getAsBoolean(), "0.3 ratio > 0.5 ratio should be false");
+  }
+
+  @Test
+  void testMultipleRatioComparisons() {
+    // Simulate a range of external data values
+    double[] ratioValues = {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+    double threshold = 0.5;
+    EngineValue thresholdValue = new DoubleScalar(caster, threshold, Units.of("count"));
+
+    int trueCount = 0;
+    int falseCount = 0;
+
+    for (double v : ratioValues) {
+      EngineValue ratioValue = new DoubleScalar(caster, v, Units.of("ratio"));
+      EngineValue result = ratioValue.greaterThan(thresholdValue);
+      boolean actual = result.getAsBoolean();
+      boolean expected = v > threshold;
+
+      assertEquals(expected, actual,
+          String.format("Comparison %f ratio > %f count should be %s", v, threshold, expected));
+
+      if (actual) {
+        trueCount++;
+      } else {
+        falseCount++;
+      }
+    }
+
+    // Verify we got different results for different values
+    assertTrue(trueCount > 0, "Should have some true results");
+    assertTrue(falseCount > 0, "Should have some false results");
+  }
+
+  @Test
+  void testRatioVsCountLessThan() {
+    EngineValue ratioValue = new DoubleScalar(caster, 0.3, Units.of("ratio"));
+    EngineValue countValue = new DoubleScalar(caster, 0.5, Units.of("count"));
+
+    // 0.3 < 0.5 should be true
+    EngineValue result = ratioValue.lessThan(countValue);
+    assertTrue(result.getAsBoolean(), "0.3 ratio < 0.5 count should be true");
+  }
+
+  @Test
+  void testRatioVsCountEqual() {
+    EngineValue ratioValue = new DoubleScalar(caster, 0.5, Units.of("ratio"));
+    EngineValue countValue = new DoubleScalar(caster, 0.5, Units.of("count"));
+
+    // 0.5 == 0.5 should be true
+    EngineValue result = ratioValue.equalTo(countValue);
+    assertTrue(result.getAsBoolean(), "0.5 ratio == 0.5 count should be true");
+  }
+}

--- a/src/test/java/org/joshsim/lang/interpret/ConfigInterpreterTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/ConfigInterpreterTest.java
@@ -261,4 +261,68 @@ class ConfigInterpreterTest {
     assertEquals(-42.5, config.getValue("negative").getAsDouble(), 0.0001);
     assertEquals(Units.METERS, config.getValue("negative").getUnits());
   }
+
+  @Test
+  void testParsePercentWithSymbol() {
+    // Arrange - percent symbol should convert 8% to 0.08
+    String input = "rate = 8 %";
+
+    // Act
+    Config config = interpreter.interpret(input, factory);
+
+    // Assert
+    assertTrue(config.hasValue("rate"));
+    assertEquals(0.08, config.getValue("rate").getAsDouble(), 0.0001);
+    assertEquals(Units.COUNT, config.getValue("rate").getUnits());
+  }
+
+  @Test
+  void testParsePercentWithWord() {
+    // Arrange - "percent" word should convert 8 percent to 0.08
+    String input = "rate = 8 percent";
+
+    // Act
+    Config config = interpreter.interpret(input, factory);
+
+    // Assert
+    assertTrue(config.hasValue("rate"));
+    assertEquals(0.08, config.getValue("rate").getAsDouble(), 0.0001);
+    assertEquals(Units.COUNT, config.getValue("rate").getUnits());
+  }
+
+  @Test
+  void testParsePercentDecimalValue() {
+    // Arrange - decimal percentages should also work: 12.5% -> 0.125
+    String input = "rate = 12.5 %";
+
+    // Act
+    Config config = interpreter.interpret(input, factory);
+
+    // Assert
+    assertTrue(config.hasValue("rate"));
+    assertEquals(0.125, config.getValue("rate").getAsDouble(), 0.0001);
+    assertEquals(Units.COUNT, config.getValue("rate").getUnits());
+  }
+
+  @Test
+  void testParseMultiplePercentValues() {
+    // Arrange - multiple percent values in same config
+    StringJoiner joiner = new StringJoiner("\n");
+    joiner.add("growthRate = 8 percent");
+    joiner.add("threshold = 25 %");
+    joiner.add("coverage = 48.5 percent");
+    String input = joiner.toString();
+
+    // Act
+    Config config = interpreter.interpret(input, factory);
+
+    // Assert
+    assertTrue(config.hasValue("growthRate"));
+    assertTrue(config.hasValue("threshold"));
+    assertTrue(config.hasValue("coverage"));
+
+    assertEquals(0.08, config.getValue("growthRate").getAsDouble(), 0.0001);
+    assertEquals(0.25, config.getValue("threshold").getAsDouble(), 0.0001);
+    assertEquals(0.485, config.getValue("coverage").getAsDouble(), 0.0001);
+  }
 }


### PR DESCRIPTION
Noticed that JoshConfigParserVisitor was not making the same conversion from count to pct (divide by 100) that we see in JoshValueVisitor, leading to wacky behavior. 