### PR TITLE
[dev-restore] meta synthetic vars (`stepCount` and `year`) 

### DIFF
--- a/josh-tests/conformance/temporal/queries/test_temporal_queries_meta.josh
+++ b/josh-tests/conformance/temporal/queries/test_temporal_queries_meta.josh
@@ -1,7 +1,7 @@
 # @category: temporal
 # @subcategory: queries
 # @priority: critical
-# @description: Test temporal metadata (meta.year, meta.step, meta.stepCount)
+# @description: Test temporal metadata (meta.year, meta.stepCount)
 
 start simulation TemporalQueriesMeta
 
@@ -15,8 +15,7 @@ start simulation TemporalQueriesMeta
   steps.low = 2020 year
   steps.high = 2024 year
 
-  stepCount.init = 0 count
-  stepCount.step = prior.stepCount + 1 count
+  # NOTE: Do NOT define stepCount here - we want to test the built-in meta.stepCount
 
 end simulation
 
@@ -29,27 +28,17 @@ start patch Default
   recordedYear.init = 0 year
   recordedYear.step = meta.year
 
-  recordedStep.init = 0 year
-  recordedStep.step = meta.step
-
   recordedStepCount.init = 0 count
   recordedStepCount.step = meta.stepCount
 
-  # Assert meta.year matches expected values
+  # Assert meta.year matches expected values (current simulation year)
   assert.yearStep0.step:if(meta.stepCount == 0 count) = meta.year == 2020 years
   assert.yearStep1.step:if(meta.stepCount == 1 count) = meta.year == 2021 years
   assert.yearStep2.step:if(meta.stepCount == 2 count) = meta.year == 2022 years
   assert.yearStep3.step:if(meta.stepCount == 3 count) = meta.year == 2023 years
   assert.yearStep4.step:if(meta.stepCount == 4 count) = meta.year == 2024 years
 
-  # Assert meta.step matches meta.year (they should be the same)
-  assert.stepEqualsYearStep0.step:if(meta.stepCount == 0 count) = meta.step == 2020 years
-  assert.stepEqualsYearStep1.step:if(meta.stepCount == 1 count) = meta.step == 2021 years
-  assert.stepEqualsYearStep2.step:if(meta.stepCount == 2 count) = meta.step == 2022 years
-  assert.stepEqualsYearStep3.step:if(meta.stepCount == 3 count) = meta.step == 2023 years
-  assert.stepEqualsYearStep4.step:if(meta.stepCount == 4 count) = meta.step == 2024 years
-
-  # Assert meta.stepCount increases from 0
+  # Assert meta.stepCount increases from 0 (0-based step counter)
   assert.stepCountStep0.step:if(meta.year == 2020 years) = meta.stepCount == 0 count
   assert.stepCountStep1.step:if(meta.year == 2021 years) = meta.stepCount == 1 count
   assert.stepCountStep2.step:if(meta.year == 2022 years) = meta.stepCount == 2 count
@@ -61,11 +50,6 @@ start patch Default
   assert.recordedYearStep2.step:if(meta.stepCount == 2 count) = current.recordedYear == 2022 years
   assert.recordedYearStep3.step:if(meta.stepCount == 3 count) = current.recordedYear == 2023 years
   assert.recordedYearStep4.step:if(meta.stepCount == 4 count) = current.recordedYear == 2024 years
-
-  assert.recordedStepStep1.step:if(meta.stepCount == 1 count) = current.recordedStep == 2021 years
-  assert.recordedStepStep2.step:if(meta.stepCount == 2 count) = current.recordedStep == 2022 years
-  assert.recordedStepStep3.step:if(meta.stepCount == 3 count) = current.recordedStep == 2023 years
-  assert.recordedStepStep4.step:if(meta.stepCount == 4 count) = current.recordedStep == 2024 years
 
   assert.recordedStepCountStep1.step:if(meta.stepCount == 1 count) = current.recordedStepCount == 1 count
   assert.recordedStepCountStep2.step:if(meta.stepCount == 2 count) = current.recordedStepCount == 2 count
