### PR TITLE
[dev-restore] Lambda scope for filter expressions (port PR #314)

### DIFF
--- a/src/main/java/org/joshsim/engine/func/LocalScope.java
+++ b/src/main/java/org/joshsim/engine/func/LocalScope.java
@@ -84,6 +84,28 @@ public class LocalScope implements Scope {
   }
 
   /**
+   * Defines a constant value in the local scope, allowing shadowing of parent scope variables.
+   *
+   * <p>Unlike {@link #defineConstant}, this method only checks if the variable exists in this
+   * local scope, not in the parent scope. This allows temporarily shadowing variables from
+   * enclosing scopes, which is useful for filter expressions where the type name needs to
+   * be bound to the subject distribution.</p>
+   *
+   * @param name The name of the constant to define within this LocalScope.
+   * @param value The value to associate with the constant within this LocalScope.
+   * @throws RuntimeException if a variable with the given name already exists in this local scope.
+   */
+  public void defineConstantAllowShadowing(String name, EngineValue value) {
+    if (localValues.containsKey(name)) {
+      String message =
+          String.format("The variable %s already exists in this local scope.", name);
+      throw new RuntimeException(message);
+    }
+
+    localValues.put(name, value);
+  }
+
+  /**
    * Determine what values are on this scope.
    *
    * @return all attributes within this scope.

--- a/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
@@ -585,4 +585,28 @@ public interface EventHandlerMachine {
    * @return Reference to this machine for chaining.
    */
   EventHandlerMachine debugVariadic(int argCount);
+
+  /**
+   * Peek at the top value on the stack without removing it.
+   *
+   * <p>Returns the value at the top of the stack without popping it. This is useful
+   * for inspecting values before operations that need the value to remain on the stack.</p>
+   *
+   * @return The value at the top of the stack.
+   */
+  EngineValue peek();
+
+  /**
+   * Execute an action with a temporary local binding in scope.
+   *
+   * <p>Creates a nested scope with the given name bound to the given value, executes
+   * the provided action within that scope, then restores the original scope. This is
+   * useful for filter expressions where the type name needs to be temporarily bound
+   * to the subject distribution being filtered.</p>
+   *
+   * @param name The name to bind in the temporary scope.
+   * @param value The value to bind to the name.
+   * @param action The action to execute with the binding in scope.
+   */
+  void withLocalBinding(String name, EngineValue value, Runnable action);
 }

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -54,7 +54,7 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
 
   private final EngineBridge bridge;
   private final Stack<EngineValue> memory;
-  private final LocalScope scope;
+  private LocalScope scope;  // Mutable to allow temporary scope swapping in withLocalBinding
   private final EngineValueFactory valueFactory;
   private final boolean favorBigDecimal;
   private final Optional<CombinedDebugOutputFacade> debugOutputFacade;
@@ -1156,6 +1156,29 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
    */
   private boolean isQueryForPatch(ValueResolver resolver, String patchName) {
     return resolver.toString().contains("ValueResolver(" + patchName + ")");
+  }
+
+  @Override
+  public EngineValue peek() {
+    return memory.peek();
+  }
+
+  @Override
+  public void withLocalBinding(String name, EngineValue value, Runnable action) {
+    // Create nested local scope that allows shadowing parent scope variables
+    LocalScope nestedScope = new LocalScope(scope);
+    nestedScope.defineConstantAllowShadowing(name, value);
+
+    // Temporarily switch to nested scope
+    LocalScope originalScope = this.scope;
+    this.scope = nestedScope;
+
+    try {
+      action.run();
+    } finally {
+      // Always restore original scope, even if action throws
+      this.scope = originalScope;
+    }
   }
 
 }

--- a/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitor.java
@@ -42,6 +42,10 @@ public class JoshDistributionVisitor implements JoshVisitorDelegate {
   /**
    * Parse a slice expression.
    *
+   * <p>Handles filter expressions like {@code Trees[Tree.age > 5 years]} by temporarily
+   * binding the type name (e.g., "Tree") to the subject distribution within the scope
+   * where the filter expression is evaluated.</p>
+   *
    * @param ctx The ANTLR context from which to parse the slice expression.
    * @return JoshFragment containing the slice expression parsed.
    */
@@ -51,7 +55,16 @@ public class JoshDistributionVisitor implements JoshVisitorDelegate {
 
     EventHandlerAction action = (machine) -> {
       subjectAction.apply(machine);
-      selectionAction.apply(machine);
+
+      // Extract type name and bind to local scope for filter expressions
+      EngineValue subject = machine.peek();
+      String typeName = subject.getLanguageType().getRootType();
+
+      // Evaluate selection with type name bound to subject distribution
+      machine.withLocalBinding(typeName, subject, () -> {
+        selectionAction.apply(machine);
+      });
+
       return machine.slice();
     };
 

--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitorTest.java
@@ -2,6 +2,9 @@ package org.joshsim.lang.interpret.visitor.delegates;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -9,6 +12,7 @@ import static org.mockito.Mockito.when;
 import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.EngineValueFactory;
 import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.engine.value.type.LanguageType;
 import org.joshsim.lang.antlr.JoshLangParser.ExpressionContext;
 import org.joshsim.lang.antlr.JoshLangParser.NormalSampleContext;
 import org.joshsim.lang.antlr.JoshLangParser.SampleParamContext;
@@ -76,9 +80,25 @@ class JoshDistributionVisitorTest {
     EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
     when(mockMachine.slice()).thenReturn(mockMachine);
 
+    // Mock peek() to return a subject value with language type
+    EngineValue subjectValue = mock(EngineValue.class);
+    LanguageType languageType = mock(LanguageType.class);
+    when(mockMachine.peek()).thenReturn(subjectValue);
+    when(subjectValue.getLanguageType()).thenReturn(languageType);
+    when(languageType.getRootType()).thenReturn("Tree");
+
+    // Mock withLocalBinding to actually invoke the runnable
+    doAnswer(invocation -> {
+      Runnable runnable = invocation.getArgument(2);
+      runnable.run();
+      return null;
+    }).when(mockMachine).withLocalBinding(eq("Tree"), eq(subjectValue), any(Runnable.class));
+
     action.apply(mockMachine);
 
     verify(subjectAction).apply(mockMachine);
+    verify(mockMachine).peek();
+    verify(mockMachine).withLocalBinding(eq("Tree"), eq(subjectValue), any(Runnable.class));
     verify(selectionAction).apply(mockMachine);
     verify(mockMachine).slice();
   }


### PR DESCRIPTION
Port the lambda scope fix from dev branch (PR #314) to resolve ValueResolver errors in collection filter expressions like:
  Trees[Tree.age > 5 years]

Previously, Tree.age could not be resolved inside the filter brackets because "Tree" was not in scope during filter evaluation.

Changes:
- LocalScope: Add defineConstantAllowShadowing() to allow temporary shadowing of parent scope variables during filter evaluation
- EventHandlerMachine: Add peek() and withLocalBinding() interface methods
- SingleThreadEventHandlerMachine: Implement peek() and withLocalBinding() with proper scope management using try-finally
- JoshDistributionVisitor: Update visitSlice() to bind the type name (e.g., "Tree") to the subject distribution before evaluating the filter expression
