### PR TITLE
[dev-restore] map and distribution expansion / element-wise support

### DIFF
--- a/josh-tests/conformance/types/map/test_map_chained.josh
+++ b/josh-tests/conformance/types/map/test_map_chained.josh
@@ -25,29 +25,38 @@ start patch Default
   step2.init = map step1 from [0 count, 10 count] to [0 %, 100 %] linearly
   assert.linearChain.init = step2 == 50 %
 
-  # Test chaining linear then quadratic
+  # Test chaining linear then quadratic (parabola)
+  # Linear: 50 m -> 50 count (center of domain)
+  # Quadratic parabola: 50 count (center) -> 100% (max of range)
   input2.init = 50 m
   linearStep.init = map input2 from [0 m, 100 m] to [0 count, 100 count] linearly
   quadStep.init = map linearStep from [0 count, 100 count] to [0 %, 100 %] quadratically
-  # After linear (50 m -> 50 count), then quadratic (50 count -> 25%)
-  assert.linearThenQuadratic.init = quadStep < 30 %
-  assert.linearThenQuadraticPositive.init = quadStep > 20 %
+  assert.linearThenQuadratic.init = quadStep == 100 %
 
   # Test chaining quadratic then linear
+  # Quadratic parabola: 50 m (center) -> 100 count (max)
+  # Linear: 100 count -> 100%
   input3.init = 50 m
   quadFirstStep.init = map input3 from [0 m, 100 m] to [0 count, 100 count] quadratically
   linearSecondStep.init = map quadFirstStep from [0 count, 100 count] to [0 %, 100 %] linearly
-  # After quadratic (50 m -> ~25 count), then linear (25 count -> 25%)
-  assert.quadraticThenLinear.init = linearSecondStep < 30 %
-  assert.quadraticThenLinearPositive.init = linearSecondStep > 20 %
+  assert.quadraticThenLinear.init = linearSecondStep == 100 %
+
+  # Test chaining with endpoint values (where quadratic gives 0)
+  # Quadratic parabola: 0 m (endpoint) -> 0 count
+  # Linear: 0 count -> 0%
+  inputEndpoint.init = 0 m
+  quadEndpoint.init = map inputEndpoint from [0 m, 100 m] to [0 count, 100 count] quadratically
+  linearAfterQuad.init = map quadEndpoint from [0 count, 100 count] to [0 %, 100 %] linearly
+  assert.quadraticEndpointThenLinear.init = linearAfterQuad == 0 %
 
   # Test three-step chain: linear -> quadratic -> sigmoid
   input4.init = 50 m
   chain1.init = map input4 from [0 m, 100 m] to [0 count, 100 count] linearly
   chain2.init = map chain1 from [0 count, 100 count] to [0 count, 100 count] quadratically
   chain3.init = map chain2 from [0 count, 100 count] to [0 %, 100 %] sigmoidally
-  # Complex composition, result should be within valid range
-  assert.threeStepChainValid.init = chain3 >= 0 %
+  # Linear: 50 m -> 50 count; Quadratic parabola: 50 count -> 100 count
+  # Sigmoid: 100 count (endpoint) -> ~99.75% (approaching max)
+  assert.threeStepChainValid.init = chain3 > 95 %
   assert.threeStepChainBounded.init = chain3 <= 100 %
 
   # Test chaining with range scaling
@@ -57,12 +66,14 @@ start patch Default
   assert.scalingChain.init = scale2 == 0.25 m
 
   # Test chaining with different mappings produces different results
-  input6.init = 50 m
+  input6.init = 25 m  # Use non-center value to see difference
   allLinear1.init = map input6 from [0 m, 100 m] to [0 count, 100 count] linearly
   allLinear2.init = map allLinear1 from [0 count, 100 count] to [0 %, 100 %] linearly
+  # Linear: 25 m -> 25 count -> 25%
 
   mixedMap1.init = map input6 from [0 m, 100 m] to [0 count, 100 count] quadratically
   mixedMap2.init = map mixedMap1 from [0 count, 100 count] to [0 %, 100 %] linearly
