### PR TITLE
[dev-restore] Valid count on boolean distribution

### DIFF
--- a/LanguageSpecification.md
+++ b/LanguageSpecification.md
@@ -1439,7 +1439,7 @@ start patch Default
   Fire.step = {
     const count = 1 count if (sample uniform from 0% to 100% < 5%) else 0 count
     const new = create count of Fire
-    return prior.Fire + new;
+    return prior.Fire | new;
   }
 
 end patch

--- a/src/main/java/org/joshsim/engine/value/type/EngineValue.java
+++ b/src/main/java/org/joshsim/engine/value/type/EngineValue.java
@@ -55,6 +55,18 @@ public abstract class EngineValue {
   public abstract Optional<Integer> getSize();
 
   /**
+   * Get the count of elements in this value.
+   *
+   * <p>For scalars and entities, this returns 1. For distributions, this returns
+   * the number of elements. For boolean distributions, this returns the count
+   * of TRUE values.</p>
+   *
+   * @return the count of elements
+   * @throws UnsupportedOperationException if count is not defined (e.g., virtual distributions)
+   */
+  public abstract long getCount();
+
+  /**
    * Convert this EngineValue to a Scalar.
    *
    * <p>Convert this EngineValue to a Scalar such that Scalars return themselves unchanged while
@@ -443,6 +455,57 @@ public abstract class EngineValue {
   }
 
   /**
+   * Perform logical AND operation with another engine value.
+   *
+   * @param other The other engine value.
+   * @return EngineValue with a single boolean if both are scalars or a distribution of boolean
+   *     values for element-wise AND if either is a distribution.
+   */
+  public EngineValue and(EngineValue other) {
+    if (getLanguageType().isDistribution()) {
+      return unsafeAnd(other);
+    } else if (other.getLanguageType().isDistribution()) {
+      return other.unsafeAnd(this);
+    } else {
+      return unsafeAnd(other);
+    }
+  }
+
+  /**
+   * Perform logical OR operation with another engine value.
+   *
+   * @param other The other engine value.
+   * @return EngineValue with a single boolean if both are scalars or a distribution of boolean
+   *     values for element-wise OR if either is a distribution.
+   */
+  public EngineValue or(EngineValue other) {
+    if (getLanguageType().isDistribution()) {
+      return unsafeOr(other);
+    } else if (other.getLanguageType().isDistribution()) {
+      return other.unsafeOr(this);
+    } else {
+      return unsafeOr(other);
+    }
+  }
+
+  /**
+   * Perform logical XOR operation with another engine value.
+   *
+   * @param other The other engine value.
+   * @return EngineValue with a single boolean if both are scalars or a distribution of boolean
+   *     values for element-wise XOR if either is a distribution.
+   */
+  public EngineValue xor(EngineValue other) {
+    if (getLanguageType().isDistribution()) {
+      return unsafeXor(other);
+    } else if (other.getLanguageType().isDistribution()) {
+      return other.unsafeXor(this);
+    } else {
+      return unsafeXor(other);
+    }
+  }
+
+  /**
    * Add this value to another value assuming that the units and type are compatible.
    *
    * @param other the other value.
@@ -587,6 +650,33 @@ public abstract class EngineValue {
    * @throws IllegalArgumentException if units are incompatible.
    */
   protected abstract EngineValue unsafeNotEqualTo(EngineValue other);
+
+  /**
+   * Perform logical AND with another value.
+   *
+   * @param other the other value.
+   * @return the result of the logical AND operation.
+   * @throws UnsupportedOperationException if the operation is not supported for this data type.
+   */
+  protected abstract EngineValue unsafeAnd(EngineValue other);
+
+  /**
+   * Perform logical OR with another value.
+   *
+   * @param other the other value.
+   * @return the result of the logical OR operation.
+   * @throws UnsupportedOperationException if the operation is not supported for this data type.
+   */
+  protected abstract EngineValue unsafeOr(EngineValue other);
+
+  /**
+   * Perform logical XOR with another value.
+   *
+   * @param other the other value.
+   * @return the result of the logical XOR operation.
+   * @throws UnsupportedOperationException if the operation is not supported for this data type.
+   */
+  protected abstract EngineValue unsafeXor(EngineValue other);
 
   /**
    * Determine if this value can be used to raise another value to a power.

--- a/src/main/java/org/joshsim/engine/value/type/EntityValue.java
+++ b/src/main/java/org/joshsim/engine/value/type/EntityValue.java
@@ -40,6 +40,11 @@ public class EntityValue extends EngineValue {
   }
 
   @Override
+  public long getCount() {
+    return 1;
+  }
+
+  @Override
   public Scalar getAsScalar() {
     throw new UnsupportedOperationException("Entity conversion to scalar is not defined.");
   }
@@ -172,6 +177,21 @@ public class EntityValue extends EngineValue {
   @Override
   protected EngineValue unsafeNotEqualTo(EngineValue other) {
     throw new UnsupportedOperationException("Entity comparison is not defined.");
+  }
+
+  @Override
+  protected EngineValue unsafeAnd(EngineValue other) {
+    throw new UnsupportedOperationException("Entity logical AND is not defined.");
+  }
+
+  @Override
+  protected EngineValue unsafeOr(EngineValue other) {
+    throw new UnsupportedOperationException("Entity logical OR is not defined.");
+  }
+
+  @Override
+  protected EngineValue unsafeXor(EngineValue other) {
+    throw new UnsupportedOperationException("Entity logical XOR is not defined.");
   }
 
   @Override

--- a/src/main/java/org/joshsim/engine/value/type/RealizedDistribution.java
+++ b/src/main/java/org/joshsim/engine/value/type/RealizedDistribution.java
@@ -201,6 +201,93 @@ public class RealizedDistribution extends Distribution {
   }
 
   @Override
+  protected EngineValue unsafeAnd(EngineValue other) {
+    if (other.getLanguageType().isDistribution()) {
+      // Element-wise AND with another distribution
+      List<EngineValue> otherValues = ((RealizedDistribution) other.getAsDistribution()).values;
+      if (values.size() != otherValues.size()) {
+        throw new IllegalArgumentException(
+            "Cannot perform element-wise AND on distributions of different sizes: "
+            + values.size() + " vs " + otherValues.size());
+      }
+      List<EngineValue> result = new ArrayList<>(values.size());
+      for (int i = 0; i < values.size(); i++) {
+        boolean andResult = values.get(i).getAsBoolean() && otherValues.get(i).getAsBoolean();
+        result.add(new BooleanScalar(getCaster(), andResult, Units.EMPTY));
+      }
+      return new RealizedDistribution(getCaster(), result, Units.EMPTY);
+    } else {
+      // AND each element with a scalar
+      boolean otherBool = other.getAsBoolean();
+      List<EngineValue> result = values.stream()
+          .map(value -> {
+            boolean andResult = value.getAsBoolean() && otherBool;
+            return new BooleanScalar(getCaster(), andResult, Units.EMPTY);
+          })
+          .collect(Collectors.toCollection(ArrayList::new));
+      return new RealizedDistribution(getCaster(), result, Units.EMPTY);
+    }
+  }
+
+  @Override
+  protected EngineValue unsafeOr(EngineValue other) {
+    if (other.getLanguageType().isDistribution()) {
+      // Element-wise OR with another distribution
+      List<EngineValue> otherValues = ((RealizedDistribution) other.getAsDistribution()).values;
+      if (values.size() != otherValues.size()) {
+        throw new IllegalArgumentException(
+            "Cannot perform element-wise OR on distributions of different sizes: "
+            + values.size() + " vs " + otherValues.size());
+      }
+      List<EngineValue> result = new ArrayList<>(values.size());
+      for (int i = 0; i < values.size(); i++) {
+        boolean orResult = values.get(i).getAsBoolean() || otherValues.get(i).getAsBoolean();
+        result.add(new BooleanScalar(getCaster(), orResult, Units.EMPTY));
+      }
+      return new RealizedDistribution(getCaster(), result, Units.EMPTY);
+    } else {
+      // OR each element with a scalar
+      boolean otherBool = other.getAsBoolean();
+      List<EngineValue> result = values.stream()
+          .map(value -> {
+            boolean orResult = value.getAsBoolean() || otherBool;
+            return new BooleanScalar(getCaster(), orResult, Units.EMPTY);
+          })
+          .collect(Collectors.toCollection(ArrayList::new));
+      return new RealizedDistribution(getCaster(), result, Units.EMPTY);
+    }
+  }
+
+  @Override
+  protected EngineValue unsafeXor(EngineValue other) {
+    if (other.getLanguageType().isDistribution()) {
+      // Element-wise XOR with another distribution
+      List<EngineValue> otherValues = ((RealizedDistribution) other.getAsDistribution()).values;
+      if (values.size() != otherValues.size()) {
+        throw new IllegalArgumentException(
+            "Cannot perform element-wise XOR on distributions of different sizes: "
+            + values.size() + " vs " + otherValues.size());
+      }
+      List<EngineValue> result = new ArrayList<>(values.size());
+      for (int i = 0; i < values.size(); i++) {
+        boolean xorResult = values.get(i).getAsBoolean() ^ otherValues.get(i).getAsBoolean();
+        result.add(new BooleanScalar(getCaster(), xorResult, Units.EMPTY));
+      }
+      return new RealizedDistribution(getCaster(), result, Units.EMPTY);
+    } else {
+      // XOR each element with a scalar
+      boolean otherBool = other.getAsBoolean();
+      List<EngineValue> result = values.stream()
+          .map(value -> {
+            boolean xorResult = value.getAsBoolean() ^ otherBool;
+            return new BooleanScalar(getCaster(), xorResult, Units.EMPTY);
+          })
+          .collect(Collectors.toCollection(ArrayList::new));
+      return new RealizedDistribution(getCaster(), result, Units.EMPTY);
+    }
+  }
+
+  @Override
   public Scalar getAsScalar() {
     throw new UnsupportedOperationException("Cannot convert multiple values to a single scalar.");
   }
@@ -265,6 +352,16 @@ public class RealizedDistribution extends Distribution {
   @Override
   public Optional<Integer> getSize() {
     return Optional.of(values.size());
+  }
+
+  @Override
+  public long getCount() {
+    if (getLanguageType().getRootType().equals("boolean")) {
+      return values.stream()
+          .filter(EngineValue::getAsBoolean)
+          .count();
+    }
+    return values.size();
   }
 
   @Override

--- a/src/main/java/org/joshsim/engine/value/type/Scalar.java
+++ b/src/main/java/org/joshsim/engine/value/type/Scalar.java
@@ -34,6 +34,11 @@ public abstract class Scalar extends EngineValue implements Comparable<Scalar> {
     return Optional.of(1);
   }
 
+  @Override
+  public long getCount() {
+    return 1;
+  }
+
   /**
    * Converts this Scalar into a Distribution.
    *
@@ -228,6 +233,24 @@ public abstract class Scalar extends EngineValue implements Comparable<Scalar> {
   @Override
   protected EngineValue unsafeNotEqualTo(EngineValue other) {
     boolean result = getInnerValue().compareTo(other.getInnerValue()) != 0;
+    return new BooleanScalar(caster, result, Units.EMPTY);
+  }
+
+  @Override
+  protected EngineValue unsafeAnd(EngineValue other) {
+    boolean result = getAsBoolean() && other.getAsBoolean();
+    return new BooleanScalar(caster, result, Units.EMPTY);
+  }
+
+  @Override
+  protected EngineValue unsafeOr(EngineValue other) {
+    boolean result = getAsBoolean() || other.getAsBoolean();
+    return new BooleanScalar(caster, result, Units.EMPTY);
+  }
+
+  @Override
+  protected EngineValue unsafeXor(EngineValue other) {
+    boolean result = getAsBoolean() ^ other.getAsBoolean();
     return new BooleanScalar(caster, result, Units.EMPTY);
   }
 

--- a/src/main/java/org/joshsim/engine/value/type/VirtualDistribution.java
+++ b/src/main/java/org/joshsim/engine/value/type/VirtualDistribution.java
@@ -155,6 +155,11 @@ public abstract class VirtualDistribution extends Distribution {
   }
 
   @Override
+  public long getCount() {
+    throw new UnsupportedOperationException("Cannot count a virtualized distribution.");
+  }
+
+  @Override
   public Scalar getAsScalar() {
     return sample().getAsScalar();
   }
@@ -276,6 +281,24 @@ public abstract class VirtualDistribution extends Distribution {
   protected EngineValue unsafeNotEqualTo(EngineValue other) {
     RealizedDistribution realized = realizeToMatchOther(other);
     return realized.unsafeNotEqualTo(other);
+  }
+
+  @Override
+  protected EngineValue unsafeAnd(EngineValue other) {
+    RealizedDistribution realized = realizeToMatchOther(other);
+    return realized.unsafeAnd(other);
+  }
+
+  @Override
+  protected EngineValue unsafeOr(EngineValue other) {
+    RealizedDistribution realized = realizeToMatchOther(other);
+    return realized.unsafeOr(other);
+  }
+
+  @Override
+  protected EngineValue unsafeXor(EngineValue other) {
+    RealizedDistribution realized = realizeToMatchOther(other);
+    return realized.unsafeXor(other);
   }
 
 }

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -244,9 +244,8 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
     EngineValue left = pop();
     endConversionGroup();
 
-    boolean result = right.getAsBoolean() && left.getAsBoolean();
-    EngineValue resultDecorated = valueFactory.build(result, EMPTY_UNITS);
-    memory.push(resultDecorated);
+    EngineValue result = left.and(right);
+    memory.push(result);
 
     return this;
   }
@@ -258,9 +257,8 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
     EngineValue left = pop();
     endConversionGroup();
 
-    boolean result = right.getAsBoolean() || left.getAsBoolean();
-    EngineValue resultDecorated = valueFactory.build(result, EMPTY_UNITS);
-    memory.push(resultDecorated);
+    EngineValue result = left.or(right);
+    memory.push(result);
 
     return this;
   }
@@ -272,9 +270,8 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
     EngineValue left = pop();
     endConversionGroup();
 
-    boolean result = right.getAsBoolean() ^ left.getAsBoolean();
-    EngineValue resultDecorated = valueFactory.build(result, EMPTY_UNITS);
-    memory.push(resultDecorated);
+    EngineValue result = left.xor(right);
+    memory.push(result);
 
     return this;
   }
@@ -769,14 +766,7 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
   @Override
   public EventHandlerMachine count() {
     EngineValue value = pop();
-    Distribution distribution = value.getAsDistribution();
-    Optional<Integer> size = distribution.getSize();
-
-    if (!size.isPresent()) {
-      throw new IllegalArgumentException("Cannot count a virtualized distribution.");
-    }
-
-    EngineValue result = valueFactory.build(size.get(), EMPTY_UNITS);
+    EngineValue result = valueFactory.build(value.getCount(), EMPTY_UNITS);
     memory.push(result);
     return this;
   }


### PR DESCRIPTION
Previously we were dealing with a bug where boolean distrubutions were incorrectly returning size rather than number of `true` values in a `count`:

```
oldTreeCount.step = count(here.Trees.age > 50 years)
```

Rather than return the number of trues, the number of trees total was returned, which is not the intended behavior. 

Additionally, something like: 

```
middleAgedCount.step = count(here.Trees.age >= 25 years and here.Trees.age < 75 years)
```

Was returning 0 or 1, stochastically, because of a vestige of earlier times (rather than element-wise AND, it was sampling a single value - similar solution to #314). 