### PR TITLE
[dev-restore] Debug / print feature

### DIFF
--- a/examples/guide/hello_debug_cli.josh
+++ b/examples/guide/hello_debug_cli.josh
@@ -33,8 +33,7 @@ start organism ForeverTree
   height.init = 0 meters
   height.step = prior.height + sample uniform from 0 meters to 1 meters
 
-  # dbg.step = debug("Tree", identifier, " takes a step age:", age, " with height: ", height, "at location", here.x, here.y)
-  dbg.step = debug("Tree takes a step age:", age, " with height: ", height)
+  dbg.step = debug("Tree age:", age, "height:", height)
 
 end organism
 

--- a/examples/guide/hello_debug_cli.josh
+++ b/examples/guide/hello_debug_cli.josh
@@ -1,0 +1,47 @@
+start simulation Main
+
+  grid.size = 1000 m
+  grid.low = 33.7 degrees latitude, -115.4 degrees longitude
+  grid.high = 34.0 degrees latitude, -116.4 degrees longitude
+  grid.patch = "Default"
+
+  steps.low = 0 count
+  steps.high = 10 count
+
+  exportFiles.patch = "file:///tmp/hello_josh.csv"
+  debugFiles.patch = "file:///tmp/hello_josh_patch_debug.txt"
+  debugFiles.organism = "file:///tmp/hello_josh_organism_debug.txt"
+
+end simulation
+
+start patch Default
+
+  ForeverTree.init = create 10 count of ForeverTree
+
+  export.averageAge.step = mean(ForeverTree.age)
+  export.averageHeight.step = mean(ForeverTree.height)
+
+  dbg.step = debug("Patch step complete")
+
+end patch
+
+start organism ForeverTree
+
+  age.init = 0 year
+  age.step = prior.age + 1 year
+
+  height.init = 0 meters
+  height.step = prior.height + sample uniform from 0 meters to 1 meters
+
+  # dbg.step = debug("Tree", identifier, " takes a step age:", age, " with height: ", height, "at location", here.x, here.y)
+  dbg.step = debug("Tree takes a step age:", age, " with height: ", height)
+
+end organism
+
+start unit year
+
+  alias years
+  alias yr
+  alias yrs
+
+end unit

--- a/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
+++ b/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
@@ -51,6 +51,7 @@ CONFIG_: 'config';
 CONST_: 'const';
 CREATE_: 'create';
 CURRENT_: 'current';
+DEBUG_: 'debug';
 DISTURBANCE_: 'disturbance';
 ELIF_: 'elif';
 ELSE_: 'else';
@@ -100,7 +101,7 @@ IDENTIFIER_: [A-Za-z][A-Za-z0-9]*;
 WHITE_SPACE: [ \u000B\t\r\n] -> channel(HIDDEN);
 
 // Identifiers
-nakedIdentifier: (IDENTIFIER_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_);
+nakedIdentifier: (IDENTIFIER_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_|ORGANISM_);
 identifier: nakedIdentifier (DOT_ (nakedIdentifier))*;
 
 // Values
@@ -128,6 +129,7 @@ expression: unitsValue # simpleExpression
   | operand=expression AS_ target=identifier # cast
   | FORCE_ operand=expression AS_ target=identifier # castForce
   | name=funcName LPAREN_ operand=expression RPAREN_ # singleParamFunctionCall
+  | name=funcName LPAREN_ args=expressionList RPAREN_ # variadicFunctionCall
   | left=expression POW_ right=expression # powExpression
   | left=expression op=(MULT_ | DIV_) right=expression # multiplyExpression
   | left=expression op=(ADD_ | SUB_) right=expression # additionExpression
@@ -150,9 +152,11 @@ expression: unitsValue # simpleExpression
   | pos=expression IF_ cond=expression ELSE_ neg=expression # conditional
   ;
 
-funcName: (MEAN_ | STD_) # reservedFuncName
+funcName: (MEAN_ | STD_ | DEBUG_) # reservedFuncName
   | identifier # identifierFuncName
   ;
+
+expressionList: expression (COMMA_ expression)+;
 
 assignment: CONST_ name=identifier EQ_ val=expression;
 

--- a/src/main/java/org/joshsim/JoshSimFacadeUtil.java
+++ b/src/main/java/org/joshsim/JoshSimFacadeUtil.java
@@ -21,7 +21,10 @@ import org.joshsim.lang.bridge.SimulationStepper;
 import org.joshsim.lang.interpret.BridgeGetter;
 import org.joshsim.lang.interpret.JoshInterpreter;
 import org.joshsim.lang.interpret.JoshProgram;
+import org.joshsim.lang.io.CombinedDebugOutputFacade;
 import org.joshsim.lang.io.CombinedExportFacade;
+import org.joshsim.lang.io.DebugOutputFacadeBuilder;
+import org.joshsim.lang.io.ExportFacadeFactory;
 import org.joshsim.lang.io.InputOutputLayer;
 import org.joshsim.lang.parse.JoshParser;
 import org.joshsim.lang.parse.ParseResult;
@@ -108,9 +111,22 @@ public class JoshSimFacadeUtil {
       bridgeGetter.setBridge(bridge);
     }
 
+    ExportFacadeFactory exportFactory = inputOutputLayer.getExportFacadeFactory();
+
+    // Create debug output facade from simulation entity configuration
+    CombinedDebugOutputFacade debugFacade = DebugOutputFacadeBuilder.build(
+        simEntity,
+        exportFactory
+    );
+
+    // Inject debug facade into bridge getter if configured
+    if (bridgeGetter != null && debugFacade.isConfigured()) {
+      bridgeGetter.setDebugOutputFacade(debugFacade);
+    }
+
     CombinedExportFacade exportFacade = new CombinedExportFacade(
         simEntity,
-        inputOutputLayer.getExportFacadeFactory()
+        exportFactory
     );
 
     // Create incremental export callback if export configured