+  # Quadratic parabola: 25 m -> 75 count (halfway to center) -> 75%
 
   assert.chainsDiffer.init = allLinear2 != mixedMap2
 

--- a/josh-tests/conformance/types/map/test_map_quadratic.josh
+++ b/josh-tests/conformance/types/map/test_map_quadratic.josh
@@ -1,7 +1,7 @@
 # @category: types
 # @subcategory: map
 # @priority: medium
-# @description: Test quadratic mapping with curve transformations
+# @description: Test quadratic mapping with parabola transformations
 
 start simulation MapQuadratic
 
@@ -19,66 +19,57 @@ end simulation
 
 start patch Default
 
-  # Test quadratic map at range boundaries
+  # Quadratic mapping creates a PARABOLA where:
+  # - The CENTER of the domain maps to one extreme of the range
+  # - The ENDPOINTS of the domain map to the other extreme
+  # Default behavior (centerIsMaximum=true): center → max, endpoints → min
+  # This models optimal range curves (e.g., optimal temperature)
+
+  # Test quadratic map at endpoints - should map to range minimum
   input1.init = 0 m
   mapped1.init = map input1 from [0 m, 100 m] to [0 count, 100 count] quadratically
   assert.quadraticAtMin.init = mapped1 == 0 count
 
   input2.init = 100 m
   mapped2.init = map input2 from [0 m, 100 m] to [0 count, 100 count] quadratically
-  assert.quadraticAtMax.init = mapped2 == 100 count
+  assert.quadraticAtMax.init = mapped2 == 0 count
 
-  # Test quadratic map at midpoint
-  # Quadratic curve should be non-linear, so midpoint input != midpoint output
+  # Test quadratic map at midpoint - should map to range maximum
   input3.init = 50 m
   mapped3.init = map input3 from [0 m, 100 m] to [0 count, 100 count] quadratically
-  # For quadratic, middle should be less than linear (25 for 50%)
-  assert.quadraticAtMid.init = mapped3 < 50 count
-  assert.quadraticAtMidPositive.init = mapped3 > 0 count
+  assert.quadraticAtMid.init = mapped3 == 100 count
 
   # Test quadratic produces different result than linear
-  input4.init = 50 m
+  input4.init = 25 m
   linearMap.init = map input4 from [0 m, 100 m] to [0 count, 100 count] linearly
   quadraticMap.init = map input4 from [0 m, 100 m] to [0 count, 100 count] quadratically
   assert.quadraticDiffersFromLinear.init = quadraticMap != linearMap
 
-  # Test quadratic curve progression
-  # Quadratic should accelerate, so 25% < 6.25%, 75% < 56.25%
+  # Test quadratic curve at 25% - parabola should give 75% of max
+  # At x=25, distance from center is 25, half the max distance of 50
+  # Parabola: y = 100 * (1 - ((x-50)/50)^2) = 100 * (1 - 0.25) = 75
   input5.init = 25 m
   mapped5.init = map input5 from [0 m, 100 m] to [0 count, 100 count] quadratically
-  # At 25%, quadratic should give 6.25 (0.25^2 = 0.0625)
-  assert.quadraticEarlySmall.init = mapped5 < 10 count
+  assert.quadraticAt25.init = mapped5 > 70 count
+  assert.quadraticAt25High.init = mapped5 < 80 count
 
+  # Test quadratic curve at 75% - should be symmetric with 25%
   input6.init = 75 m
   mapped6.init = map input6 from [0 m, 100 m] to [0 count, 100 count] quadratically