@@ -132,4 +116,7 @@ end unit
 start unit m
   alias meter
   alias meters
+end unit
+
+start unit count
 end unit

--- a/src/main/java/org/joshsim/lang/interpret/ValueResolver.java
+++ b/src/main/java/org/joshsim/lang/interpret/ValueResolver.java
@@ -170,6 +170,15 @@ public class ValueResolver {
     return entityScope.getOptional(index);
   }
 
+  /**
+   * Get the path being resolved.
+   *
+   * @return the dot-separated path string.
+   */
+  public String getPath() {
+    return path;
+  }
+
   @Override
   public String toString() {
     return String.format("ValueResolver(%s)", path);

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -97,11 +97,26 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
 
   @Override
   public EventHandlerMachine push(ValueResolver valueResolver) {
+    String path = valueResolver.getPath();
+
+    // Try normal resolution first
     Optional<EngineValue> value = valueResolver.get(scope);
-    memory.push(value.orElseThrow(
-        () -> new IllegalStateException("Unable to get value for " + valueResolver)
-    ));
-    return this;
+    if (value.isPresent()) {
+      memory.push(value.get());
+      return this;
+    }
+
+    // Fall back to built-in meta attributes (e.g., meta.year, meta.stepCount)
+    if (path.startsWith("meta.")) {
+      String attrName = path.substring(5); // Remove "meta." prefix
+      Optional<EngineValue> builtin = getBuiltinMetaAttribute(attrName);
+      if (builtin.isPresent()) {
+        memory.push(builtin.get());
+        return this;
+      }
+    }
+
+    throw new IllegalStateException("Unable to get value for " + valueResolver);
   }
 
   @Override
@@ -545,9 +560,46 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
   public EventHandlerMachine pushAttribute(ValueResolver resolver) {
     Entity entity = pop().getAsEntity();
     Scope scope = new EntityScope(entity);
-    EngineValue attributeValue = resolver.get(scope).orElseThrow();
-    memory.push(attributeValue);
-    return this;
+
+    // Try normal resolution first
+    Optional<EngineValue> value = resolver.get(scope);
+    if (value.isPresent()) {
+      memory.push(value.get());
+      return this;
+    }
+
+    // Fall back to built-in meta attributes on simulation entity
+    if (entity.getEntityType() == EntityType.SIMULATION) {
+      Optional<EngineValue> builtin = getBuiltinMetaAttribute(resolver.getPath());
+      if (builtin.isPresent()) {
+        memory.push(builtin.get());
+        return this;
+      }
+    }
+
+    throw new IllegalStateException("Unable to get attribute " + resolver.getPath()
+        + " from " + entity.getName());
+  }
+
+  /**
+   * Get a built-in meta attribute value if the name matches a built-in.
+   *
+   * <p>Built-in meta attributes are available without user definition per the language spec:
+   * meta.stepCount (0-based step counter), meta.year/meta.step (current step value).</p>
+   *
+   * @param name the attribute name to check.
+   * @return Optional containing the value if it's a built-in, empty otherwise.
+   */
+  private Optional<EngineValue> getBuiltinMetaAttribute(String name) {
+    return switch (name) {
+      case "stepCount" -> Optional.of(
+          valueFactory.build(bridge.getAbsoluteTimestep(), COUNT_UNITS)
+      );
+      case "year" -> Optional.of(
+          valueFactory.build(bridge.getCurrentTimestep(), Units.of("years"))
+      );
+      default -> Optional.empty();
+    };
   }
 
   @Override


### PR DESCRIPTION
We now expose `meta.year` and `meta.stepCount` as synthetic vars, which don't need to be defined by the user, as defined in `LanguageSpecification.md`.

`meta.stepCount` resolves to absolute timestep -> 0, 1, 2
`meta.year` resolves to current simulation year if defined -> 2025, 2026, 2027
