### PR TITLE
[dev-restore] Timestamp for templating within TemplateStringRenderer

### DIFF
--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -945,7 +945,7 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
         String.join(" ", parts),
         step,
         info.entityCategory,
-        info.identifier, 
+        info.identifier,
         info.x,
         info.y
     );

--- a/src/main/java/org/joshsim/lang/io/JvmExportFacadeFactory.java
+++ b/src/main/java/org/joshsim/lang/io/JvmExportFacadeFactory.java
@@ -10,6 +10,9 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -30,12 +33,16 @@ import org.joshsim.util.MinioOptions;
  */
 public class JvmExportFacadeFactory implements ExportFacadeFactory {
 
+  private static final DateTimeFormatter TIMESTAMP_FORMAT =
+      DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
+
   private final int replicate;
   private final MapExportSerializeStrategy serializeStrategy;
   private final Optional<PatchBuilderExtents> extents;
   private final Optional<BigDecimal> width;
   private final TemplateStringRenderer templateRenderer;
   private final MinioOptions minioOptions;
+  private final String timestamp;
   private TemplateResult lastTemplateResult;
 
   /**
@@ -53,6 +60,7 @@ public class JvmExportFacadeFactory implements ExportFacadeFactory {
     this.replicate = replicate;
     this.templateRenderer = templateRenderer;
     this.minioOptions = minioOptions;
+    this.timestamp = TIMESTAMP_FORMAT.format(Instant.now().atZone(ZoneId.systemDefault()));
     serializeStrategy = new MapSerializeStrategy();
     extents = Optional.empty();
     width = Optional.empty();
@@ -90,6 +98,7 @@ public class JvmExportFacadeFactory implements ExportFacadeFactory {
     this.replicate = replicate;
     this.templateRenderer = templateRenderer;
     this.minioOptions = minioOptions;
+    this.timestamp = TIMESTAMP_FORMAT.format(Instant.now().atZone(ZoneId.systemDefault()));
     this.extents = Optional.of(extents);
     this.width = Optional.of(width);
     MapSerializeStrategy inner = new MapSerializeStrategy();
@@ -161,13 +170,15 @@ public class JvmExportFacadeFactory implements ExportFacadeFactory {
     if (template.contains(".tif") || template.contains(".tiff")) {
       String replicateStr = ((Integer) replicate).toString();
       String withReplicate = template.replaceAll("\\{replicate\\}", replicateStr);
-      String withStep = withReplicate.replaceAll("\\{step\\}", "__step__");
+      String withTimestamp = withReplicate.replaceAll("\\{timestamp\\}", timestamp);
+      String withStep = withTimestamp.replaceAll("\\{step\\}", "__step__");
       String withVariable = withStep.replaceAll("\\{variable\\}", "__variable__");
       return withVariable;
     }
 
     // For tabular and NetCDF formats, remove replicate template (consolidated files)
-    String withStep = template.replaceAll("\\{step\\}", "__step__");
+    String withTimestamp = template.replaceAll("\\{timestamp\\}", timestamp);
+    String withStep = withTimestamp.replaceAll("\\{step\\}", "__step__");
     String withVariable = withStep.replaceAll("\\{variable\\}", "__variable__");
     return withVariable.replaceAll("\\{replicate\\}", "");
   }

--- a/src/main/java/org/joshsim/pipeline/job/config/TemplateStringRenderer.java
+++ b/src/main/java/org/joshsim/pipeline/job/config/TemplateStringRenderer.java
@@ -11,6 +11,9 @@
 
 package org.joshsim.pipeline.job.config;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -41,9 +44,12 @@ import org.joshsim.pipeline.job.JoshJobFileInfo;
 public class TemplateStringRenderer {
 
   private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{([^}]+)\\}");
+  private static final DateTimeFormatter TIMESTAMP_FORMAT =
+      DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
 
   private final JoshJob job;
   private final int replicate;
+  private final String timestamp;
 
   /**
    * Creates a new template string renderer.
@@ -53,11 +59,27 @@ public class TemplateStringRenderer {
    * @throws IllegalArgumentException if job is null
    */
   public TemplateStringRenderer(JoshJob job, int replicate) {
+    this(job, replicate, TIMESTAMP_FORMAT.format(Instant.now().atZone(ZoneId.systemDefault())));
+  }
+
+  /**
+   * Creates a new template string renderer with a specific timestamp.
+   *
+   * <p>This constructor allows injecting a specific timestamp for testing purposes
+   * or for ensuring consistent timestamps across multiple renderers.</p>
+   *
+   * @param job The Josh job containing file mappings for template substitution
+   * @param replicate The replicate number for export-specific templates
+   * @param timestamp The timestamp string to use for {timestamp} template substitution
+   * @throws IllegalArgumentException if job is null
+   */
+  public TemplateStringRenderer(JoshJob job, int replicate, String timestamp) {
     if (job == null) {
       throw new IllegalArgumentException("JoshJob cannot be null");
     }
     this.job = job;
     this.replicate = replicate;
+    this.timestamp = timestamp;
   }
 
   /**
@@ -153,6 +175,7 @@ public class TemplateStringRenderer {
 
       // Add export-specific templates
       availableTemplates.add("{replicate}");
+      availableTemplates.add("{timestamp}");
       availableTemplates.add("{step}");
       availableTemplates.add("{variable}");
 
@@ -214,7 +237,8 @@ public class TemplateStringRenderer {
   private boolean isExportSpecificTemplate(String templateVar) {
     return "replicate".equals(templateVar)
            || "step".equals(templateVar)
-           || "variable".equals(templateVar);
+           || "variable".equals(templateVar)
+           || "timestamp".equals(templateVar);
   }
 
   /**
@@ -233,6 +257,9 @@ public class TemplateStringRenderer {
     // If {replicate} is present, replace with actual number for ALL formats
     // If {replicate} is absent, no replacement needed (consolidated files)
     result = result.replaceAll("\\{replicate\\}", Integer.toString(replicate));
+
+    // Timestamp template - replaced with consistent timestamp for the entire run
+    result = result.replaceAll("\\{timestamp\\}", timestamp);
 
     // Step and variable templates always become placeholders for later processing
     result = result.replaceAll("\\{step\\}", "__step__");

--- a/src/test/java/org/joshsim/pipeline/job/config/TemplateStringRendererStrategyTest.java
+++ b/src/test/java/org/joshsim/pipeline/job/config/TemplateStringRendererStrategyTest.java
@@ -125,7 +125,7 @@ class TemplateStringRendererStrategyTest {
 
     assertTrue(exception.getMessage().contains("Unknown template variables: {unknown}"));
     assertTrue(exception.getMessage().contains(
-        "Available: {example}, {other}, {replicate}, {step}, {variable}"));
+        "Available: {example}, {other}, {replicate}, {timestamp}, {step}, {variable}"));
   }
 
   @Test

--- a/src/test/java/org/joshsim/pipeline/job/config/TemplateStringRendererTest.java
+++ b/src/test/java/org/joshsim/pipeline/job/config/TemplateStringRendererTest.java
@@ -218,7 +218,7 @@ public class TemplateStringRendererTest {
 
     String message = exception.getMessage();
     assertTrue(message.contains("Unknown template variables: {missing}"));
-    assertTrue(message.contains("Available: {replicate}, {step}, {variable}"));
+    assertTrue(message.contains("Available: {replicate}, {timestamp}, {step}, {variable}"));
   }
 
   @Test
@@ -402,5 +402,97 @@ public class TemplateStringRendererTest {
     String result = customRenderer.renderTemplate(template).getProcessedTemplate();
 
     assertEquals("/tmp/example_1_test-env_v1.0_beta.csv", result);
+  }
+
+  @Test
+  public void testTimestampTemplateWithExplicitTimestamp() {
+    // Use the constructor with explicit timestamp for deterministic testing
+    String ts = "20260113_120000";
+    TemplateStringRenderer timestampRenderer = new TemplateStringRenderer(job, 0, ts);
+
+    String template = "/tmp/output_{timestamp}/results.csv";
+    String expected = "/tmp/output_20260113_120000/results.csv";
+    assertEquals(expected, timestampRenderer.renderTemplate(template).getProcessedTemplate());
+  }
+
+  @Test
+  public void testTimestampConsistencyAcrossMultipleCalls() {
+    // Use the constructor with explicit timestamp
+    String ts = "20260113_120000";
+    TemplateStringRenderer timestampRenderer = new TemplateStringRenderer(job, 0, ts);
+
+    String template1 = "/tmp/{timestamp}/file1.csv";
+    String template2 = "/tmp/{timestamp}/file2.csv";
+
+    String result1 = timestampRenderer.renderTemplate(template1).getProcessedTemplate();
+    String result2 = timestampRenderer.renderTemplate(template2).getProcessedTemplate();
+
+    assertEquals("/tmp/20260113_120000/file1.csv", result1);
+    assertEquals("/tmp/20260113_120000/file2.csv", result2);
+  }
+
+  @Test
+  public void testTimestampWithOtherTemplates() {
+    String ts = "20260113_143052";
+    TemplateStringRenderer timestampRenderer = new TemplateStringRenderer(job, 1, ts);
+
+    String template = "/data/{timestamp}/{example}_{replicate}.csv";
+    String expected = "/data/20260113_143052/example_1_1.csv";
+    assertEquals(expected, timestampRenderer.renderTemplate(template).getProcessedTemplate());
+  }
+
+  @Test
+  public void testTimestampWithGeotiff() {
+    String ts = "20260113_143052";
+    TemplateStringRenderer timestampRenderer = new TemplateStringRenderer(job, 2, ts);
+
+    String template = "/output/{timestamp}/result_{replicate}_{step}_{variable}.tif";
+    String expected = "/output/20260113_143052/result_2___step_____variable__.tif";
+    assertEquals(expected, timestampRenderer.renderTemplate(template).getProcessedTemplate());
+  }
+
+  @Test
+  public void testTimestampAvailableInErrorMessage() {
+    JoshJob emptyJob = new JoshJobBuilder()
+        .setReplicates(1)
+        .build();
+    TemplateStringRenderer emptyRenderer = new TemplateStringRenderer(emptyJob, 0);
+
+    String template = "/path/{missing}.csv";
+    RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+      emptyRenderer.renderTemplate(template).getProcessedTemplate();
+    });
+
+    String message = exception.getMessage();
+    assertTrue(message.contains("{timestamp}"),
+        "Error message should include {timestamp} as available template");
+  }
+
+  @Test
+  public void testTimestampMultipleOccurrences() {
+    String ts = "20260113_120000";
+    TemplateStringRenderer timestampRenderer = new TemplateStringRenderer(job, 0, ts);
+
+    String template = "/data/{timestamp}/backup_{timestamp}.csv";
+    String expected = "/data/20260113_120000/backup_20260113_120000.csv";
+    assertEquals(expected, timestampRenderer.renderTemplate(template).getProcessedTemplate());
+  }
+
+  @Test
+  public void testDefaultConstructorGeneratesTimestamp() {
+    // Test that the default constructor generates a timestamp in the expected format
+    TemplateStringRenderer defaultRenderer = new TemplateStringRenderer(job, 0);
+
+    String template = "/data/{timestamp}/output.csv";
+    String result = defaultRenderer.renderTemplate(template).getProcessedTemplate();
+
+    // Verify the timestamp was replaced (should not contain {timestamp})
+    assertTrue(!result.contains("{timestamp}"),
+        "Timestamp template should be replaced");
+
+    // Verify the format is yyyyMMdd_HHmmss (15 characters)
+    // Example: /data/20260113_120000/output.csv
+    assertTrue(result.matches("/data/\\d{8}_\\d{6}/output\\.csv"),
+        "Timestamp should match format yyyyMMdd_HHmmss");
   }
 }


### PR DESCRIPTION
`TemplateStringRenderer` was handled within #334 - this is a small update that implements `timestamp` as a valid template var, primarily to deduplicate runs within the `josh-models` repo. 