-  # At 75%, quadratic should give 56.25 (0.75^2 = 0.5625)
-  assert.quadraticLateLarge.init = mapped6 > 50 count
-  assert.quadraticLateRange.init = mapped6 < 65 count
+  assert.quadraticAt75.init = mapped6 > 70 count
+  assert.quadraticAt75High.init = mapped6 < 80 count
+
+  # Test symmetry: 25% and 75% should give same result (equidistant from center)
+  assert.quadraticSymmetric.init = mapped5 == mapped6
 
   # Test quadratic with percentage output
   pctInput1.init = 0 m
   pctMapped1.init = map pctInput1 from [0 m, 100 m] to [0 %, 100 %] quadratically
   assert.quadraticPctMin.init = pctMapped1 == 0 %
 
-  pctInput2.init = 100 m
+  pctInput2.init = 50 m
   pctMapped2.init = map pctInput2 from [0 m, 100 m] to [0 %, 100 %] quadratically
   assert.quadraticPctMax.init = pctMapped2 == 100 %
-
-  # Test quadratic is monotonically increasing
-  # Smaller input should give smaller output
-  smallInput.init = 30 m
-  smallMapped.init = map smallInput from [0 m, 100 m] to [0 count, 100 count] quadratically
-
-  largeInput.init = 70 m
-  largeMapped.init = map largeInput from [0 m, 100 m] to [0 count, 100 count] quadratically
-
-  assert.quadraticMonotonic.init = smallMapped < largeMapped
-
-  # Test quadratic with inverted range
-  invertInput.init = 50 m
-  invertMapped.init = map invertInput from [0 m, 100 m] to [100 count, 0 count] quadratically
-  # Should still show quadratic behavior
-  assert.invertedQuadratic.init = invertMapped > 50 count
 
 end patch
 

--- a/josh-tests/conformance/types/map/test_map_sigmoid.josh
+++ b/josh-tests/conformance/types/map/test_map_sigmoid.josh
@@ -46,17 +46,17 @@ start patch Default
   assert.sigmoidDiffersFromLinear.init = sigmoidMap != linearMap
 
   # Test sigmoid S-curve characteristics
-  # Early values should be larger than quadratic (slow start)
+  # Early values should be small (compressed toward 0 due to S-curve)
   earlyInput.init = 25 m
   earlyMapped.init = map earlyInput from [0 m, 100 m] to [0 count, 100 count] sigmoidally
-  # Sigmoid at 25% should be > 15 (slower than linear quadratic)
-  assert.sigmoidEarlyAboveQuadratic.init = earlyMapped > 15 count
+  # Sigmoid at 25% should be < 10 (steep transition happens in middle)
+  assert.sigmoidEarlyCompressed.init = earlyMapped < 10 count
 
-  # Late values should be smaller than linear (slow end)
+  # Late values should be large (stretched toward 100 due to S-curve)
   lateInput.init = 75 m
   lateMapped.init = map lateInput from [0 m, 100 m] to [0 count, 100 count] sigmoidally
-  # Sigmoid at 75% should be < 85 (slower than linear)
-  assert.sigmoidLateBelowLinear.init = lateMapped < 85 count
+  # Sigmoid at 75% should be > 90 (steep transition in middle pushes late values high)
+  assert.sigmoidLateExpanded.init = lateMapped > 90 count
 
   # Test sigmoid with percentage output
   pctInput1.init = 50 m

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -12,6 +12,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Stack;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.joshsim.engine.entity.base.Entity;
 import org.joshsim.engine.entity.base.MutableEntity;
 import org.joshsim.engine.entity.prototype.EmbeddedParentEntityPrototype;
@@ -26,6 +29,7 @@ import org.joshsim.engine.value.engine.EngineValueFactory;
 import org.joshsim.engine.value.engine.Slicer;
 import org.joshsim.engine.value.type.Distribution;
 import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.engine.value.type.RealizedDistribution;
 import org.joshsim.engine.value.type.Scalar;
 import org.joshsim.lang.bridge.EngineBridge;
 import org.joshsim.lang.bridge.ShadowingEntityPrototype;