@@ -120,6 +136,7 @@ public class JoshSimFacadeUtil {
     SimulationStepper stepper = new SimulationStepper(bridge, exportCallback);
 
     exportFacade.start();
+    debugFacade.start();
 
     while (!bridge.isComplete()) {
       long completedStep = stepper.perform(serialPatches);
@@ -145,6 +162,7 @@ public class JoshSimFacadeUtil {
     }
 
     exportFacade.join();
+    debugFacade.join();
   }
 
   /**

--- a/src/main/java/org/joshsim/lang/bridge/SyntheticScope.java
+++ b/src/main/java/org/joshsim/lang/bridge/SyntheticScope.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import org.joshsim.engine.func.Scope;
+import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.EngineValueFactory;
 import org.joshsim.engine.value.type.EngineValue;
 

--- a/src/main/java/org/joshsim/lang/bridge/SyntheticScope.java
+++ b/src/main/java/org/joshsim/lang/bridge/SyntheticScope.java
@@ -10,7 +10,6 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import org.joshsim.engine.func.Scope;
-import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.EngineValueFactory;
 import org.joshsim.engine.value.type.EngineValue;
 

--- a/src/main/java/org/joshsim/lang/interpret/BridgeGetter.java
+++ b/src/main/java/org/joshsim/lang/interpret/BridgeGetter.java
@@ -6,7 +6,9 @@
 
 package org.joshsim.lang.interpret;
 
+import java.util.Optional;
 import org.joshsim.lang.bridge.EngineBridge;
+import org.joshsim.lang.io.CombinedDebugOutputFacade;
 
 
 /**
@@ -31,6 +33,29 @@ public interface BridgeGetter {
    */
   default void setBridge(EngineBridge bridge) {
     throw new UnsupportedOperationException("setBridge not supported by this implementation");
+  }
+
+  /**
+   * Sets the debug output facade for writing debug messages.
+   *
+   * <p>This allows injecting a configured debug output facade so that debug()
+   * function calls can write to the appropriate destinations.</p>
+   *
+   * @param debugOutputFacade The debug output facade to use.
+   */
+  default void setDebugOutputFacade(CombinedDebugOutputFacade debugOutputFacade) {
+    throw new UnsupportedOperationException(
+        "setDebugOutputFacade not supported by this implementation"
+    );
+  }
+
+  /**
+   * Get the optional debug output facade for writing debug output.
+   *
+   * @return Optional containing the debug output facade if configured, empty otherwise.
+   */
+  default Optional<CombinedDebugOutputFacade> getDebugOutputFacade() {
+    return Optional.empty();
   }
 
 }

--- a/src/main/java/org/joshsim/lang/interpret/FutureBridgeGetter.java
+++ b/src/main/java/org/joshsim/lang/interpret/FutureBridgeGetter.java
@@ -17,6 +17,7 @@ import org.joshsim.engine.value.engine.EngineValueFactory;
 import org.joshsim.lang.bridge.EngineBridge;
 import org.joshsim.lang.bridge.EngineBridgeSimulationStore;
 import org.joshsim.lang.bridge.MinimalEngineBridge;
+import org.joshsim.lang.io.CombinedDebugOutputFacade;
 import org.joshsim.lang.io.InputOutputLayer;
 import org.joshsim.precompute.JshdExternalGetter;
 
@@ -35,6 +36,7 @@ public class FutureBridgeGetter implements BridgeGetter {
   private Optional<EngineBridge> builtBridge;
   private Optional<EngineGeometryFactory> geometryFactory;
   private Optional<InputOutputLayer> inputOutputLayer;
+  private Optional<CombinedDebugOutputFacade> debugOutputFacade;
 
   /**
    * Creates a new future bridge getter with no initial configuration.
@@ -48,6 +50,7 @@ public class FutureBridgeGetter implements BridgeGetter {
     this.builtBridge = Optional.empty();
     this.geometryFactory = Optional.empty();
     this.inputOutputLayer = Optional.empty();
+    this.debugOutputFacade = Optional.empty();
   }
 
   /**
@@ -97,6 +100,24 @@ public class FutureBridgeGetter implements BridgeGetter {
       throw new IllegalStateException("Input output layer already set.");
     }
     this.inputOutputLayer = Optional.of(inputOutputLayer);
+  }
+
+  /**
+   * Sets the debug output facade for debug output.
+   *
+   * @param debugOutputFacade The debug output facade to use for debug() function calls.
+   */
+  @Override
+  public void setDebugOutputFacade(CombinedDebugOutputFacade debugOutputFacade) {
+    if (this.debugOutputFacade.isPresent()) {
+      throw new IllegalStateException("Debug output facade already set.");
+    }
+    this.debugOutputFacade = Optional.of(debugOutputFacade);
+  }
+
+  @Override
+  public Optional<CombinedDebugOutputFacade> getDebugOutputFacade() {
+    return this.debugOutputFacade;
   }
 
   /**

--- a/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
@@ -562,4 +562,27 @@ public interface EventHandlerMachine {
    * @param name The name of the config value to push.
    */
   void pushConfigWithDefault(String name);
+
+  /**
+   * Write a debug message to the configured debug output.
+   *
+   * <p>Pops the top of the stack, converts it to a string, and writes it to the debug output
+   * along with the current step number and entity type context. If no debug output is configured,
+   * this operation is a no-op with zero overhead.</p>
+   *
+   * @return Reference to this machine for chaining.
+   */
+  EventHandlerMachine writeDebug();
+
+  /**
+   * Write multiple values to debug output by concatenating them.
+   *
+   * <p>Pops the specified number of values from the stack, concatenates them with spaces,
+   * and writes to the configured debug output. After writing, pushes 0 count as the result
+   * (allowing debug to be used in expressions without side effects).</p>
+   *
+   * @param argCount Number of arguments to pop from the stack.
+   * @return Reference to this machine for chaining.
+   */
+  EventHandlerMachine debugVariadic(int argCount);
 }

--- a/src/main/java/org/joshsim/lang/interpret/machine/PushDownMachineCallable.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/PushDownMachineCallable.java
@@ -34,7 +34,11 @@ public class PushDownMachineCallable implements CompiledCallable {
 
   @Override
   public EngineValue evaluate(Scope scope) {
-    EventHandlerMachine machine = new SingleThreadEventHandlerMachine(bridgeGetter.get(), scope);
+    EventHandlerMachine machine = new SingleThreadEventHandlerMachine(
+        bridgeGetter.get(),
+        scope,
+        bridgeGetter.getDebugOutputFacade()
+    );
     handlerAction.apply(machine);
     return machine.getResult();
   }

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -908,33 +908,13 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
       return this;
     }
 
