### PR TITLE
[dev-restore] Built-ins for 'here'

### DIFF
--- a/josh-tests/conformance/spatial/patches/test_spatial_patches_heterogeneous.josh
+++ b/josh-tests/conformance/spatial/patches/test_spatial_patches_heterogeneous.josh
@@ -1,22 +1,16 @@
 # @category: spatial
 # @subcategory: patches
 # @priority: medium
-# @description: Test heterogeneous grid with multiple patch types and different behaviors
+# @description: Test heterogeneous grid with state-based patch types and different behaviors
 
 start simulation SpatialPatchesHeterogeneous
 
-  # Create a 4x4 grid with multiple patch types
+  # Create a 4x4 grid with patch types determined by state
   grid.size = 10 m
   grid.low.x = 0 m
   grid.low.y = 0 m
   grid.high.x = 40 m
   grid.high.y = 40 m  # 4x4 grid
-
-  # Create a checkerboard pattern of patch types
-  grid.patch = "Wet"
-  grid.patch:if((meta.x + meta.y) == 2 count) = "Dry"
-  grid.patch:if((meta.x + meta.y) == 4 count) = "Dry"
-  grid.patch:if((meta.x + meta.y) == 6 count) = "Dry"
 
   steps.low = 0 count
   steps.high = 3 count
@@ -26,27 +20,35 @@ start simulation SpatialPatchesHeterogeneous
 
 end simulation
 
-start patch Wet
+start patch Default
 
-  moisture.init = 80 percent
-  moisture.step = prior.moisture - 2 percent
+  # Right side of grid (x > 20m) is Dry, left side is Wet
+  # Cell centers are at x = 5, 15, 25, 35 meters
+  state.init = "Wet"
+  state.init:if(here.x > 20 m) = "Dry"
 
-  # Wet patches support more plants
-  Plant.init = create 5 count of Plant
+  moisture.init = 50 percent
+  patchType.init = "unknown"
 
-  patchType.init = "wet"
+  start state "Wet"
+    moisture.init = 80 percent
+    moisture.step = prior.moisture - 2 percent
 
-end patch
+    # Wet patches support more plants
+    Plant.init = create 5 count of Plant
 
-start patch Dry
+    patchType.init = "wet"
+  end state
 
-  moisture.init = 20 percent
-  moisture.step = prior.moisture - 1 percent
+  start state "Dry"
+    moisture.init = 20 percent
+    moisture.step = prior.moisture - 1 percent
 
-  # Dry patches support fewer plants
-  Plant.init = create 2 count of Plant
+    # Dry patches support fewer plants
+    Plant.init = create 2 count of Plant
 
-  patchType.init = "dry"
+    patchType.init = "dry"
+  end state
 
 end patch
 

--- a/josh-tests/conformance/spatial/patches/test_spatial_patches_types.josh
+++ b/josh-tests/conformance/spatial/patches/test_spatial_patches_types.josh
@@ -1,22 +1,16 @@
 # @category: spatial
 # @subcategory: patches
 # @priority: high
-# @description: Test different patch types on grid - organisms on correct patch type
+# @description: Test different patch types on grid using state-based initialization
 
 start simulation SpatialPatchesTypes
 
-  # Create a 3x3 grid with two patch types
+  # Create a 3x3 grid with two patch types determined by state
   grid.size = 10 m
   grid.low.x = 0 m
   grid.low.y = 0 m
   grid.high.x = 30 m
   grid.high.y = 30 m  # 3x3 grid
-
-  # Use alternating patch pattern
-  grid.patch = "Forest"
-  grid.patch:if(meta.x == 0 count and meta.y == 0 count) = "Grassland"
-  grid.patch:if(meta.x == 2 count and meta.y == 2 count) = "Grassland"
-  grid.patch:if(meta.x == 1 count and meta.y == 1 count) = "Grassland"
 
   steps.low = 0 count
   steps.high = 2 count
@@ -26,21 +20,26 @@ start simulation SpatialPatchesTypes
 
 end simulation
 
-start patch Forest
+start patch Default
 
-  # Forest patches have trees
-  Tree.init = create 3 count of Tree
+  # Patches on the diagonal (where x == y) are Grassland, others are Forest
+  # Cell centers are at (5,5), (15,15), (25,25) for diagonal
+  state.init = "Forest"
+  state.init:if(here.x == here.y) = "Grassland"
 
-  patchType.init = "forest"
+  patchType.init = "unknown"
 
-end patch
+  start state "Forest"
+    # Forest patches have trees
+    Tree.init = create 3 count of Tree
+    patchType.init = "forest"
+  end state
 
-start patch Grassland
-
-  # Grassland patches have grass
-  Grass.init = create 5 count of Grass
-
-  patchType.init = "grassland"
+  start state "Grassland"
+    # Grassland patches have grass
+    Grass.init = create 5 count of Grass
+    patchType.init = "grassland"
+  end state
 
 end patch
 

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -116,6 +116,16 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
       }
     }
 
+    // Fall back to built-in here attributes (e.g., here.x, here.y)
+    if (path.startsWith("here.")) {
+      String attrName = path.substring(5); // Remove "here." prefix
+      Optional<EngineValue> builtin = getBuiltinHereAttribute(attrName);
+      if (builtin.isPresent()) {
+        memory.push(builtin.get());
+        return this;
+      }
+    }
+
     throw new IllegalStateException("Unable to get value for " + valueResolver);
   }
 
@@ -594,6 +604,38 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
       );
       case "year" -> Optional.of(
           valueFactory.build(bridge.getCurrentTimestep(), Units.of("years"))
+      );
+      default -> Optional.empty();
+    };
+  }
+
+  /**
+   * Get a built-in here attribute value if the name matches a built-in.
+   *
+   * <p>Built-in here attributes provide spatial information about the current patch:
+   * here.x (center X coordinate in meters), here.y (center Y coordinate in meters).</p>
+   *
+   * @param name the attribute name to check.
+   * @return Optional containing the value if it's a built-in, empty otherwise.
+   */
+  private Optional<EngineValue> getBuiltinHereAttribute(String name) {
+    if (!scope.has("here")) {
+      return Optional.empty();
+    }
+
+    Entity here = scope.get("here").getAsEntity();
+    Optional<EngineGeometry> geometry = here.getGeometry();
+
+    if (geometry.isEmpty()) {
+      return Optional.empty();
+    }
+
+    return switch (name) {
+      case "x" -> Optional.of(
+          valueFactory.buildForNumber(geometry.get().getCenterX().doubleValue(), Units.of("m"))
+      );
+      case "y" -> Optional.of(
+          valueFactory.buildForNumber(geometry.get().getCenterY().doubleValue(), Units.of("m"))
       );
       default -> Optional.empty();
     };


### PR DESCRIPTION
As laid out in language spec, we have a reserved keyword 'here' that references the patch being stepped OR the parent patch of an organism. Currently it exposes only `x` and `y`. 