### PR TITLE
[dev-restore] Give equality of booleans an epsilon for Josh float comparison

### DIFF
--- a/src/main/java/org/joshsim/engine/value/type/DecimalScalar.java
+++ b/src/main/java/org/joshsim/engine/value/type/DecimalScalar.java
@@ -128,4 +128,56 @@ public class DecimalScalar extends Scalar {
       determineRaisedUnits(getUnits(), other.getAsInt())
     );
   }
+
+  /**
+   * Epsilon value for floating-point equality comparison.
+   *
+   * <p>This value is used to determine if two decimal numbers are "equal"
+   * within acceptable precision limits. Some operations involve conversion
+   * through doubles which can introduce small rounding errors.</p>
+   */
+  private static final double EPSILON = 1e-10;
+
+  /**
+   * Compares this DecimalScalar to another EngineValue for equality using epsilon tolerance.
+   *
+   * <p>While BigDecimal provides exact decimal arithmetic, some operations may involve
+   * floating-point conversions. This method uses epsilon tolerance for robustness.</p>
+   *
+   * @param other the other EngineValue to compare with.
+   * @return a BooleanScalar indicating whether the values are equal within tolerance.
+   */
+  @Override
+  protected EngineValue unsafeEqualTo(EngineValue other) {
+    double thisVal = getAsDouble();
+    double otherVal = other.getAsDouble();
+    double diff = Math.abs(thisVal - otherVal);
+
+    // Use relative epsilon for large values, absolute for small values
+    double scale = Math.max(1.0, Math.max(Math.abs(thisVal), Math.abs(otherVal)));
+    boolean result = diff < EPSILON * scale;
+
+    return new BooleanScalar(getCaster(), result, Units.EMPTY);
+  }
+
+  /**
+   * Compares this DecimalScalar to another EngineValue for inequality using epsilon tolerance.
+   *
+   * <p>This is the logical negation of {@link #unsafeEqualTo(EngineValue)}.</p>
+   *
+   * @param other the other EngineValue to compare with.
+   * @return a BooleanScalar indicating whether the values are not equal within tolerance.
+   */
+  @Override
+  protected EngineValue unsafeNotEqualTo(EngineValue other) {
+    double thisVal = getAsDouble();
+    double otherVal = other.getAsDouble();
+    double diff = Math.abs(thisVal - otherVal);
+
+    // Use relative epsilon for large values, absolute for small values
+    double scale = Math.max(1.0, Math.max(Math.abs(thisVal), Math.abs(otherVal)));
+    boolean result = diff >= EPSILON * scale;
+
+    return new BooleanScalar(getCaster(), result, Units.EMPTY);
+  }
 }

--- a/src/main/java/org/joshsim/engine/value/type/DoubleScalar.java
+++ b/src/main/java/org/joshsim/engine/value/type/DoubleScalar.java
@@ -127,4 +127,57 @@ public class DoubleScalar extends Scalar {
         determineRaisedUnits(getUnits(), other.getAsInt())
     );
   }
+
+  /**
+   * Epsilon value for floating-point equality comparison.
+   *
+   * <p>This value is used to determine if two floating-point numbers are "equal"
+   * within acceptable precision limits. Standard floating-point arithmetic can
+   * produce small rounding errors (e.g., 0.4 + 0.05 = 0.45000000000000001).</p>
+   */
+  private static final double EPSILON = 1e-10;
+
+  /**
+   * Compares this DoubleScalar to another EngineValue for equality using epsilon tolerance.
+   *
+   * <p>Floating-point arithmetic can produce small rounding errors, so exact comparison
+   * is unreliable. This method uses relative epsilon for large values and absolute
+   * epsilon for small values to determine equality.</p>
+   *
+   * @param other the other EngineValue to compare with.
+   * @return a BooleanScalar indicating whether the values are equal within tolerance.
+   */
+  @Override
+  protected EngineValue unsafeEqualTo(EngineValue other) {
+    double thisVal = getAsDouble();
+    double otherVal = other.getAsDouble();
+    double diff = Math.abs(thisVal - otherVal);
+
+    // Use relative epsilon for large values, absolute for small values
+    double scale = Math.max(1.0, Math.max(Math.abs(thisVal), Math.abs(otherVal)));
+    boolean result = diff < EPSILON * scale;
+
+    return new BooleanScalar(getCaster(), result, Units.EMPTY);
+  }
+
+  /**
+   * Compares this DoubleScalar to another EngineValue for inequality using epsilon tolerance.
+   *
+   * <p>This is the logical negation of {@link #unsafeEqualTo(EngineValue)}.</p>
+   *
+   * @param other the other EngineValue to compare with.
+   * @return a BooleanScalar indicating whether the values are not equal within tolerance.
+   */
+  @Override
+  protected EngineValue unsafeNotEqualTo(EngineValue other) {
+    double thisVal = getAsDouble();
+    double otherVal = other.getAsDouble();
+    double diff = Math.abs(thisVal - otherVal);
+
+    // Use relative epsilon for large values, absolute for small values
+    double scale = Math.max(1.0, Math.max(Math.abs(thisVal), Math.abs(otherVal)));
+    boolean result = diff >= EPSILON * scale;
+
+    return new BooleanScalar(getCaster(), result, Units.EMPTY);
+  }
 }

