### PR TITLE
[dev-restore] reproducible / deterministic seed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -260,3 +260,25 @@ checkstyleMain.dependsOn setupCheckstyle
 
 // Require Checkstyle set up before checing test.
 checkstyleTest.dependsOn setupCheckstyle
+
+// Task to run conformance tests
+task conformanceTest(type: Test) {
+    description = 'Runs conformance tests'
+    group = 'verification'
+    
+    useJUnitPlatform()
+    
+    include 'org/joshsim/conformance/**'
+    
+    testLogging {
+        events "passed", "skipped", "failed"
+        showStandardStreams = false
+        exceptionFormat = "full"
+    }
+    
+    // Generate XML reports for analysis
+    reports {
+        junitXml.required = true
+        html.required = true
+    }
+}

--- a/src/main/java/org/joshsim/command/RunCommand.java
+++ b/src/main/java/org/joshsim/command/RunCommand.java
@@ -218,6 +218,14 @@ public class RunCommand implements Callable<Integer> {
     if (seed != null) {
       SharedRandom.initialize(seed);
       output.printInfo("Using random seed: " + seed);
+
+      // Force serial execution when seeded for deterministic results
+      // Parallel execution would cause non-deterministic random call ordering
+      if (!serialPatches) {
+        output.printInfo(
+            "Note: Forcing serial patch execution for reproducibility with --seed");
+        serialPatches = true;
+      }
     } else {
       SharedRandom.initialize(Optional.empty());
     }

--- a/src/main/java/org/joshsim/command/RunCommand.java
+++ b/src/main/java/org/joshsim/command/RunCommand.java
@@ -52,6 +52,7 @@ import org.joshsim.util.OutputOptions;
 import org.joshsim.util.OutputStepsParser;
 import org.joshsim.util.ProgressCalculator;
 import org.joshsim.util.ProgressUpdate;
+import org.joshsim.util.SharedRandom;
 import org.joshsim.util.SimulationMetadata;
 import org.joshsim.util.SimulationMetadataExtractor;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -159,6 +160,13 @@ public class RunCommand implements Callable<Integer> {
   )
   private boolean uploadData = false;
 
+  @Option(
+      names = "--seed",
+      description = "Random seed for reproducible simulations. If specified, all random "
+                  + "operations will use this seed to produce deterministic results."
+  )
+  private Long seed = null;
+
   /**
    * Parses custom parameter command-line options.
    *
@@ -204,6 +212,14 @@ public class RunCommand implements Callable<Integer> {
     if (replicates < 1) {
       output.printError("Number of replicates must be at least 1");
       return 1;
+    }
+
+    // Initialize shared random with seed for reproducibility
+    if (seed != null) {
+      SharedRandom.initialize(seed);
+      output.printInfo("Using random seed: " + seed);
+    } else {
+      SharedRandom.initialize(Optional.empty());
     }
 
     // Parse output steps early for fail-fast validation
@@ -433,6 +449,9 @@ public class RunCommand implements Callable<Integer> {
         }
       }
     }
+
+    // Clean up shared random
+    SharedRandom.clear();
 
     return 0;
   }

--- a/src/main/java/org/joshsim/engine/value/type/RealizedDistribution.java
+++ b/src/main/java/org/joshsim/engine/value/type/RealizedDistribution.java
@@ -12,9 +12,11 @@ import java.util.Collections;
 import java.util.DoubleSummaryStatistics;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 import java.util.stream.Collectors;
 import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.EngineValueCaster;
+import org.joshsim.util.SharedRandom;
 
 /**
  * Distribution with a finite number of elements.
@@ -251,7 +253,7 @@ public class RealizedDistribution extends Distribution {
   @Override
   public EngineValue sample() {
     requireNonEmpty();
-    int index = (int) (Math.random() * values.size());
+    int index = SharedRandom.nextInt(values.size());
     return values.get(index);
   }
 
@@ -392,7 +394,9 @@ public class RealizedDistribution extends Distribution {
       throw new IllegalArgumentException(message);
     }
     List<EngineValue> sampledValues = new ArrayList<>(values);
-    Collections.shuffle(sampledValues);
+    // Use SharedRandom for reproducibility
+    Random random = SharedRandom.get();
+    Collections.shuffle(sampledValues, random);
     return new RealizedDistribution(getCaster(), sampledValues.subList(0, (int) count), getUnits());
   }
 

--- a/src/main/java/org/joshsim/engine/value/type/StandardVirtualDistribution.java
+++ b/src/main/java/org/joshsim/engine/value/type/StandardVirtualDistribution.java
@@ -7,9 +7,9 @@
 package org.joshsim.engine.value.type;
 
 import java.math.BigDecimal;
-import java.util.Random;
 import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.EngineValueCaster;
+import org.joshsim.util.SharedRandom;
 
 /**
  * A normal distribution.
@@ -20,7 +20,6 @@ import org.joshsim.engine.value.engine.EngineValueCaster;
 public class StandardVirtualDistribution extends VirtualDistribution {
   private final BigDecimal mu;
   private final BigDecimal sigma;
-  private final Random random = new Random();
 
 
   /**
@@ -43,7 +42,7 @@ public class StandardVirtualDistribution extends VirtualDistribution {
    */
   @Override
   public EngineValue sample() {
-    double baseValue = random.nextGaussian();
+    double baseValue = SharedRandom.nextGaussian();
     double value = baseValue * sigma.doubleValue() + mu.doubleValue();
     return new DecimalScalar(caster, BigDecimal.valueOf(value), units);
   }

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -11,7 +11,6 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Stack;
 import org.joshsim.engine.entity.base.Entity;
 import org.joshsim.engine.entity.base.MutableEntity;
@@ -36,6 +35,7 @@ import org.joshsim.lang.interpret.mapping.MapBounds;
 import org.joshsim.lang.interpret.mapping.MapStrategy;
 import org.joshsim.lang.interpret.mapping.MappingBuilder;
 import org.joshsim.lang.io.CombinedDebugOutputFacade;
+import org.joshsim.util.SharedRandom;
 
 
 /**
@@ -56,7 +56,6 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
   private final Stack<EngineValue> memory;
   private final LocalScope scope;
   private final EngineValueFactory valueFactory;
-  private final Random random;
   private final boolean favorBigDecimal;
   private final Optional<CombinedDebugOutputFacade> debugOutputFacade;
 
@@ -93,7 +92,6 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
     valueFactory = bridge.getEngineValueFactory();
     currentValueResolver = new ValueResolver(valueFactory, "current");
     favorBigDecimal = valueFactory.isFavoringBigDecimal();
-    random = new Random();
     isEnded = false;
   }
 
@@ -566,7 +564,7 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
     if (Math.abs(maxDouble - minDouble) < 1e-7) {
       doubleResult = minDouble;
     } else {
-      doubleResult = random.nextDouble(minDouble, maxDouble);
+      doubleResult = SharedRandom.nextDouble(minDouble, maxDouble);
     }
 
     EngineValue decoratedResult = valueFactory.buildForNumber(doubleResult, min.getUnits());
@@ -584,7 +582,7 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
 
     double meanDouble = mean.getAsDouble();
     double stdDouble = std.getAsDouble();
-    double randGauss = random.nextGaussian(meanDouble, stdDouble);
+    double randGauss = SharedRandom.nextGaussian(meanDouble, stdDouble);
 
     EngineValue result = valueFactory.buildForNumber(randGauss, mean.getUnits());
     memory.push(result);

--- a/src/main/java/org/joshsim/util/SharedRandom.java
+++ b/src/main/java/org/joshsim/util/SharedRandom.java
@@ -1,0 +1,177 @@
+/**
+ * Thread-local shared random number generator for reproducible simulations.
+ *
+ * <p>Provides a centralized random number generator that can be seeded for
+ * reproducible simulation results. Uses ThreadLocal storage to ensure thread
+ * safety while maintaining consistent random sequences within each thread.</p>
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.util;
+
+import java.util.Optional;
+import java.util.Random;
+
+
+/**
+ * Utility class for managing a shared Random instance across simulation components.
+ *
+ * <p>This class provides thread-local storage for a Random instance that can be
+ * seeded at simulation start for reproducible results. All simulation components
+ * that need random numbers should use this class instead of creating their own
+ * Random instances.</p>
+ *
+ * <p>Usage pattern:
+ * <pre>
+ * // At simulation start
+ * SharedRandom.initialize(Optional.of(42L));
+ *
+ * // In simulation code
+ * double value = SharedRandom.get().nextDouble();
+ *
+ * // At simulation end (cleanup)
+ * SharedRandom.clear();
+ * </pre>
+ * </p>
+ */
+public final class SharedRandom {
+
+  private static final ThreadLocal<Random> THREAD_LOCAL_RANDOM = new ThreadLocal<>();
+  private static final ThreadLocal<Optional<Long>> THREAD_LOCAL_SEED = new ThreadLocal<>();
+
+  private SharedRandom() {
+    // Utility class - prevent instantiation
+  }
+
+  /**
+   * Initialize the shared random number generator for the current thread.
+   *
+   * <p>If a seed is provided, creates a seeded Random for reproducible results.
+   * If no seed is provided, creates an unseeded Random with default behavior.</p>
+   *
+   * @param seed Optional seed value. If present, the Random will be seeded for reproducibility.
+   */
+  public static void initialize(Optional<Long> seed) {
+    if (seed.isPresent()) {
+      THREAD_LOCAL_RANDOM.set(new Random(seed.get()));
+      THREAD_LOCAL_SEED.set(seed);
+    } else {
+      THREAD_LOCAL_RANDOM.set(new Random());
+      THREAD_LOCAL_SEED.set(Optional.empty());
+    }
+  }
+
+  /**
+   * Initialize the shared random number generator with a specific seed.
+   *
+   * @param seed The seed value for reproducible random sequences.
+   */
+  public static void initialize(long seed) {
+    initialize(Optional.of(seed));
+  }
+
+  /**
+   * Get the shared Random instance for the current thread.
+   *
+   * <p>If initialize() has not been called, creates a default unseeded Random.
+   * This ensures backward compatibility with code that doesn't explicitly
+   * initialize the shared random.</p>
+   *
+   * @return The shared Random instance for the current thread.
+   */
+  public static Random get() {
+    Random random = THREAD_LOCAL_RANDOM.get();
+    if (random == null) {
+      // Lazy initialization with default unseeded Random
+      random = new Random();
+      THREAD_LOCAL_RANDOM.set(random);
+      THREAD_LOCAL_SEED.set(Optional.empty());
+    }
+    return random;
+  }
+
+  /**
+   * Check if the shared random has been initialized with a seed.
+   *
+   * @return true if a seed was provided during initialization, false otherwise.
+   */
+  public static boolean isSeeded() {
+    Optional<Long> seed = THREAD_LOCAL_SEED.get();
+    return seed != null && seed.isPresent();
+  }
+
+  /**
+   * Get the seed used for initialization, if any.
+   *
+   * @return Optional containing the seed if one was provided, empty otherwise.
+   */
+  public static Optional<Long> getSeed() {
+    Optional<Long> seed = THREAD_LOCAL_SEED.get();
+    return seed != null ? seed : Optional.empty();
+  }
+
+  /**
+   * Clear the shared random instance for the current thread.
+   *
+   * <p>Should be called at the end of simulation runs to clean up thread-local
+   * storage and prevent memory leaks.</p>
+   */
+  public static void clear() {
+    THREAD_LOCAL_RANDOM.remove();
+    THREAD_LOCAL_SEED.remove();
+  }
+
+  /**
+   * Generate a random double using the shared Random.
+   *
+   * <p>Convenience method equivalent to get().nextDouble().</p>
+   *
+   * @return A random double between 0.0 (inclusive) and 1.0 (exclusive).
+   */
+  public static double nextDouble() {
+    return get().nextDouble();
+  }
+
+  /**
+   * Generate a random double in a range using the shared Random.
+   *
+   * @param min The minimum value (inclusive).
+   * @param max The maximum value (exclusive).
+   * @return A random double between min and max.
+   */
+  public static double nextDouble(double min, double max) {
+    return get().nextDouble(min, max);
+  }
+
+  /**
+   * Generate a random integer using the shared Random.
+   *
+   * @param bound The upper bound (exclusive).
+   * @return A random integer between 0 (inclusive) and bound (exclusive).
+   */
+  public static int nextInt(int bound) {
+    return get().nextInt(bound);
+  }
+
+  /**
+   * Generate a Gaussian-distributed random double using the shared Random.
+   *
+   * @return A random double from a Gaussian distribution with mean 0 and std 1.
+   */
+  public static double nextGaussian() {
+    return get().nextGaussian();
+  }
+
+  /**
+   * Generate a Gaussian-distributed random double with specified parameters.
+   *
+   * @param mean The mean of the distribution.
+   * @param stddev The standard deviation of the distribution.
+   * @return A random double from the specified Gaussian distribution.
+   */
+  public static double nextGaussian(double mean, double stddev) {
+    return get().nextGaussian(mean, stddev);
+  }
+
+}


### PR DESCRIPTION
This PR introduces `seed` functionality, such that single-threaded simulations (more on that below) will be deterministic. Important for testing and reproducibility!

Without more complication it would be difficult to align these across threads, primarily because due to our assumptions of the grid (basically that all patches can see their own state and the entire system at the previous timestep - we use a parallel stream to execute patches in parallel and thus don't really control their activation order). There are some approaches that would probably work there, but for now the primary use case is to enable deterministic integration / conformance tests without relying on the central limit theorem / law of large numbers to save us :sweat_smile:  

```
java -jar joshsim-fat.jar run simulation.josh Main --seed 42
```