-    String message = value.getAsString();
+    String message = formatDebugValue(value);
     long step = bridge.getAbsoluteTimestep();
+    DebugEntityInfo info = getDebugEntityInfo();
 
-    // Get current entity type category from scope
-    String entityCategory = "unknown";
-    try {
-      EngineValue currentValue = scope.get("current");
-      if (currentValue != null) {
-        MutableEntity current = currentValue.getAsMutableEntity();
-        EntityType type = current.getEntityType();
-        // Map EntityType to debug file key
-        entityCategory = switch (type) {
-          case AGENT -> "organism";  // organisms map to AGENT type
-          case PATCH -> "patch";
-          case SIMULATION -> "simulation";
-          case DISTURBANCE -> "disturbance";
-          default -> "unknown";
-        };
-      }
-    } catch (Exception e) {
-      // Fall back to "unknown" if we can't determine entity type
-    }
-
-    // Set entity type context and write
+    // Write with full context
     CombinedDebugOutputFacade facade = debugOutputFacade.get();
-    facade.setCurrentEntityType(entityCategory);
-    facade.write(message, step);
+    facade.write(message, step, info.entityCategory, info.identifier, info.x, info.y);
 
     // Push the original value back (debug is a pass-through function)
     push(value);
@@ -947,7 +927,7 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
     List<String> parts = new ArrayList<>();
     for (int i = 0; i < argCount; i++) {
       EngineValue value = pop();
-      parts.add(0, value.getAsString()); // Insert at beginning to reverse order
+      parts.add(0, formatDebugValue(value)); // Insert at beginning to reverse order
     }
 
     if (debugOutputFacade.isEmpty()) {
@@ -957,14 +937,78 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
     }
 
     long step = bridge.getAbsoluteTimestep();
+    DebugEntityInfo info = getDebugEntityInfo();
 
