### PR TITLE
[dev-restore] Inconsistent prior attr value

### DIFF
--- a/src/main/java/org/joshsim/lang/bridge/ShadowingEntity.java
+++ b/src/main/java/org/joshsim/lang/bridge/ShadowingEntity.java
@@ -280,20 +280,17 @@ public class ShadowingEntity implements MutableEntity {
       }
     }
 
-    inner.setAttributeValue(name, value);
+    // NOTE: Do NOT write to inner here. Values are written to inner at endSubstep().
+    // This ensures that prior.X returns the value from the previous substep, not
+    // a value that was just computed in this substep by another attribute.
   }
 
   @Override
   public void setAttributeValue(int index, EngineValue value) {
     String[] indexArray = inner.getIndexToAttributeName();
-    String attributeName = null;
 
     boolean indexInRange = index >= 0 && indexArray != null && index < indexArray.length;
-    if (indexInRange) {
-      attributeName = indexArray[index];
-    }
-
-    if (attributeName == null) {
+    if (!indexInRange) {
       String message = String.format(
           "Attribute index %d not found for entity %s",
           index, inner.getName());
@@ -305,7 +302,9 @@ public class ShadowingEntity implements MutableEntity {
       resolvedCacheByIndex[index] = value;
     }
 
-    setAttributeValue(attributeName, value);
+    // NOTE: Do NOT write to inner here. Values are written to inner at endSubstep().
+    // This ensures that prior.X returns the value from the previous substep, not
+    // a value that was just computed in this substep by another attribute.
   }
 
   /**
@@ -758,6 +757,17 @@ public class ShadowingEntity implements MutableEntity {
   @Override
   public void endSubstep() {
     InnerEntityGetter.getInnerEntities(this).forEach((x) -> x.endSubstep());
+
+    // Copy resolved values from cache to inner entity.
+    // This is done at endSubstep (rather than in setAttributeValue) to ensure that
+    // prior.X always returns the value from the previous substep, not a value that
+    // was computed earlier in the current substep by another attribute.
+    for (int i = 0; i < resolvedCacheByIndex.length; i++) {
+      EngineValue resolved = resolvedCacheByIndex[i];
+      if (resolved != null) {
+        inner.setAttributeValue(i, resolved);
+      }
+    }
 
     // Clear array-based tracking
     Arrays.fill(resolvingByIndex, false);

--- a/src/test/java/org/joshsim/lang/bridge/ShadowingEntityTest.java
+++ b/src/test/java/org/joshsim/lang/bridge/ShadowingEntityTest.java
@@ -82,8 +82,44 @@ public class ShadowingEntityTest {
     Optional<EngineValue> priorValue = spatialEntity.getPriorAttribute(attrName);
     assertEquals(mockEngineValue, priorValue.get());
 
+    // setAttributeValue should cache the value but NOT write to inner immediately.
+    // Values are deferred to endSubstep() to ensure prior.X returns the correct value.
     spatialEntity.setAttributeValue(attrName, mockEngineValue);
-    verify(mockSpatialEntity).setAttributeValue(attrName, mockEngineValue);
+
+    // The value should be available via getAttributeValue (from cache)
+    Optional<EngineValue> cachedValue = spatialEntity.getAttributeValue(attrName);
+    assertTrue(cachedValue.isPresent());
+    assertEquals(mockEngineValue, cachedValue.get());
+  }
+
+  @Test
+  void testDeferredWriteToInnerAtEndSubstep() {
+    String attrName = "testAttr";
+    String substepName = "test";
+
+    // Setup index mapping for endSubstep to copy values
+    Map<String, Integer> indexMap = Map.of(attrName, 0);
+    String[] indexToNameArray = new String[] {attrName};
+    when(mockSpatialEntity.getAttributeNameToIndex()).thenReturn(indexMap);
+    when(mockSpatialEntity.getIndexToAttributeName()).thenReturn(indexToNameArray);
+    when(mockSpatialEntity.getAttributeIndex(attrName)).thenReturn(Optional.of(0));
+
+    // Recreate entity with proper mocks
+    spatialEntity = new ShadowingEntity(
+        valueFactory,
+        mockSpatialEntity,
+        patchEntity,
+        mockSimulation
+    );
+
+    spatialEntity.startSubstep(substepName);
+    spatialEntity.setAttributeValue(attrName, mockEngineValue);
+
+    // Value should be written to inner at endSubstep
+    spatialEntity.endSubstep();
+
+    // Verify inner.setAttributeValue was called at endSubstep
+    verify(mockSpatialEntity).setAttributeValue(0, mockEngineValue);
   }
 
   @Test

--- a/src/test/java/org/joshsim/lang/bridge/ShadowingEntityTest.java
+++ b/src/test/java/org/joshsim/lang/bridge/ShadowingEntityTest.java
@@ -95,7 +95,6 @@ public class ShadowingEntityTest {
   @Test
   void testDeferredWriteToInnerAtEndSubstep() {
     String attrName = "testAttr";
-    String substepName = "test";
 
     // Setup index mapping for endSubstep to copy values
     Map<String, Integer> indexMap = Map.of(attrName, 0);
@@ -112,6 +111,7 @@ public class ShadowingEntityTest {
         mockSimulation
     );
 
+    String substepName = "test";
     spatialEntity.startSubstep(substepName);
     spatialEntity.setAttributeValue(attrName, mockEngineValue);
 


### PR DESCRIPTION
Due to the timing of attribute updates, multiple reads of the prior attributes would lead to inconsistent values, essentially because setAttributeValue() was immediately writing the inner entity. Now we simply cache the value for a given attribute for the duration of the current step, allowing prior to point to the actual entity, then updating the entity itslef at the end on `endSubstep()`. 

```
start patch Default
  counter.init = 0 count
  counter.step = prior.counter + 1 count  # Uses prior correctly

  observer.init = 0 count
  observer.step = prior.counter           # BUG: Gets current.counter, not prior!
end patch
```

Expected behavior:
- Step 0: counter=1, observer=0 (both should see prior.counter=0)
- Step 1: counter=2, observer=1 (both should see prior.counter=1)

Actual behavior (before fix):
- Step 0: counter=1, observer=1 (observer incorrectly sees prior.counter=1)
- Step 1: counter=2, observer=2 (observer incorrectly sees prior.counter=2)