@@ -683,126 +687,63 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
 
   @Override
   public EventHandlerMachine abs() {
-    EngineValue value = pop();
-
-    if (value.getLanguageType().isDistribution()) {
-      throw new IllegalArgumentException("Cannot apply abs to a distribution.");
-    }
-
-    EngineValue result;
-    if (favorBigDecimal) {
-      BigDecimal absValue = value.getAsDecimal().abs();
-      result = valueFactory.build(absValue, value.getUnits());
-    } else {
-      double absValue = Math.abs(value.getAsDouble());
-      result = valueFactory.build(absValue, value.getUnits());
-    }
-    memory.push(result);
-
-    return this;
+    return applyUnaryMathFunction(v -> {
+      if (favorBigDecimal) {
+        return valueFactory.build(v.getAsDecimal().abs(), v.getUnits());
+      }
+      return valueFactory.build(Math.abs(v.getAsDouble()), v.getUnits());
+    });
   }
 
   @Override
   public EventHandlerMachine ceil() {
-    EngineValue value = pop();
-
-    if (value.getLanguageType().isDistribution()) {
-      throw new IllegalArgumentException("Cannot apply ceil to a distribution.");
-    }
-
-    EngineValue result;
-    if (favorBigDecimal) {
-      BigDecimal ceilValue = value.getAsDecimal().setScale(0, RoundingMode.CEILING);
-      result = valueFactory.build(ceilValue, value.getUnits());
-    } else {
-      double ceilValue = Math.ceil(value.getAsDouble());
-      result = valueFactory.build(ceilValue, value.getUnits());
-    }
-    memory.push(result);
-
-    return this;
+    return applyUnaryMathFunction(v -> {
+      if (favorBigDecimal) {
+        return valueFactory.build(v.getAsDecimal().setScale(0, RoundingMode.CEILING), v.getUnits());
+      }
+      return valueFactory.build(Math.ceil(v.getAsDouble()), v.getUnits());
+    });
   }
 
   @Override
   public EventHandlerMachine floor() {
-    EngineValue value = pop();
-
-    if (value.getLanguageType().isDistribution()) {
-      throw new IllegalArgumentException("Cannot apply floor to a distribution.");
-    }
-
-    EngineValue result;
-    if (favorBigDecimal) {
-      BigDecimal floorValue = value.getAsDecimal().setScale(0, RoundingMode.FLOOR);
-      result = valueFactory.build(floorValue, value.getUnits());
-    } else {
-      double floorValue = Math.floor(value.getAsDouble());
-      result = valueFactory.build(floorValue, value.getUnits());
-    }
-    memory.push(result);
-
-    return this;
+    return applyUnaryMathFunction(v -> {
+      if (favorBigDecimal) {
+        return valueFactory.build(v.getAsDecimal().setScale(0, RoundingMode.FLOOR), v.getUnits());
+      }
+      return valueFactory.build(Math.floor(v.getAsDouble()), v.getUnits());
+    });
   }
 
   @Override
   public EventHandlerMachine round() {
-    EngineValue value = pop();
-
-    if (value.getLanguageType().isDistribution()) {
-      throw new IllegalArgumentException("Cannot apply round to a distribution.");
-    }
-
-    EngineValue result;
-    if (favorBigDecimal) {
-      BigDecimal roundedValue = value.getAsDecimal().setScale(0, RoundingMode.HALF_UP);
-      result = valueFactory.build(roundedValue, value.getUnits());
-    } else {
-      double roundedValue = Math.round(value.getAsDouble());
-      result = valueFactory.build(roundedValue, value.getUnits());
-    }
-    memory.push(result);
-
-    return this;
+    return applyUnaryMathFunction(v -> {
+      if (favorBigDecimal) {
+        return valueFactory.build(v.getAsDecimal().setScale(0, RoundingMode.HALF_UP), v.getUnits());
+      }
+      return valueFactory.build(Math.round(v.getAsDouble()), v.getUnits());
+    });
   }
 
   @Override
   public EventHandlerMachine log10() {
-    EngineValue value = pop();
-
-    if (value.getLanguageType().isDistribution()) {
-      throw new IllegalArgumentException("Cannot apply log10 to a distribution.");
-    }
-
-    if (value.getAsDecimal().compareTo(BigDecimal.ZERO) <= 0) {
-      throw new IllegalArgumentException("Logarithm can only be applied to positive numbers.");
-    }
-
-    double logValue = Math.log10(value.getAsDouble());
-    EngineValue result = valueFactory.buildForNumber(logValue, value.getUnits());
-    memory.push(result);
-
-    return this;
+    return applyUnaryMathFunction(v -> {
+      if (v.getAsDecimal().compareTo(BigDecimal.ZERO) <= 0) {
+        throw new IllegalArgumentException("Logarithm can only be applied to positive numbers.");
+      }
+      return valueFactory.buildForNumber(Math.log10(v.getAsDouble()), v.getUnits());
+    });
   }
 
   @Override
   public EventHandlerMachine ln() {
-    EngineValue value = pop();
-
-    if (value.getLanguageType().isDistribution()) {
-      throw new IllegalArgumentException("Cannot apply natural log (ln) to a distribution.");
-    }
-
-    if (value.getAsDecimal().compareTo(BigDecimal.ZERO) <= 0) {
-      throw new IllegalArgumentException(
-          "Natural logarithm can only be applied to positive numbers."
-      );
-    }
-
-    double lnValue = Math.log(value.getAsDouble());
-    EngineValue result = valueFactory.buildForNumber(lnValue, value.getUnits());
-    memory.push(result);
-
-    return this;
+    return applyUnaryMathFunction(v -> {
+      if (v.getAsDecimal().compareTo(BigDecimal.ZERO) <= 0) {
+        throw new IllegalArgumentException(
+            "Natural logarithm can only be applied to positive numbers.");
+      }
+      return valueFactory.buildForNumber(Math.log(v.getAsDouble()), v.getUnits());
+    });
   }
 
   @Override