-    // Get current entity type category from scope
+    // Write with full context
+    CombinedDebugOutputFacade facade = debugOutputFacade.get();
+    facade.write(String.join(" ", parts), step, info.entityCategory, info.identifier, info.x, info.y);
+
+    // Push 0 count as result (allows debug in expressions)
+    push(valueFactory.build(0, Units.of("count")));
+    return this;
+  }
+
+  /**
+   * Formats a value for debug output with cleaner formatting.
+   *
+   * <p>Applies formatting improvements:
+   * <ul>
+   *   <li>Strips surrounding quotes from string values</li>
+   *   <li>Truncates floating point numbers to 4 decimal places</li>
+   * </ul>
+   *
+   * @param value The EngineValue to format.
+   * @return A formatted string representation.
+   */
+  private String formatDebugValue(EngineValue value) {
+    String raw = value.getAsString();
+
+    // Strip surrounding quotes from strings
+    if (raw.length() >= 2 && raw.startsWith("\"") && raw.endsWith("\"")) {
+      return raw.substring(1, raw.length() - 1);
+    }
+
+    // Try to truncate floating point numbers to 4 decimal places
+    try {
+      // Check if it looks like a decimal number (contains a dot)
+      if (raw.contains(".") && !raw.contains(" ")) {
+        double d = Double.parseDouble(raw);
+        // Format to 4 decimal places, removing trailing zeros
+        String formatted = String.format("%.4f", d);
+        // Remove trailing zeros after decimal point (but keep at least one decimal place)
+        formatted = formatted.replaceAll("0+$", "").replaceAll("\\.$", ".0");
+        return formatted;
+      }
+    } catch (NumberFormatException e) {
+      // Not a number, return as-is
+    }
+
+    return raw;
+  }
+
+  /**
+   * Helper record to hold entity debug context information.
+   */
+  private record DebugEntityInfo(String entityCategory, String identifier, double x, double y) {}
+
+  /**
+   * Extracts debug context information from the current entity in scope.
+   *
+   * @return DebugEntityInfo with entity category, identifier, and location.
+   */
+  private DebugEntityInfo getDebugEntityInfo() {
     String entityCategory = "unknown";
+    String identifier = "0";
+    double x = 0.0;
+    double y = 0.0;
+
     try {
       EngineValue currentValue = scope.get("current");
       if (currentValue != null) {
         MutableEntity current = currentValue.getAsMutableEntity();
         EntityType type = current.getEntityType();
+
+        // Map EntityType to debug file key
         entityCategory = switch (type) {
           case AGENT -> "organism";
           case PATCH -> "patch";
@@ -972,19 +1016,33 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
           case DISTURBANCE -> "disturbance";
           default -> "unknown";
         };
+
+        // Get unique identifier from Java identity hash
+        identifier = Integer.toHexString(System.identityHashCode(current));
+
+        // Get location - try entity's own geometry first, then fall back to "here"
+        Optional<EngineGeometry> geometry = current.getGeometry();
+        if (geometry.isPresent()) {
+          x = geometry.get().getCenterX().doubleValue();
+          y = geometry.get().getCenterY().doubleValue();
+        } else if (scope.has("here")) {
+          // For inner entities (organisms), use containing patch's location
+          EngineValue hereValue = scope.get("here");
+          if (hereValue != null) {
+            Entity here = hereValue.getAsEntity();
+            Optional<EngineGeometry> hereGeom = here.getGeometry();
+            if (hereGeom.isPresent()) {
+              x = hereGeom.get().getCenterX().doubleValue();
+              y = hereGeom.get().getCenterY().doubleValue();
+            }
+          }
+        }
       }
     } catch (Exception e) {
-      // Fall back to "unknown"
+      // Fall back to defaults if we can't determine entity info
     }
 
-    // Concatenate with spaces and write
-    CombinedDebugOutputFacade facade = debugOutputFacade.get();
-    facade.setCurrentEntityType(entityCategory);
-    facade.write(String.join(" ", parts), step);
-
-    // Push 0 count as result (allows debug in expressions)
-    push(valueFactory.build(0, Units.of("count")));
-    return this;
+    return new DebugEntityInfo(entityCategory, identifier, x, y);
   }
 
   /**

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -941,7 +941,14 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
 
     // Write with full context
     CombinedDebugOutputFacade facade = debugOutputFacade.get();
-    facade.write(String.join(" ", parts), step, info.entityCategory, info.identifier, info.x, info.y);
+    facade.write(
+        String.join(" ", parts),
+        step,
+        info.entityCategory,
+        info.identifier, 
+        info.x,
+        info.y
+    );
 
     // Push 0 count as result (allows debug in expressions)
     push(valueFactory.build(0, Units.of("count")));

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -17,6 +17,7 @@ import org.joshsim.engine.entity.base.Entity;
 import org.joshsim.engine.entity.base.MutableEntity;
 import org.joshsim.engine.entity.prototype.EmbeddedParentEntityPrototype;
 import org.joshsim.engine.entity.prototype.EntityPrototype;
+import org.joshsim.engine.entity.type.EntityType;
 import org.joshsim.engine.func.EntityScope;
 import org.joshsim.engine.func.LocalScope;
 import org.joshsim.engine.func.Scope;
@@ -34,6 +35,7 @@ import org.joshsim.lang.interpret.action.EventHandlerAction;
 import org.joshsim.lang.interpret.mapping.MapBounds;
 import org.joshsim.lang.interpret.mapping.MapStrategy;
 import org.joshsim.lang.interpret.mapping.MappingBuilder;
+import org.joshsim.lang.io.CombinedDebugOutputFacade;
 
 
 /**
@@ -56,6 +58,7 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
   private final EngineValueFactory valueFactory;
   private final Random random;
   private final boolean favorBigDecimal;
+  private final Optional<CombinedDebugOutputFacade> debugOutputFacade;
 
   private boolean inConversionGroup;
   private Optional<Units> conversionTarget;
@@ -68,8 +71,21 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
    * @param scope The scope in which to have this automaton perform its operations.
    */
   public SingleThreadEventHandlerMachine(EngineBridge bridge, Scope scope) {
+    this(bridge, scope, Optional.empty());
+  }
+
+  /**
+   * Create a new push-down automaton with debug output support.
+   *
+   * @param bridge The EngineBridge through which to interact with the engine.
+   * @param scope The scope in which to have this automaton perform its operations.
+   * @param debugOutputFacade Optional debug output facade for writing debug messages.
+   */
+  public SingleThreadEventHandlerMachine(EngineBridge bridge, Scope scope,
+      Optional<CombinedDebugOutputFacade> debugOutputFacade) {
     this.bridge = bridge;
     this.scope = new LocalScope(scope);
+    this.debugOutputFacade = debugOutputFacade;
 
     memory = new Stack<>();
     inConversionGroup = false;
@@ -880,6 +896,95 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
     EngineValue defaultValue = pop(); // Get default from stack
     Optional<EngineValue> configValue = bridge.getConfigOptional(name);
     push(configValue.orElse(defaultValue));
+  }
+
+  @Override
+  public EventHandlerMachine writeDebug() {
+    EngineValue value = pop();
+
+    if (debugOutputFacade.isEmpty()) {
+      // No debug output facade configured - push value back (pass-through)
+      push(value);
+      return this;
+    }
+
+    String message = value.getAsString();
+    long step = bridge.getAbsoluteTimestep();
+
+    // Get current entity type category from scope
+    String entityCategory = "unknown";
+    try {
+      EngineValue currentValue = scope.get("current");
+      if (currentValue != null) {
+        MutableEntity current = currentValue.getAsMutableEntity();
+        EntityType type = current.getEntityType();
+        // Map EntityType to debug file key
+        entityCategory = switch (type) {
+          case AGENT -> "organism";  // organisms map to AGENT type
+          case PATCH -> "patch";
+          case SIMULATION -> "simulation";
+          case DISTURBANCE -> "disturbance";
+          default -> "unknown";
+        };
+      }
+    } catch (Exception e) {
+      // Fall back to "unknown" if we can't determine entity type
+    }
+
+    // Set entity type context and write
+    CombinedDebugOutputFacade facade = debugOutputFacade.get();
+    facade.setCurrentEntityType(entityCategory);
+    facade.write(message, step);
+
+    // Push the original value back (debug is a pass-through function)
+    push(value);
+    return this;
+  }
+
+  @Override
+  public EventHandlerMachine debugVariadic(int argCount) {
+    // Pop all values in reverse order (last arg is on top of stack)
+    List<String> parts = new ArrayList<>();
+    for (int i = 0; i < argCount; i++) {
+      EngineValue value = pop();
+      parts.add(0, value.getAsString()); // Insert at beginning to reverse order
+    }
+
+    if (debugOutputFacade.isEmpty()) {
+      // No debug output configured - push 0 count as result
+      push(valueFactory.build(0, Units.of("count")));
+      return this;
+    }
+
+    long step = bridge.getAbsoluteTimestep();
+
+    // Get current entity type category from scope
+    String entityCategory = "unknown";
+    try {
+      EngineValue currentValue = scope.get("current");
+      if (currentValue != null) {
+        MutableEntity current = currentValue.getAsMutableEntity();
+        EntityType type = current.getEntityType();
+        entityCategory = switch (type) {
+          case AGENT -> "organism";
+          case PATCH -> "patch";
+          case SIMULATION -> "simulation";
+          case DISTURBANCE -> "disturbance";
+          default -> "unknown";
+        };
+      }
+    } catch (Exception e) {
+      // Fall back to "unknown"
+    }
+
+    // Concatenate with spaces and write
+    CombinedDebugOutputFacade facade = debugOutputFacade.get();
+    facade.setCurrentEntityType(entityCategory);
+    facade.write(String.join(" ", parts), step);
+
+    // Push 0 count as result (allows debug in expressions)
+    push(valueFactory.build(0, Units.of("count")));
+    return this;
   }
 
   /**

--- a/src/main/java/org/joshsim/lang/interpret/visitor/JoshParserToMachineVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/JoshParserToMachineVisitor.java
@@ -153,6 +153,11 @@ public class JoshParserToMachineVisitor extends JoshLangBaseVisitor<JoshFragment
     return mathematicsVisitor.visitSingleParamFunctionCall(ctx);
   }
 
+  public JoshFragment visitVariadicFunctionCall(
+      JoshLangParser.VariadicFunctionCallContext ctx) {
+    return mathematicsVisitor.visitVariadicFunctionCall(ctx);
+  }
+
   public JoshFragment visitConcatExpression(JoshLangParser.ConcatExpressionContext ctx) {
     return stringOperationVisitor.visitConcatExpression(ctx);
   }

--- a/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshMathematicsVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshMathematicsVisitor.java
@@ -6,6 +6,8 @@
 
 package org.joshsim.lang.interpret.visitor.delegates;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.EngineValueFactory;
 import org.joshsim.lang.antlr.JoshLangParser;
@@ -299,6 +301,7 @@ public class JoshMathematicsVisitor implements JoshVisitorDelegate {
       case "abs" -> (machine) -> machine.abs();
       case "ceil" -> (machine) -> machine.ceil();
       case "count" -> (machine) -> machine.count();
+      case "debug" -> (machine) -> machine.writeDebug();
       case "floor" -> (machine) -> machine.floor();
       case "log10" -> (machine) -> machine.log10();
       case "ln" -> (machine) -> machine.ln();
@@ -318,6 +321,44 @@ public class JoshMathematicsVisitor implements JoshVisitorDelegate {
     };
 
     return new ActionFragment(action);
+  }
+
+  /**
+   * Parse a variadic function call (function with multiple arguments).
+   *
+   * <p>Currently only supports the debug() function with multiple arguments.
+   * Arguments are evaluated and concatenated with spaces for debug output.</p>
+   *
+   * @param ctx The ANTLR context from which to parse the function call.
+   * @return JoshFragment containing the function call operation parsed.
+   * @throws IllegalArgumentException if the function name is not supported for variadic calls.
+   */
+  public JoshFragment visitVariadicFunctionCall(
+      JoshLangParser.VariadicFunctionCallContext ctx) {
+    String funcName = ctx.name.getText();
+
+    if ("debug".equals(funcName)) {
+      // Parse all arguments
+      List<EventHandlerAction> argActions = new ArrayList<>();
+      for (JoshLangParser.ExpressionContext expr : ctx.args.expression()) {
+        argActions.add(expr.accept(parent).getCurrentAction());
+      }
+
+      EventHandlerAction action = (machine) -> {
+        // Evaluate all arguments - they are pushed onto the stack in order
+        for (EventHandlerAction argAction : argActions) {
+          argAction.apply(machine);
+        }
+
+        // Machine method pops all values, formats them, and writes to debug
+        machine.debugVariadic(argActions.size());
+        return machine;
+      };
+
+      return new ActionFragment(action);
+    } else {
+      throw new IllegalArgumentException("Unknown variadic function: " + funcName);
+    }
   }
 
 }

