### PR TITLE
[dev-restore] Extend the quoted compound unit logic to jshc as well

### DIFF
--- a/src/main/antlr/org/joshsim/lang/antlr/JoshConfig.g4
+++ b/src/main/antlr/org/joshsim/lang/antlr/JoshConfig.g4
@@ -11,6 +11,7 @@
  *   <li>Whitespace flexible around equals sign</li>
  *   <li>Variable names follow Josh language patterns</li>
  *   <li>Values must be valid EngineValue format (number + optional units)</li>
+ *   <li>Compound units via quoted strings: rainfall = 50 "mm / month"</li>
  * </ul>
  *
  * These configuration strings may be provided in jshc files.
@@ -31,6 +32,8 @@ COMMENT_ : '#' ~[\r\n]* -> channel(HIDDEN) ;
 EQUALS_ : '=' ;
 
 PERCENT_ : '%' ;
+
+STR_ : '"' ~["]* '"' ;
 
 IDENTIFIER_ : [A-Za-z/][A-Za-z0-9/]* ;
 
@@ -59,4 +62,4 @@ identifier : IDENTIFIER_ ;
 
 number : NUMBER_ ;
 
-value : number (identifier | PERCENT_)? ;
+value : number (identifier | PERCENT_ | STR_)? ;

--- a/src/main/java/org/joshsim/lang/interpret/visitor/JoshConfigParserVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/JoshConfigParserVisitor.java
@@ -96,6 +96,11 @@ public class JoshConfigParserVisitor extends JoshConfigBaseVisitor<JshcFragment>
       if (unitsText.equals("percent")) {
         isPercent = true;
       }
+    } else if (ctx.STR_() != null) {
+      // Handle quoted compound units like "mm / month"
+      unitsText = ctx.STR_().getText();
+      // Strip quotes
+      unitsText = unitsText.substring(1, unitsText.length() - 1);
     } else if (isPercent) {
       unitsText = "%";
     }

--- a/src/test/java/org/joshsim/engine/config/JshcConfigGetterTest.java
+++ b/src/test/java/org/joshsim/engine/config/JshcConfigGetterTest.java
@@ -179,4 +179,32 @@ public class JshcConfigGetterTest {
     verify(mockInputStrategy).exists("test");
     verify(mockInputStrategy, times(0)).open("test");
   }
+
+  @Test
+  public void testCompoundUnits() throws IOException {
+    // Setup - compound units via quoted string
+    String configContent = "rainfall = 50 \"mm / month\"\nevapRate = 2.5 \"kg / hectare\"";
+    InputStream inputStream = new ByteArrayInputStream(
+        configContent.getBytes(StandardCharsets.UTF_8));
+    when(mockInputStrategy.exists("test.jshc")).thenReturn(true);
+    when(mockInputStrategy.open("test.jshc")).thenReturn(inputStream);
+
+    // Execute
+    Optional<Config> configOpt = getter.getConfig("test.jshc");
+
+    // Verify
+    assertTrue(configOpt.isPresent());
+    Config config = configOpt.get();
+
+    assertNotNull(config.getValue("rainfall"));
+    assertEquals(50.0, config.getValue("rainfall").getAsDouble(), 0.001);
+    assertEquals(Units.of("mm / month"), config.getValue("rainfall").getUnits());
+
+    assertNotNull(config.getValue("evapRate"));
+    assertEquals(2.5, config.getValue("evapRate").getAsDouble(), 0.001);
+    assertEquals(Units.of("kg / hectare"), config.getValue("evapRate").getUnits());
+
+    verify(mockInputStrategy).exists("test.jshc");
+    verify(mockInputStrategy).open("test.jshc");
+  }
 }


### PR DESCRIPTION
Something that I should have done in #344 - extend the quoted unit logic to jshc's as well. Easy fix!