@@ -1263,6 +1204,61 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
       // Always restore original scope, even if action throws
       this.scope = originalScope;
     }
+  }
+
+  /**
+   * Apply a unary math function to a value, handling both scalars and distributions.
+   *
+   * <p>If the value is a distribution, applies the function element-wise. Otherwise, applies
+   * directly to the scalar value. This eliminates boilerplate in abs(), ceil(), floor(), etc.</p>
+   *
+   * @param scalarFunction The function to apply to each scalar value.
+   * @return This machine for method chaining.
+   */
+  private EventHandlerMachine applyUnaryMathFunction(
+      Function<EngineValue, EngineValue> scalarFunction
+  ) {
+    EngineValue value = pop();
+    EngineValue result;
+
+    if (value.getLanguageType().isDistribution()) {
+      result = applyToDistribution(value, scalarFunction);
+    } else {
+      result = scalarFunction.apply(value);
+    }
+
+    memory.push(result);
+    return this;
+  }
+
+  /**
+   * Apply a unary function to each element of a distribution.
+   *
+   * @param distribution The distribution (realized or virtual) to apply the function to.
+   * @param function The function to apply to each element.
+   * @return A new RealizedDistribution containing the transformed values.
+   */
+  private EngineValue applyToDistribution(
+      EngineValue distribution,
+      Function<EngineValue, EngineValue> function
+  ) {
+    Distribution dist = distribution.getAsDistribution();
+
+    // Get the size - if virtual, sample a reasonable number of elements
+    Optional<Integer> sizeOpt = dist.getSize();
+    int size = sizeOpt.orElse(1000); // Default sample size for virtual distributions
+
+    // Get contents and apply function element-wise
+    Iterable<EngineValue> contents = dist.getContents(size, true);
+    List<EngineValue> transformedValues = StreamSupport.stream(contents.spliterator(), false)
+        .map(function)
+        .collect(Collectors.toCollection(ArrayList::new));
+
+    return new RealizedDistribution(
+        distribution.getCaster(),
+        transformedValues,
+        distribution.getUnits()
+    );
   }
 
 }