--- a/src/main/java/org/joshsim/lang/io/CombinedDebugOutputFacade.java
+++ b/src/main/java/org/joshsim/lang/io/CombinedDebugOutputFacade.java
@@ -1,0 +1,169 @@
+/**
+ * Combined facade that routes debug messages to per-entity-type output facades.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.io;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Routes debug messages to different output facades based on entity type.
+ *
+ * <p>This facade follows the same architectural pattern as {@link CombinedExportFacade},
+ * which routes entity exports to different destinations. The key differences are:</p>
+ * <ul>
+ *   <li>This routes String debug messages, CombinedExportFacade routes Entity data</li>
+ *   <li>This uses {@link DebugOutputFacade}, CombinedExportFacade uses format-specific facades</li>
+ * </ul>
+ *
+ * <p>Uses a ThreadLocal to track the current entity type context, allowing thread-safe
+ * routing in multi-threaded simulation environments (e.g., parallel replicates).</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * Map&lt;String, DebugOutputFacade&gt; facades = new HashMap&lt;&gt;();
+ * facades.put("patch", new DebugOutputFacade(new LocalOutputStreamStrategy("/tmp/patch.log")));
+ * facades.put("agent", new DebugOutputFacade(new LocalOutputStreamStrategy("/tmp/agent.log")));
+ *
+ * CombinedDebugOutputFacade combined = new CombinedDebugOutputFacade(facades);
+ * combined.start();
+ *
+ * // In simulation, entity type is set automatically by the machine
+ * combined.write("Debug message", 1, "patch");
+ *
+ * combined.join();
+ * </pre>
+ *
+ * @see DebugOutputFacade
+ * @see CombinedExportFacade
+ */
+public class CombinedDebugOutputFacade {
+
+  private final Map<String, DebugOutputFacade> facadesByEntityType;
+  private final ThreadLocal<String> currentEntityType;
+
+  /**
+   * Creates a combined facade with the specified per-entity-type output facades.
+   *
+   * <p>The facades map should contain entries for each entity type that needs separate
+   * debug output. Entity types not in the map will have their debug messages silently
+   * ignored (zero overhead).</p>
+   *
+   * @param facadesByEntityType Map from entity type names to their corresponding facades.
+   */
+  public CombinedDebugOutputFacade(Map<String, DebugOutputFacade> facadesByEntityType) {
+    this.facadesByEntityType = new HashMap<>(facadesByEntityType);
+    this.currentEntityType = new ThreadLocal<>();
+  }
+
+  /**
+   * Creates an empty combined facade (no configured outputs).
+   *
+   * <p>Use this constructor when debug output is disabled. All write operations
+   * will be silently ignored with zero overhead.</p>
+   */
+  public CombinedDebugOutputFacade() {
+    this(new HashMap<>());
+  }
+
+  /**
+   * Starts all per-entity-type output facades.
+   */
+  public void start() {
+    facadesByEntityType.values().forEach(DebugOutputFacade::start);
+  }
+
+  /**
+   * Waits for all per-entity-type output facades to complete.
+   */
+  public void join() {
+    facadesByEntityType.values().forEach(DebugOutputFacade::join);
+  }
+
+  /**
+   * Writes a debug message to the facade for the current entity type.
+   *
+   * <p>The message is routed based on the entity type set via {@link #setCurrentEntityType}.
+   * If no entity type is set or no facade is configured for the current type,
+   * the message is silently ignored.</p>
+   *
+   * @param message The debug message to write.
+   * @param step The current simulation step number.
+   */
+  public void write(String message, long step) {
+    String entityType = currentEntityType.get();
+    if (entityType == null) {
+      return;
+    }
+
+    DebugOutputFacade facade = facadesByEntityType.get(entityType);
+    if (facade != null) {
+      facade.write(message, step, entityType);
+    }
+  }
+
+  /**
+   * Writes a debug message with explicit entity type.
+   *
+   * @param message The debug message to write.
+   * @param step The current simulation step number.
+   * @param entityType The entity type for routing.
+   */
+  public void write(String message, long step, String entityType) {
+    DebugOutputFacade facade = facadesByEntityType.get(entityType);
+    if (facade != null) {
+      facade.write(message, step, entityType);
+    }
+  }
+
+  /**
+   * Sets the current entity type context for this thread.
+   *
+   * <p>This method should be called before write() to establish which entity type's
+   * facade should receive the next message. The entity type context is thread-local,
+   * so different threads can have different entity type contexts simultaneously.</p>
+   *
+   * @param entityType The entity type name (e.g., "patch", "agent", "disturbance").
+   */
+  public void setCurrentEntityType(String entityType) {
+    currentEntityType.set(entityType);
+  }
+
+  /**
+   * Clears the current entity type context for this thread.
+   */
+  public void clearCurrentEntityType() {
+    currentEntityType.remove();
+  }
+
+  /**
+   * Gets the current entity type context for this thread.
+   *
+   * @return The current entity type, or null if none is set.
+   */
+  public String getCurrentEntityType() {
+    return currentEntityType.get();
+  }
+
+  /**
+   * Checks if any output facades are configured.
+   *
+   * @return true if at least one entity type facade is configured, false otherwise.
+   */
+  public boolean isConfigured() {
+    return !facadesByEntityType.isEmpty();
+  }
+
+  /**
+   * Gets the number of configured entity type facades.
+   *
+   * @return The number of entity types with configured facades.
+   */
+  public int getFacadeCount() {
+    return facadesByEntityType.size();
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/io/CombinedDebugOutputFacade.java
+++ b/src/main/java/org/joshsim/lang/io/CombinedDebugOutputFacade.java
@@ -84,38 +84,23 @@ public class CombinedDebugOutputFacade {
   }
 
   /**
-   * Writes a debug message to the facade for the current entity type.
+   * Writes a debug message with entity context information.
    *
-   * <p>The message is routed based on the entity type set via {@link #setCurrentEntityType}.
-   * If no entity type is set or no facade is configured for the current type,
-   * the message is silently ignored.</p>
-   *
-   * @param message The debug message to write.
-   * @param step The current simulation step number.
-   */
-  public void write(String message, long step) {
-    String entityType = currentEntityType.get();
-    if (entityType == null) {
-      return;
-    }
-
-    DebugOutputFacade facade = facadesByEntityType.get(entityType);
-    if (facade != null) {
-      facade.write(message, step, entityType);
-    }
-  }
-
-  /**
-   * Writes a debug message with explicit entity type.
+   * <p>The message is routed based on entity type. If no facade is configured
+   * for the entity type, the message is silently ignored.</p>
    *
    * @param message The debug message to write.
    * @param step The current simulation step number.
    * @param entityType The entity type for routing.
+   * @param identifier Unique identifier for the entity (hex hash).
+   * @param x X coordinate of the entity's location.
+   * @param y Y coordinate of the entity's location.
    */
-  public void write(String message, long step, String entityType) {
+  public void write(String message, long step, String entityType,
+                    String identifier, double x, double y) {
     DebugOutputFacade facade = facadesByEntityType.get(entityType);
     if (facade != null) {
-      facade.write(message, step, entityType);
+      facade.write(message, step, entityType, identifier, x, y);
     }
   }
 

--- a/src/main/java/org/joshsim/lang/io/DebugOutputFacade.java
+++ b/src/main/java/org/joshsim/lang/io/DebugOutputFacade.java
@@ -1,0 +1,163 @@
+/**
+ * Facade for writing debug output messages to a single destination.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.io;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.Optional;
+import org.joshsim.compat.CompatibilityLayerKeeper;
+import org.joshsim.compat.QueueService;
+import org.joshsim.compat.QueueServiceCallback;
+
+/**
+ * Writes debug messages to a single output destination (file, minio, stdout).
+ *
+ * <p>This facade follows the same architectural pattern as {@link ExportFacade} implementations
+ * like {@link org.joshsim.lang.io.strategy.CsvExportFacade}:</p>
+ * <ul>
+ *   <li>Uses {@link QueueService} for asynchronous writes to avoid blocking simulation</li>
+ *   <li>Uses {@link OutputStreamStrategy} for destination abstraction (file, minio, stdout)</li>
+ *   <li>Has start/join lifecycle for background thread management</li>
+ * </ul>
+ *
+ * <p><b>Key difference from ExportFacade:</b> This facade writes plain text strings (from the
+ * {@code debug()} function), while ExportFacade implementations write serialized Entity data.
+ * The input type difference (String vs Entity) is why this doesn't implement the ExportFacade
+ * interface directly.</p>
+ *
+ * <p>Messages are formatted with step number and entity type context:</p>
+ * <pre>[Step 5, patch] Your debug message here</pre>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * OutputStreamStrategy strategy = new LocalOutputStreamStrategy("/tmp/debug.txt");
+ * DebugOutputFacade facade = new DebugOutputFacade(strategy);
+ * facade.start();
+ * facade.write("Hello from simulation", 5, "patch");
+ * facade.join();
+ * </pre>
+ *
+ * @see ExportFacade
+ * @see CombinedDebugOutputFacade
+ */
+public class DebugOutputFacade {
+
+  private final QueueService queueService;
+  private final InnerWriter innerWriter;
+
+  /**
+   * Creates a debug output facade for the specified output strategy.
+   *
+   * @param outputStrategy The strategy for opening the output stream.
+   */
+  public DebugOutputFacade(OutputStreamStrategy outputStrategy) {
+    this.innerWriter = new InnerWriter(outputStrategy);
+    this.queueService = CompatibilityLayerKeeper.get().createQueueService(innerWriter);
+  }
+
+  /**
+   * Starts the facade's background queue service.
+   *
+   * <p>Must be called before {@link #write}. The background thread will process
+   * queued messages until {@link #join} is called.</p>
+   */
+  public void start() {
+    queueService.start();
+  }
+
+  /**
+   * Waits for all queued messages to be written and shuts down.
+   *
+   * <p>Blocks until the background thread has processed all pending messages
+   * and closed the output stream.</p>
+   */
+  public void join() {
+    queueService.join();
+  }
+
+  /**
+   * Writes a debug message with context information.
+   *
+   * <p>The message is queued for asynchronous writing. The actual write happens
+   * in the background thread to avoid blocking the simulation.</p>
+   *
+   * @param message The debug message to write.
+   * @param step The current simulation step number.
+   * @param entityType The type of entity generating the message (e.g., "patch", "agent").
+   */
+  public void write(String message, long step, String entityType) {
+    DebugMessage debugMessage = new DebugMessage(message, step, entityType);
+    queueService.add(debugMessage);
+  }
+
+  /**
+   * Internal record to hold debug message data for queue processing.
+   */
+  private record DebugMessage(String message, long step, String entityType) {}
+
+  /**
+   * Internal callback that handles writing debug messages to the output stream.
+   *
+   * <p>This follows the same pattern as the InnerWriter in CsvExportFacade.</p>
+   */
+  private static class InnerWriter implements QueueServiceCallback {
+
+    private final OutputStream outputStream;
+    private final PrintWriter writer;
+    private final boolean isStdout;
+
+    /**
+     * Creates the inner writer with the specified output strategy.
+     *
+     * @param outputStrategy The strategy for opening the output stream.
+     * @throws RuntimeException if the output stream cannot be opened.
+     */
+    public InnerWriter(OutputStreamStrategy outputStrategy) {
+      try {
+        this.outputStream = outputStrategy.open();
+        this.writer = new PrintWriter(outputStream, true);
+        this.isStdout = outputStrategy instanceof StdoutOutputStreamStrategy;
+      } catch (IOException e) {
+        throw new RuntimeException("Error opening debug output stream", e);
+      }
+    }
+
+    @Override
+    public void onStart() {
+      // No initialization needed
+    }
+
+    @Override
+    public void onTask(Optional<Object> taskMaybe) {
+      if (taskMaybe.isEmpty()) {
+        writer.flush();
+        return;
+      }
+
+      DebugMessage msg = (DebugMessage) taskMaybe.get();
+      String formatted = String.format("[Step %d, %s] %s",
+          msg.step(), msg.entityType(), msg.message());
+      writer.println(formatted);
+    }
+
+    @Override
+    public void onEnd() {
+      writer.flush();
+      // Don't close stdout, but close files
+      if (!isStdout) {
+        writer.close();
+        try {
+          outputStream.close();
+        } catch (IOException e) {
+          throw new RuntimeException("Error closing debug output stream", e);
+        }
+      }
+    }
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/io/DebugOutputFacade.java
+++ b/src/main/java/org/joshsim/lang/io/DebugOutputFacade.java
@@ -89,16 +89,21 @@ public class DebugOutputFacade {
    * @param message The debug message to write.
    * @param step The current simulation step number.
    * @param entityType The type of entity generating the message (e.g., "patch", "agent").
+   * @param identifier Unique identifier for the entity (hex hash).
+   * @param x X coordinate of the entity's location.
+   * @param y Y coordinate of the entity's location.
    */
-  public void write(String message, long step, String entityType) {
-    DebugMessage debugMessage = new DebugMessage(message, step, entityType);
+  public void write(String message, long step, String entityType,
+                    String identifier, double x, double y) {
+    DebugMessage debugMessage = new DebugMessage(message, step, entityType, identifier, x, y);
     queueService.add(debugMessage);
   }
 
   /**
    * Internal record to hold debug message data for queue processing.
    */
-  private record DebugMessage(String message, long step, String entityType) {}
+  private record DebugMessage(String message, long step, String entityType,
+                              String identifier, double x, double y) {}
 
   /**
    * Internal callback that handles writing debug messages to the output stream.
@@ -140,8 +145,8 @@ public class DebugOutputFacade {
       }
 
       DebugMessage msg = (DebugMessage) taskMaybe.get();
-      String formatted = String.format("[Step %d, %s] %s",
-          msg.step(), msg.entityType(), msg.message());
+      String formatted = String.format("[Step %d, %s @ %s (%.1f, %.1f)] %s",
+          msg.step(), msg.entityType(), msg.identifier(), msg.x(), msg.y(), msg.message());
       writer.println(formatted);
     }
 

--- a/src/main/java/org/joshsim/lang/io/DebugOutputFacadeBuilder.java
+++ b/src/main/java/org/joshsim/lang/io/DebugOutputFacadeBuilder.java
@@ -1,0 +1,121 @@
+/**
+ * Builder for creating CombinedDebugOutputFacade from simulation entity configuration.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.io;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.value.type.EngineValue;
+
+/**
+ * Builds a CombinedDebugOutputFacade by reading debugFiles.* attributes from simulation entity.
+ *
+ * <p>This builder follows the same pattern as {@link CombinedExportFacade} for reading
+ * configuration from simulation entities. It reads attributes like:</p>
+ * <ul>
+ *   <li>debugFiles.organism - output path for organism debug messages</li>
+ *   <li>debugFiles.patch - output path for patch debug messages</li>
+ *   <li>debugFiles.agent - output path for agent debug messages</li>
+ * </ul>
+ *
+ * <p>Supported path schemes depend on the ExportFacadeFactory implementation:</p>
+ * <ul>
+ *   <li>file:// - writes to local file system</li>
+ *   <li>minio:// - writes to MinIO object storage (requires MinIO configuration)</li>
+ *   <li>stdout:// - writes to standard output</li>
+ * </ul>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * CombinedDebugOutputFacade debugFacade = DebugOutputFacadeBuilder.build(simEntity, factory);
+ * debugFacade.start();
+ * // ... simulation runs ...
+ * debugFacade.join();
+ * </pre>
+ */
+public class DebugOutputFacadeBuilder {
+
+  private static final String DEBUG_FILES_PREFIX = "debugFiles.";
+  private static final String[] ENTITY_TYPES = {"organism", "patch", "agent", "disturbance"};
+
+  /**
+   * Builds a CombinedDebugOutputFacade from the simulation entity's configuration.
+   *
+   * <p>Uses the ExportFacadeFactory to create OutputStreamStrategy instances, allowing
+   * debug output to use the same infrastructure (file, MinIO) as export output.</p>
+   *
+   * @param simEntity The simulation entity containing debugFiles.* attributes.
+   * @param exportFactory The export factory to use for creating output stream strategies.
+   * @return A CombinedDebugOutputFacade configured based on the entity's attributes.
+   */
+  public static CombinedDebugOutputFacade build(MutableEntity simEntity,
+                                                 ExportFacadeFactory exportFactory) {
+    Map<String, DebugOutputFacade> facades = new HashMap<>();
+
+    simEntity.startSubstep("constant");
+
+    for (String entityType : ENTITY_TYPES) {
+      String attributeName = DEBUG_FILES_PREFIX + entityType;
+      Optional<EngineValue> value = simEntity.getAttributeValue(attributeName);
+
+      if (value.isPresent()) {
+        try {
+          String templatePath = value.get().getAsString();
+          String path = exportFactory.getPath(templatePath);
+          OutputStreamStrategy strategy = createStrategyFromPath(path, exportFactory);
+          facades.put(entityType, new DebugOutputFacade(strategy));
+        } catch (Exception e) {
+          // Skip this entity type if strategy creation fails (e.g., in web environment)
+          // Debug output will be silently ignored for this entity type
+        }
+      }
+    }
+
+    simEntity.endSubstep();
+
+    return new CombinedDebugOutputFacade(facades);
+  }
+
+  /**
+   * Creates an OutputStreamStrategy from a path string.
+   *
+   * <p>Handles stdout:// specially, and delegates to JvmExportFacadeFactory for file:// and
+   * minio://. Other factory types (e.g., SandboxExportFacadeFactory for WASM) do not support
+   * debug file output and will throw an exception.</p>
+   *
+   * @param path The path string (e.g., "file:///tmp/debug.txt", "stdout://")
+   * @param exportFactory The export factory to use for creating strategies.
+   * @return The appropriate OutputStreamStrategy for the path.
+   * @throws IllegalArgumentException if the path scheme is unsupported or factory doesn't support
+   *     debug output.
+   */
+  private static OutputStreamStrategy createStrategyFromPath(String path,
+                                                              ExportFacadeFactory exportFactory) {
+    String cleanPath = path.replaceAll("\"", "");
+
+    if (cleanPath.startsWith("stdout://") || cleanPath.equals("stdout")) {
+      return new StdoutOutputStreamStrategy();
+    }
+
+    ExportTarget target = ExportTargetParser.parse(cleanPath);
+
+    // Only JvmExportFacadeFactory supports file-based debug output
+    // Other factories (e.g., SandboxExportFacadeFactory for WASM) don't support file I/O
+    if (exportFactory instanceof JvmExportFacadeFactory jvmFactory) {
+      return jvmFactory.createOutputStreamStrategy(target);
+    }
+
+    // Non-JVM environments don't support debug file output
+    throw new UnsupportedOperationException(
+        "Debug file output is only supported in JVM environments. "
+        + "Use stdout:// for debug output in other environments, "
+        + "or remove debugFiles configuration."
+    );
+  }
+
+}

--- a/src/main/java/org/joshsim/lang/io/StdoutOutputStreamStrategy.java
+++ b/src/main/java/org/joshsim/lang/io/StdoutOutputStreamStrategy.java
@@ -1,0 +1,25 @@
+/**
+ * Strategy to write to standard output (stdout).
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.io;
+
+import java.io.OutputStream;
+
+/**
+ * OutputStreamStrategy implementation that writes to standard output.
+ *
+ * <p>This strategy returns System.out as the OutputStream. Note that the caller
+ * should NOT close the returned stream, as closing System.out would prevent
+ * further console output.</p>
+ */
+public class StdoutOutputStreamStrategy implements OutputStreamStrategy {
+
+  @Override
+  public OutputStream open() {
+    return System.out;
+  }
+
+}


### PR DESCRIPTION
This is essentially a reimplementation of #326, using a different approach. 

#326 fully abstracts export and debug logic into generics (`OutputWriter<T>`, `WriteTask<T>`, `OutputWriterFactory`, `SandboxOutputWriterFactory`, etc etc), but introduced like 1500+ lines and 11 new files to do so. Also, based on the fact that the debug logic was implemented to try and address #321, #322, and #323, there is some contamination of organism lifecycle changes and debug logic (primarily due to poor branch discipline on my part!!!). 

This branch implements the same feature of being able to use `debug()` expressions to get rich templated printouts of agent / simulation behavior as defined below. However, it does so by duplicating:
  - Queue lifecycle pattern (start/join) - ~30 lines
  - Combined routing pattern (by entity type) - ~100 lines
  - WASM sandbox delegation pattern - ~50 lines

But, in doing so, we avoid having to monkey around with working export logic and (I think) have much less abstracted code to maintain in this regard. I suspect we won't be adding any new output implementations, so I think it's a worthy tradeoff. 

___________________________________

###   Configuration (in simulation block)
```
start simulation Main
  debugFiles.patch = "file:///tmp/patch_debug.txt"
  debugFiles.organism = "file:///tmp/organism_debug.txt"
end simulation
```

### Usage (in entity blocks)
```
start patch Default
  dbg.step = debug("Patch step complete")
end patch

start organism Tree
  age.step = prior.age + 1 year
  height.step = prior.height + sample uniform from 0 m to 1 m

  dbg.step = debug("Tree age:", age, "height:", height)
end organism
```

### Expected Output
```
[Step 0, organism @ 6c1bfb54 (48.5, 23.5)] Tree age: 1 height: 0.6611
[Step 1, organism @ 6c1bfb54 (48.5, 23.5)] Tree age: 2 height: 1.2345
[Step 2, organism @ 6c1bfb54 (48.5, 23.5)] Tree age: 3 height: 1.8901
```