--- a/src/test/java/org/joshsim/engine/value/type/DoubleScalarTest.java
+++ b/src/test/java/org/joshsim/engine/value/type/DoubleScalarTest.java
@@ -8,6 +8,7 @@
 package org.joshsim.engine.value.type;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -164,5 +165,81 @@ class DoubleScalarTest {
 
     assertEquals(123.456789, scalar.getAsDouble(), 0.000001);
     assertEquals("123.456789", scalar.getAsString());
+  }
+
+  @Test
+  void testEqualToWithArithmeticResult() {
+    // This is the critical test case: 0.4 + 0.05 should equal 0.45
+    // even though floating-point arithmetic produces 0.45000000000000001
+    DoubleScalar a = new DoubleScalar(caster, 0.4, Units.of("count"));
+    DoubleScalar b = new DoubleScalar(caster, 0.05, Units.of("count"));
+    DoubleScalar sum = (DoubleScalar) a.add(b);
+    DoubleScalar expected = new DoubleScalar(caster, 0.45, Units.of("count"));
+
+    EngineValue result = sum.equalTo(expected);
+    assertTrue(result.getAsBoolean(), "0.4 + 0.05 should equal 0.45 with epsilon tolerance");
+  }
+
+  @Test
+  void testEqualToWithExactValues() {
+    DoubleScalar scalar1 = new DoubleScalar(caster, 42.5, Units.of("m"));
+    DoubleScalar scalar2 = new DoubleScalar(caster, 42.5, Units.of("m"));
+
+    EngineValue result = scalar1.equalTo(scalar2);
+    assertTrue(result.getAsBoolean(), "Identical values should be equal");
+  }
+
+  @Test
+  void testEqualToWithClearlyDifferentValues() {
+    DoubleScalar scalar1 = new DoubleScalar(caster, 42.5, Units.of("m"));
+    DoubleScalar scalar2 = new DoubleScalar(caster, 42.6, Units.of("m"));
+
+    EngineValue result = scalar1.equalTo(scalar2);
+    assertFalse(result.getAsBoolean(), "Clearly different values should not be equal");
+  }
+
+  @Test
+  void testNotEqualToWithArithmeticResult() {
+    // 0.4 + 0.05 should NOT be "not equal" to 0.45
+    DoubleScalar a = new DoubleScalar(caster, 0.4, Units.of("count"));
+    DoubleScalar b = new DoubleScalar(caster, 0.05, Units.of("count"));
+    DoubleScalar sum = (DoubleScalar) a.add(b);
+    DoubleScalar expected = new DoubleScalar(caster, 0.45, Units.of("count"));
+
+    EngineValue result = sum.notEqualTo(expected);
+    assertFalse(result.getAsBoolean(), "0.4 + 0.05 should not be 'not equal' to 0.45");
+  }
+
+  @Test
+  void testNotEqualToWithClearlyDifferentValues() {
+    DoubleScalar scalar1 = new DoubleScalar(caster, 42.5, Units.of("m"));
+    DoubleScalar scalar2 = new DoubleScalar(caster, 42.6, Units.of("m"));
+
+    EngineValue result = scalar1.notEqualTo(scalar2);
+    assertTrue(result.getAsBoolean(), "Clearly different values should be not equal");
+  }
+
+  @Test
+  void testEqualToWithLargeValues() {
+    // Epsilon should scale with value magnitude
+    DoubleScalar scalar1 = new DoubleScalar(caster, 1e10, Units.of("m"));
+    DoubleScalar scalar2 = new DoubleScalar(caster, 1e10 + 0.001, Units.of("m"));
+
+    EngineValue result = scalar1.equalTo(scalar2);
+    assertTrue(result.getAsBoolean(), "Large values with tiny relative difference should be equal");
+  }
+
+  @Test
+  void testEqualToWithPercentageArithmetic() {
+    // Simulating percentage arithmetic: 40% + 5% = 45%
+    // Internally percentages are stored as 0.4, 0.05, 0.45
+    DoubleScalar fortyPercent = new DoubleScalar(caster, 0.4, Units.of("count"));
+    DoubleScalar fivePercent = new DoubleScalar(caster, 0.05, Units.of("count"));
+    DoubleScalar fortyFivePercent = new DoubleScalar(caster, 0.45, Units.of("count"));
+
+    DoubleScalar sum = (DoubleScalar) fortyPercent.add(fivePercent);
+    EngineValue result = sum.equalTo(fortyFivePercent);
+
+    assertTrue(result.getAsBoolean(), "40% + 5% should equal 45%");
   }
 }


### PR DESCRIPTION
Give equality of booleans an epsilon for Josh float comparison - didn't catch this because our JUnit tests have an epsilon baked in!