--- a/src/main/java/org/joshsim/lang/interpret/mapping/MappingBuilder.java
+++ b/src/main/java/org/joshsim/lang/interpret/mapping/MappingBuilder.java
@@ -83,14 +83,19 @@ public class MappingBuilder {
   /**
    * Build a mapping strategy based on the provided strategy name and builder settings.
    *
-   * @param strategyName The name of the mapping strategy to build ("linear", "quadratic", or
-   *     "sigmoid").
+   * <p>Accepts both base forms ("linear", "quadratic", "sigmoid") and adverb forms
+   * ("linearly", "quadratically", "sigmoidally") as used in Josh language syntax.</p>
+   *
+   * @param strategyName The name of the mapping strategy to build.
    * @return The constructed mapping strategy.
    * @throws IllegalArgumentException if the strategy name is unknown or required fields are
    *     missing.
    */
   public MapStrategy build(String strategyName) {
-    return switch (strategyName) {
+    // Normalize strategy name - accept both base and adverb forms
+    String normalizedName = normalizeStrategyName(strategyName);
+
+    return switch (normalizedName) {
       case "linear" -> new LinearMapStrategy(
           valueFactory.orElseThrow(),
           domain.orElseThrow(),
@@ -109,6 +114,21 @@ public class MappingBuilder {
           mapBehaviorArgument.orElseThrow().getAsBoolean()
       );
       default -> throw new IllegalArgumentException("Unknown mapping: " + strategyName);
+    };
+  }
+
+  /**
+   * Normalize strategy name by converting adverb forms to base forms.
+   *
+   * @param strategyName The strategy name (may be "linear" or "linearly", etc.)
+   * @return The normalized base form ("linear", "quadratic", or "sigmoid")
+   */
+  private String normalizeStrategyName(String strategyName) {
+    return switch (strategyName) {
+      case "linearly" -> "linear";
+      case "quadratically" -> "quadratic";
+      case "sigmoidally" -> "sigmoid";
+      default -> strategyName;
     };
   }
 }

--- a/src/main/java/org/joshsim/lang/interpret/mapping/SigmoidMapStrategy.java
+++ b/src/main/java/org/joshsim/lang/interpret/mapping/SigmoidMapStrategy.java
@@ -1,4 +1,3 @@
-
 /**
  * Strategy for performing a sigmoid map between a given domain and range.
  *
@@ -7,23 +6,29 @@
 
 package org.joshsim.lang.interpret.mapping;
 
-import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.EngineValueFactory;
 import org.joshsim.engine.value.type.EngineValue;
 
 /**
- * Map strategy which creates a sigmoid mapping between the given domain and range.
+ * Map strategy which creates a sigmoid (S-curve) mapping between the given domain and range.
  *
- * <p>The strategy maps values using a sigmoid function of the form y = 1 / (1 + e^(scale * x)).
- * The domain controls the x-axis scaling and shifting while the range controls the y-axis scaling.
- * The direction parameter controls whether the mapping increases or decreases with x.</p>
+ * <p>The strategy maps values using a sigmoid function that creates an S-shaped curve.
+ * Values near the domain boundaries approach (but don't quite reach) the range boundaries,
+ * while the middle of the domain maps to the middle of the range. The curve shape provides
+ * smooth transitions with gradual changes near the boundaries.</p>
  */
 public class SigmoidMapStrategy implements MapStrategy {
   private final EngineValueFactory valueFactory;
   private final MapBounds domain;
   private final MapBounds range;
   private final boolean increasing;
-  private final double scale;
+
+  /**
+   * The steepness factor for the sigmoid curve.
+   * Higher values make the transition sharper, lower values make it more gradual.
+   * Value of 6 means input normalized to [-6, 6] which gives ~99.75% coverage of sigmoid range.
+   */
+  private static final double STEEPNESS = 6.0;
 
   /**
    * Create a new map strategy that performs a sigmoid mapping between a given domain and range.
@@ -31,7 +36,8 @@ public class SigmoidMapStrategy implements MapStrategy {
    * @param valueFactory The value factory to use in constructing returned and supporting values.
    * @param domain The domain from which values provided will be mapped through the sigmoid.
    * @param range The range to which values provided will be mapped through the sigmoid.
-   * @param increasing If true, values increase as x increases. If false, values decrease.
+   * @param increasing If true, values increase as input increases (standard S-curve).
+   *     If false, values decrease as input increases (inverted S-curve).
    */
   public SigmoidMapStrategy(EngineValueFactory valueFactory, MapBounds domain, MapBounds range,
       boolean increasing) {
@@ -39,32 +45,36 @@ public class SigmoidMapStrategy implements MapStrategy {
     this.domain = domain;
     this.range = range;
     this.increasing = increasing;
-
-    // Calculate scale based on domain size
-    // For domain [-5,5] and range [0,1], scale should be -1 for increasing
-    double domainSize = domain.getHigh()
-        .subtract(domain.getLow())
-        .getAsDouble();
-
-    scale = (increasing ? -1.0 : 1.0) * (10.0 / domainSize);
   }
 
   @Override
   public EngineValue apply(EngineValue operand) {
-    // Normalize input to domain [-1,1]
-    EngineValue normalizedX = operand.subtract(domain.getLow())
-        .divide(domain.getHigh().subtract(domain.getLow()))
-        .multiply(valueFactory.buildForNumber(2, Units.EMPTY))
-        .subtract(valueFactory.buildForNumber(1, Units.EMPTY));
+    // Get domain and range bounds as doubles for calculation
+    double domainLow = domain.getLow().getAsDouble();
+    double domainHigh = domain.getHigh().getAsDouble();
+    double rangeLow = range.getLow().getAsDouble();
+    double rangeHigh = range.getHigh().getAsDouble();
 
-    // Calculate sigmoid: 1 / (1 + e^(scale * x))
-    double x = normalizedX.getAsDouble() * 5;
-    double sigmoid = 1.0 / (1.0 + Math.exp(scale * x));
+    double input = operand.getAsDouble();
 
-    // Rescale sigmoid output (0,1) to range
-    EngineValue rangeSpan = range.getHigh().subtract(range.getLow());
-    return valueFactory.buildForNumber(sigmoid, Units.EMPTY)
-        .multiply(rangeSpan)
-        .add(range.getLow());
+    // Normalize input to [-STEEPNESS, +STEEPNESS] for sigmoid
+    // This ensures the sigmoid covers most of its range (0 to 1)
+    double domainSpan = domainHigh - domainLow;
+    double t = (input - domainLow) / domainSpan; // [0, 1]
+    double x = (t * 2.0 - 1.0) * STEEPNESS; // [-STEEPNESS, +STEEPNESS]
+
+    // Apply sigmoid: 1 / (1 + e^(-x))
+    double sigmoidValue = 1.0 / (1.0 + Math.exp(-x));
+
+    // Handle increasing vs decreasing
+    if (!increasing) {
+      sigmoidValue = 1.0 - sigmoidValue;
+    }
+
+    // Scale to output range
+    double rangeSpan = rangeHigh - rangeLow;
+    double output = rangeLow + sigmoidValue * rangeSpan;
+
+    return valueFactory.buildForNumber(output, range.getLow().getUnits());
   }
 }


### PR DESCRIPTION
This PR Quadratic map functions and updates the Sigmoid to be more steep (and provides a STEEPNESS parameter). Probably something we will want to investigate in the future, but the previous implementation was giving us incorrect results at the boundaries (not reaching the actual bounds expected). 

Similarly, our language spec suggests `linearly`, `quadratically` and `sigmoidally` to be viable, we now map those back to their root. 

Lastly - a few failures associated with us not properly mapping certain mathematical functions across elements as we would expect - we now properly perform these kinds of operations element-wise. 