### PR TITLE
[dev-restore] Debug support for joshsim.org editor

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -10,7 +10,7 @@
       }
     </style>
     <link href="third_party/tabby-ui.min.css" rel="stylesheet" type="text/css" />
-    <link href="style/style.css?v=0.0.5" rel="stylesheet" type="text/css" />
+    <link href="style/style.css?v=0.0.8" rel="stylesheet" type="text/css" />
   </head>
 
   <body>
@@ -475,6 +475,51 @@ end simulation
                 
               </div>
             </div>
+
+            <div id="debug-panel" class="results-panel">
+              <details id="debug-details">
+                <summary><h3 style="display: inline;">Debug Output</h3></summary>
+                <div id="debug-controls">
+                  <div class="debug-filter-row">
+                    <label for="debug-location-filter">Location:</label>
+                    <span class="sel">
+                      <select id="debug-location-filter" class="debug-filter">
+                        <option value="">All locations</option>
+                      </select>
+                    </span>
+
+                    <label for="debug-step-filter">Step:</label>
+                    <span class="sel">
+                      <select id="debug-step-filter" class="debug-filter">
+                        <option value="">All steps</option>
+                      </select>
+                    </span>
+
+                    <label for="debug-entity-filter">Entity:</label>
+                    <span id="debug-entity-display" class="debug-entity-display">All</span>
+                    <button type="button" id="debug-entity-next" class="debug-entity-btn">Next</button>
+                    <button type="button" id="debug-entity-reset" class="debug-entity-btn secondary">Reset</button>
+
+                    <label for="debug-type-filter">Type:</label>
+                    <span class="sel">
+                      <select id="debug-type-filter" class="debug-filter">
+                        <option value="">All types</option>
+                        <option value="organism">organism</option>
+                        <option value="patch">patch</option>
+                        <option value="agent">agent</option>
+                        <option value="disturbance">disturbance</option>
+                      </select>
+                    </span>
+                  </div>
+                  <div class="debug-stats">
+                    Showing <span id="debug-filtered-count">0</span> of <span id="debug-total-count">0</span> messages
+                  </div>
+                </div>
+                <div id="debug-messages-container">
+                  <div id="debug-messages-list"></div>
+                </div>
+              </details>
+            </div>
           </div>
         </section>
       </main>
@@ -497,23 +542,23 @@ end simulation
     <script type="importmap">
       {
         "imports": {
-          "ai": "./js/ai.js?v=0.0.5",
-          "baselayer": "./js/baselayer.js?v=0.0.5",
-          "config": "./js/config.js?v=0.0.5",
-          "data": "./js/data.js?v=0.0.5",
-          "editor": "./js/editor.js?v=0.0.5",
-          "engine": "./js/engine.js?v=0.0.5",
-          "exporter": "./js/exporter.js?v=0.0.5",
-          "file": "./js/file.js?v=0.0.5",
-          "main": "./js/main.js?v=0.0.5",
-          "model": "./js/model.js?v=0.0.5",
-          "results": "./js/results.js?v=0.0.5",
-          "run": "./js/run.js?v=0.0.5",
-          "summarize": "./js/summarize.js?v=0.0.5",
-          "util": "./js/util.js?v=0.0.5",
-          "viz": "./js/viz.js?v=0.0.5",
-          "wasm": "./js/wasm.js?v=0.0.5",
-          "wire": "./js/wire.js?v=0.0.5"
+          "ai": "./js/ai.js?v=0.0.8",
+          "baselayer": "./js/baselayer.js?v=0.0.8",
+          "config": "./js/config.js?v=0.0.8",
+          "data": "./js/data.js?v=0.0.8",
+          "editor": "./js/editor.js?v=0.0.8",
+          "engine": "./js/engine.js?v=0.0.8",
+          "exporter": "./js/exporter.js?v=0.0.8",
+          "file": "./js/file.js?v=0.0.8",
+          "main": "./js/main.js?v=0.0.8",
+          "model": "./js/model.js?v=0.0.8",
+          "results": "./js/results.js?v=0.0.8",
+          "run": "./js/run.js?v=0.0.8",
+          "summarize": "./js/summarize.js?v=0.0.8",
+          "util": "./js/util.js?v=0.0.8",
+          "viz": "./js/viz.js?v=0.0.8",
+          "wasm": "./js/wasm.js?v=0.0.8",
+          "wire": "./js/wire.js?v=0.0.8"
         }
       }
     </script>

--- a/editor/index.html
+++ b/editor/index.html
@@ -10,7 +10,7 @@
       }
     </style>
     <link href="third_party/tabby-ui.min.css" rel="stylesheet" type="text/css" />
-    <link href="style/style.css?v=0.0.3" rel="stylesheet" type="text/css" />
+    <link href="style/style.css?v=0.0.5" rel="stylesheet" type="text/css" />
   </head>
 
   <body>
@@ -497,23 +497,23 @@ end simulation
     <script type="importmap">
       {
         "imports": {
-          "ai": "./js/ai.js?v=0.0.3",
-          "baselayer": "./js/baselayer.js?v=0.0.3",
-          "config": "./js/config.js?v=0.0.3",
-          "data": "./js/data.js?v=0.0.3",
-          "editor": "./js/editor.js?v=0.0.3",
-          "engine": "./js/engine.js?v=0.0.3",
-          "exporter": "./js/exporter.js?v=0.0.3",
-          "file": "./js/file.js?v=0.0.3",
-          "main": "./js/main.js?v=0.0.3",
-          "model": "./js/model.js?v=0.0.3",
-          "results": "./js/results.js?v=0.0.3",
-          "run": "./js/run.js?v=0.0.3",
-          "summarize": "./js/summarize.js?v=0.0.3",
-          "util": "./js/util.js?v=0.0.3",
-          "viz": "./js/viz.js?v=0.0.3",
-          "wasm": "./js/wasm.js?v=0.0.3",
-          "wire": "./js/wire.js?v=0.0.3"
+          "ai": "./js/ai.js?v=0.0.5",
+          "baselayer": "./js/baselayer.js?v=0.0.5",
+          "config": "./js/config.js?v=0.0.5",
+          "data": "./js/data.js?v=0.0.5",
+          "editor": "./js/editor.js?v=0.0.5",
+          "engine": "./js/engine.js?v=0.0.5",
+          "exporter": "./js/exporter.js?v=0.0.5",
+          "file": "./js/file.js?v=0.0.5",
+          "main": "./js/main.js?v=0.0.5",
+          "model": "./js/model.js?v=0.0.5",
+          "results": "./js/results.js?v=0.0.5",
+          "run": "./js/run.js?v=0.0.5",
+          "summarize": "./js/summarize.js?v=0.0.5",
+          "util": "./js/util.js?v=0.0.5",
+          "viz": "./js/viz.js?v=0.0.5",
+          "wasm": "./js/wasm.js?v=0.0.5",
+          "wire": "./js/wire.js?v=0.0.5"
         }
       }
     </script>

--- a/editor/js/main.js
+++ b/editor/js/main.js
@@ -208,7 +208,13 @@ class MainPresenter {
     const self = this;
     self._replicateResults = results;
     self._runPresenter.showButtons();
-    self._resultsPresenter.onComplete(self._metadata, self._replicateResults);
+
+    // Get debug store if using WASM backend
+    const debugStore = (self._currentEngineBackend && self._currentEngineBackend.getType() === "wasm")
+      ? self._wasmLayer.getDebugStore()
+      : null;
+
+    self._resultsPresenter.onComplete(self._metadata, self._replicateResults, debugStore);
   }
 
   /**

--- a/editor/js/model.js
+++ b/editor/js/model.js
@@ -692,7 +692,198 @@ class SimulationResultBuilder {
 }
 
 
+/**
+ * Represents a single debug message from the simulation.
+ */
+class DebugMessage {
+
+  /**
+   * Create a new debug message.
+   *
+   * @param {number} step - The simulation step when this message was emitted.
+   * @param {string} entityType - The type of entity (organism, patch, etc.).
+   * @param {string} entityId - The unique identifier of the entity.
+   * @param {number} x - The x coordinate of the entity.
+   * @param {number} y - The y coordinate of the entity.
+   * @param {string} content - The actual debug message content.
+   * @param {string} raw - The raw unparsed message string.
+   */
+  constructor(step, entityType, entityId, x, y, content, raw) {
+    const self = this;
+    self._step = step;
+    self._entityType = entityType;
+    self._entityId = entityId;
+    self._x = x;
+    self._y = y;
+    self._content = content;
+    self._raw = raw;
+  }
+
+  getStep() { return this._step; }
+  getEntityType() { return this._entityType; }
+  getEntityId() { return this._entityId; }
+  getX() { return this._x; }
+  getY() { return this._y; }
+  getContent() { return this._content; }
+  getRaw() { return this._raw; }
+
+  /**
+   * Get a location key for filtering by patch.
+   * @returns {string} Location key in format "x,y"
+   */
+  getLocationKey() {
+    const self = this;
+    return `${self._x},${self._y}`;
+  }
+
+  /**
+   * Parse a debug message string into a DebugMessage object.
+   *
+   * Expected format: "[Step N, entityType @ entityId (x, y)] content"
+   *
+   * @param {string} raw - The raw debug message string.
+   * @returns {?DebugMessage} Parsed message or null if parsing fails.
+   */
+  static parse(raw) {
+    // Format: [Step N, entityType @ entityId (x, y)] content
+    const match = raw.match(/^\[Step (\d+), (\w+) @ ([a-f0-9]+) \(([\d.]+), ([\d.]+)\)\] (.*)$/);
+    if (!match) {
+      console.warn("Failed to parse debug message:", raw);
+      return null;
+    }
+
+    const step = parseInt(match[1], 10);
+    const entityType = match[2];
+    const entityId = match[3];
+    const x = parseFloat(match[4]);
+    const y = parseFloat(match[5]);
+    const content = match[6];
+
+    return new DebugMessage(step, entityType, entityId, x, y, content, raw);
+  }
+}
+
+
+/**
+ * Stores debug messages and provides filtering capabilities.
+ */
+class DebugMessageStore {
+
+  constructor() {
+    const self = this;
+    self._messages = [];
+    self._locations = new Set();
+    self._steps = new Set();
+    self._entityIds = new Set();
+    self._entityTypes = new Set();
+  }
+
+  /**
+   * Add a debug message to the store.
+   * @param {DebugMessage} message - The message to add.
+   */
+  add(message) {
+    const self = this;
+    if (!message) return;
+
+    self._messages.push(message);
+    self._locations.add(message.getLocationKey());
+    self._steps.add(message.getStep());
+    self._entityIds.add(message.getEntityId());
+    self._entityTypes.add(message.getEntityType());
+  }
+
+  /**
+   * Clear all stored messages.
+   */
+  clear() {
+    const self = this;
+    self._messages = [];
+    self._locations.clear();
+    self._steps.clear();
+    self._entityIds.clear();
+    self._entityTypes.clear();
+  }
+
+  /**
+   * Get all unique locations.
+   * @returns {Array<string>} Sorted array of location keys.
+   */
+  getLocations() {
+    const self = this;
+    return Array.from(self._locations).sort();
+  }
+
+  /**
+   * Get all unique steps.
+   * @returns {Array<number>} Sorted array of step numbers.
+   */
+  getSteps() {
+    const self = this;
+    return Array.from(self._steps).sort((a, b) => a - b);
+  }
+
+  /**
+   * Get all unique entity IDs.
+   * @returns {Array<string>} Sorted array of entity IDs.
+   */
+  getEntityIds() {
+    const self = this;
+    return Array.from(self._entityIds).sort();
+  }
+
+  /**
+   * Get all unique entity types.
+   * @returns {Array<string>} Sorted array of entity types.
+   */
+  getEntityTypes() {
+    const self = this;
+    return Array.from(self._entityTypes).sort();
+  }
+
+  /**
+   * Get total message count.
+   * @returns {number} Total number of messages.
+   */
+  getCount() {
+    const self = this;
+    return self._messages.length;
+  }
+
+  /**
+   * Get all messages.
+   * @returns {Array<DebugMessage>} All stored messages.
+   */
+  getAll() {
+    const self = this;
+    return self._messages;
+  }
+
+  /**
+   * Filter messages based on criteria.
+   *
+   * @param {?string} location - Location key to filter by, or null for all.
+   * @param {?number} step - Step number to filter by, or null for all.
+   * @param {?string} entityId - Entity ID to filter by, or null for all.
+   * @param {?string} entityType - Entity type to filter by, or null for all.
+   * @returns {Array<DebugMessage>} Filtered messages.
+   */
+  filter(location, step, entityId, entityType) {
+    const self = this;
+    return self._messages.filter((msg) => {
+      if (location !== null && msg.getLocationKey() !== location) return false;
+      if (step !== null && msg.getStep() !== step) return false;
+      if (entityId !== null && msg.getEntityId() !== entityId) return false;
+      if (entityType !== null && msg.getEntityType() !== entityType) return false;
+      return true;
+    });
+  }
+}
+
+
 export {
+  DebugMessage,
+  DebugMessageStore,
   OutputDatum,
   SimulationMetadata,
   SimulationResult,

--- a/editor/js/parse.js
+++ b/editor/js/parse.js
@@ -92,10 +92,9 @@ function parseEngineResponse(source) {
     };
   }
 
-  // Handle debug messages - log to console and return as debug type
+  // Handle debug messages - return as debug type for UI display
   const debugMatch = source.match(/^\[debug\] (.+)$/);
   if (debugMatch) {
-    console.log("[JOSH DEBUG]", debugMatch[1]);
     return {
       type: "debug",
       message: debugMatch[1]

--- a/editor/js/parse.js
+++ b/editor/js/parse.js
@@ -92,6 +92,16 @@ function parseEngineResponse(source) {
     };
   }
 
+  // Handle debug messages - log to console and return as debug type
+  const debugMatch = source.match(/^\[debug\] (.+)$/);
+  if (debugMatch) {
+    console.log("[JOSH DEBUG]", debugMatch[1]);
+    return {
+      type: "debug",
+      message: debugMatch[1]
+    };
+  }
+
   const match = source.match(/^\[(\d+)\] (.+)$/);
   if (!match) {
     throw "Got error engine response: " + source;

--- a/editor/js/results.js
+++ b/editor/js/results.js
@@ -1,11 +1,12 @@
 /**
  * Logic for presenters handling simulation results display.
- * 
+ *
  * @license BSD-3-Clause
  */
 
 import {BasemapDialogPresenter} from "baselayer";
 import {ExportPresenter} from "exporter";
+import {DebugMessage, DebugMessageStore} from "model";
 import {DataQuery, summarizeDatasets} from "summarize";
 import {GridPresenter, ScrubPresenter, MapConfigPresenter} from "viz";
 
@@ -17,7 +18,7 @@ class ResultsPresenter {
 
   /**
    * Creates a new results presenter.
-   * 
+   *
    * @param {string} rootId - The ID of the element containing the results display.
    */
   constructor(rootId) {
@@ -38,6 +39,9 @@ class ResultsPresenter {
       self._root.querySelector("#map-dialog"),
       (url) => self._onBasemapChange(url)
     );
+    self._debugPresenter = new DebugPresenter(
+      self._root.querySelector("#debug-panel")
+    );
 
     self._results = null;
     self._metadata = null;
@@ -52,6 +56,7 @@ class ResultsPresenter {
     const self = this;
     self._statusPresenter.resetProgress();
     self._resultsDisplayPresenter.hide();
+    self._debugPresenter.clear();
     self._root.style.display = "block";
     self._secondsOnStart = self._getEpochSeconds();
   }
@@ -73,8 +78,9 @@ class ResultsPresenter {
    * @param {SimulationMetadata} metadata - The metadata of the simulation being displayed.
    * @param {Array<SimulationResult>} results - Array of simulation results containing output
    *     records.
+   * @param {DebugMessageStore} debugStore - Optional store containing debug messages.
    */
-  onComplete(metadata, results) {
+  onComplete(metadata, results, debugStore) {
     const self = this;
     self._metadata = metadata;
     self._results = results;
@@ -83,6 +89,9 @@ class ResultsPresenter {
     self._renderDisplay(metadata);
     self._exportPresenter.setDataset(metadata, results);
     self._baselayerDialogPresenter.setMetadata(metadata);
+    if (debugStore) {
+      self._debugPresenter.setDebugStore(debugStore);
+    }
   }
 
   /**
@@ -596,4 +605,300 @@ class DataQuerySelector {
 }
 
 
-export {ResultsPresenter};
+/**
+ * Presenter for the debug output panel with filtering capabilities.
+ */
+class DebugPresenter {
+
+  /**
+   * Creates a new debug presenter.
+   *
+   * @param {Element} panelElement - The debug panel DOM element.
+   */
+  constructor(panelElement) {
+    const self = this;
+    self._panel = panelElement;
+    self._debugStore = null;
+    self._entityIds = [];
+    self._currentEntityIndex = -1; // -1 means "All"
+
+    self._locationFilter = self._panel.querySelector("#debug-location-filter");
+    self._stepFilter = self._panel.querySelector("#debug-step-filter");
+    self._entityDisplay = self._panel.querySelector("#debug-entity-display");
+    self._entityNextBtn = self._panel.querySelector("#debug-entity-next");
+    self._entityResetBtn = self._panel.querySelector("#debug-entity-reset");
+    self._typeFilter = self._panel.querySelector("#debug-type-filter");
+    self._filteredCount = self._panel.querySelector("#debug-filtered-count");
+    self._totalCount = self._panel.querySelector("#debug-total-count");
+    self._messagesList = self._panel.querySelector("#debug-messages-list");
+
+    self._addEventListeners();
+  }
+
+  /**
+   * Sets the debug message store and updates the display.
+   *
+   * @param {DebugMessageStore} debugStore - The store containing debug messages.
+   */
+  setDebugStore(debugStore) {
+    const self = this;
+    self._debugStore = debugStore;
+
+    if (debugStore && debugStore.getAll().length > 0) {
+      self._panel.classList.add("visible");
+      self._populateFilters();
+      self._renderMessages();
+    } else {
+      self._panel.classList.remove("visible");
+    }
+  }
+
+  /**
+   * Clears the debug display and hides the panel.
+   */
+  clear() {
+    const self = this;
+    self._debugStore = null;
+    self._entityIds = [];
+    self._currentEntityIndex = -1;
+    self._panel.classList.remove("visible");
+    self._messagesList.innerHTML = "";
+    self._resetFilters();
+  }
+
+  /**
+   * Adds event listeners to filter controls.
+   */
+  _addEventListeners() {
+    const self = this;
+
+    // When other filters change, rebuild the filtered entity list
+    self._locationFilter.addEventListener("change", () => self._onFilterChange());
+    self._stepFilter.addEventListener("change", () => self._onFilterChange());
+    self._typeFilter.addEventListener("change", () => self._onFilterChange());
+
+    self._entityNextBtn.addEventListener("click", () => self._nextEntity());
+    self._entityResetBtn.addEventListener("click", () => self._resetEntity());
+  }
+
+  /**
+   * Handles changes to location, step, or type filters.
+   * Rebuilds the filtered entity list and resets entity selection.
+   */
+  _onFilterChange() {
+    const self = this;
+    self._rebuildFilteredEntityIds();
+    self._currentEntityIndex = -1;
+    self._updateEntityDisplay();
+    self._renderMessages();
+  }
+
+  /**
+   * Rebuilds the list of entity IDs that match current filters (excluding entity filter).
+   */
+  _rebuildFilteredEntityIds() {
+    const self = this;
+    if (!self._debugStore) {
+      self._entityIds = [];
+      return;
+    }
+
+    const location = self._locationFilter.value || null;
+    const step = self._stepFilter.value ? parseInt(self._stepFilter.value) : null;
+    const entityType = self._typeFilter.value || null;
+
+    // Get messages matching current filters (without entity filter)
+    const filtered = self._debugStore.filter(location, step, null, entityType);
+
+    // Extract unique entity IDs from filtered messages
+    const entityIdSet = new Set();
+    filtered.forEach(msg => entityIdSet.add(msg.getEntityId()));
+    self._entityIds = Array.from(entityIdSet).sort();
+  }
+
+  /**
+   * Advances to the next entity ID.
+   */
+  _nextEntity() {
+    const self = this;
+    if (self._entityIds.length === 0) return;
+
+    self._currentEntityIndex++;
+    if (self._currentEntityIndex >= self._entityIds.length) {
+      self._currentEntityIndex = 0;
+    }
+
+    self._updateEntityDisplay();
+    self._renderMessages();
+  }
+
+  /**
+   * Resets entity filter to show all entities.
+   */
+  _resetEntity() {
+    const self = this;
+    self._currentEntityIndex = -1;
+    self._updateEntityDisplay();
+    self._renderMessages();
+  }
+
+  /**
+   * Updates the entity display text.
+   */
+  _updateEntityDisplay() {
+    const self = this;
+    if (self._currentEntityIndex < 0 || self._entityIds.length === 0) {
+      self._entityDisplay.textContent = "All";
+    } else {
+      const id = self._entityIds[self._currentEntityIndex];
+      const num = self._currentEntityIndex + 1;
+      const total = self._entityIds.length;
+      self._entityDisplay.textContent = `${num}/${total}`;
+    }
+  }
+
+  /**
+   * Resets all filters to their default state.
+   */
+  _resetFilters() {
+    const self = this;
+    self._locationFilter.innerHTML = '<option value="">All locations</option>';
+    self._stepFilter.innerHTML = '<option value="">All steps</option>';
+    self._currentEntityIndex = -1;
+    self._updateEntityDisplay();
+    self._typeFilter.value = "";
+  }
+
+  /**
+   * Populates filter controls based on available data in the debug store.
+   */
+  _populateFilters() {
+    const self = this;
+    if (!self._debugStore) return;
+
+    // Populate locations
+    self._locationFilter.innerHTML = '<option value="">All locations</option>';
+    const locations = self._debugStore.getLocations();
+    locations.forEach(loc => {
+      const option = document.createElement("option");
+      option.value = loc;
+      option.text = loc;
+      self._locationFilter.appendChild(option);
+    });
+
+    // Populate steps
+    self._stepFilter.innerHTML = '<option value="">All steps</option>';
+    const steps = self._debugStore.getSteps();
+    steps.sort((a, b) => a - b);
+    steps.forEach(step => {
+      const option = document.createElement("option");
+      option.value = step;
+      option.text = `Step ${step}`;
+      self._stepFilter.appendChild(option);
+    });
+
+    // Build filtered entity IDs for cycling
+    self._rebuildFilteredEntityIds();
+    self._currentEntityIndex = -1;
+    self._updateEntityDisplay();
+
+    // Set default filter to first location if there are many messages
+    const allMessages = self._debugStore.getAll();
+    if (allMessages.length > 100 && locations.length > 0) {
+      self._locationFilter.value = locations[0];
+    }
+  }
+
+  /**
+   * Gets the currently selected entity ID.
+   *
+   * @returns {?string} The selected entity ID or null for all.
+   */
+  _getCurrentEntityId() {
+    const self = this;
+    if (self._currentEntityIndex < 0 || self._entityIds.length === 0) {
+      return null;
+    }
+    return self._entityIds[self._currentEntityIndex];
+  }
+
+  /**
+   * Renders messages based on current filter selections.
+   */
+  _renderMessages() {
+    const self = this;
+    if (!self._debugStore) {
+      self._messagesList.innerHTML = '<div class="debug-no-messages">No debug messages</div>';
+      return;
+    }
+
+    const location = self._locationFilter.value || null;
+    const step = self._stepFilter.value ? parseInt(self._stepFilter.value) : null;
+    const entityId = self._getCurrentEntityId();
+    const entityType = self._typeFilter.value || null;
+
+    const filtered = self._debugStore.filter(location, step, entityId, entityType);
+    const total = self._debugStore.getAll().length;
+
+    self._filteredCount.textContent = filtered.length;
+    self._totalCount.textContent = total;
+
+    if (filtered.length === 0) {
+      self._messagesList.innerHTML = '<div class="debug-no-messages">No messages match the current filters</div>';
+      return;
+    }
+
+    // Limit display to prevent browser slowdown
+    const displayLimit = 500;
+    const toDisplay = filtered.slice(0, displayLimit);
+
+    const html = toDisplay.map(msg => self._renderMessage(msg)).join("");
+    self._messagesList.innerHTML = html;
+
+    if (filtered.length > displayLimit) {
+      const moreDiv = document.createElement("div");
+      moreDiv.className = "debug-no-messages";
+      moreDiv.textContent = `... and ${filtered.length - displayLimit} more messages. Use filters to narrow results.`;
+      self._messagesList.appendChild(moreDiv);
+    }
+  }
+
+  /**
+   * Renders a single debug message to HTML.
+   *
+   * @param {DebugMessage} msg - The debug message to render.
+   * @returns {string} HTML string for the message.
+   */
+  _renderMessage(msg) {
+    const step = msg.getStep();
+    const entityType = msg.getEntityType();
+    const entityId = msg.getEntityId();
+    const x = msg.getX();
+    const y = msg.getY();
+    const content = this._escapeHtml(msg.getContent());
+
+    return `<div class="debug-message">
+      <span class="debug-message-header">
+        <span class="debug-message-step">[Step ${step}]</span>
+        <span class="debug-message-entity">${entityType} @ ${entityId.substring(0, 8)}</span>
+        <span class="debug-message-location">(${x}, ${y})</span>
+      </span>
+      <span class="debug-message-content">${content}</span>
+    </div>`;
+  }
+
+  /**
+   * Escapes HTML special characters in a string.
+   *
+   * @param {string} text - The text to escape.
+   * @returns {string} The escaped text.
+   */
+  _escapeHtml(text) {
+    const div = document.createElement("div");
+    div.textContent = text;
+    return div.innerHTML;
+  }
+}
+
+
+export {DebugPresenter, ResultsPresenter};

--- a/editor/js/wasm.js
+++ b/editor/js/wasm.js
@@ -22,7 +22,7 @@ class WasmLayer {
    */
   constructor() {
     const self = this;
-    self._worker = new Worker("./js/wasm.worker.js");
+    self._worker = new Worker("./js/wasm.worker.js?v=0.0.5");
     self._initialized = false;
     self._datasetBuilder = null;
     self._wireSerializer = new ExternalDataSerializer();

--- a/editor/js/wasm.js
+++ b/editor/js/wasm.js
@@ -4,7 +4,7 @@
  * @license BSD-3-Clause
  */
 
-import {SimulationMetadata, SimulationResult, SimulationResultBuilder, OutputDatum} from "model";
+import {SimulationMetadata, SimulationResult, SimulationResultBuilder, OutputDatum, DebugMessage, DebugMessageStore} from "model";
 import {getDistanceMeters} from "util";
 import {ExternalDataSerializer} from "wire";
 
@@ -22,10 +22,11 @@ class WasmLayer {
    */
   constructor() {
     const self = this;
-    self._worker = new Worker("./js/wasm.worker.js?v=0.0.5");
+    self._worker = new Worker("./js/wasm.worker.js?v=0.0.8");
     self._initialized = false;
     self._datasetBuilder = null;
     self._wireSerializer = new ExternalDataSerializer();
+    self._debugStore = new DebugMessageStore();
     self._initPromise = new Promise((resolve, reject) => {
       self._worker.onmessage = (e) => {
         const { type, result, error, success } = e.data;
@@ -144,7 +145,8 @@ class WasmLayer {
 
     const externalDataStr = self._wireSerializer.serialize(externalData);
     self._datasetBuilder = new SimulationResultBuilder();
-    
+    self._debugStore.clear();
+
     return new Promise((resolve, reject) => {
       self._worker.onmessage = (e) => {
         const { type, error, success } = e.data;
@@ -162,6 +164,9 @@ class WasmLayer {
           const rawInput = e.data.result;
           const parsed = new OutputDatum(rawInput["target"], rawInput["attributes"]);
           self._datasetBuilder.add(parsed);
+        } else if (type === "debug") {
+          const parsed = DebugMessage.parse(e.data.result);
+          self._debugStore.add(parsed);
         }
       };
       self._worker.postMessage({
@@ -312,6 +317,16 @@ class WasmLayer {
   _isDegrees(unitsStr) {
     const self = this;
     return unitsStr === "degree" || unitsStr === "degrees";
+  }
+
+  /**
+   * Get the debug message store containing messages from the last simulation run.
+   *
+   * @returns {DebugMessageStore} The debug message store.
+   */
+  getDebugStore() {
+    const self = this;
+    return self._debugStore;
   }
 }
 

--- a/editor/js/wasm.worker.js
+++ b/editor/js/wasm.worker.js
@@ -1,6 +1,6 @@
-importScripts("../war/js/JoshSim.js?v=0.0.3");
-importScripts("../war/wasm-gc/JoshSim.wasm-runtime.js?v=0.0.3");
-importScripts("./parse.js?v=0.0.3");
+importScripts("../war/js/JoshSim.js?v=0.0.5");
+importScripts("../war/wasm-gc/JoshSim.wasm-runtime.js?v=0.0.5");
+importScripts("./parse.js?v=0.0.5");
 
 let wasmLayer = null;
 let postMessage = null;
@@ -18,11 +18,22 @@ function reportStepComplete(stepCount) {
 
 /**
  * Parses a data string from MemoryWriteStrategy and reports the parsed data to the main thread.
- * 
+ *
  * @param {string} source - The formatted string containing target name and key-value pairs.
  */
 function reportData(source) {
-  const datum = parseDatum(source);
+  const trimmed = source.trim();
+
+  // Check for debug messages first - they have a different format
+  // Use startsWith for robustness (avoids regex edge cases with newlines)
+  if (trimmed.startsWith("[debug] ")) {
+    const message = trimmed.substring(8); // Remove "[debug] " prefix
+    console.log("[JOSH DEBUG]", message);
+    postMessage({ type: "debug", success: true, result: message });
+    return;
+  }
+
+  const datum = parseDatum(trimmed);
   postMessage({ type: "outputDatum", success: true, result: datum });
 }
 

--- a/editor/js/wasm.worker.js
+++ b/editor/js/wasm.worker.js
@@ -1,6 +1,6 @@
-importScripts("../war/js/JoshSim.js?v=0.0.5");
-importScripts("../war/wasm-gc/JoshSim.wasm-runtime.js?v=0.0.5");
-importScripts("./parse.js?v=0.0.5");
+importScripts("../war/js/JoshSim.js?v=0.0.8");
+importScripts("../war/wasm-gc/JoshSim.wasm-runtime.js?v=0.0.8");
+importScripts("./parse.js?v=0.0.8");
 
 let wasmLayer = null;
 let postMessage = null;

--- a/editor/js/wasm.worker.js
+++ b/editor/js/wasm.worker.js
@@ -28,7 +28,6 @@ function reportData(source) {
   // Use startsWith for robustness (avoids regex edge cases with newlines)
   if (trimmed.startsWith("[debug] ")) {
     const message = trimmed.substring(8); // Remove "[debug] " prefix
-    console.log("[JOSH DEBUG]", message);
     postMessage({ type: "debug", success: true, result: message });
     return;
   }

--- a/editor/js/wire.js
+++ b/editor/js/wire.js
@@ -123,6 +123,9 @@ class ResponseReader {
         const rawInput = intermediate["datum"];
         const parsed = new OutputDatum(rawInput["target"], rawInput["attributes"]);
         self._replicateReducer.get(intermediate["replicate"]).add(parsed);
+      } else if (intermediate["type"] === "debug") {
+        // Debug messages are already logged to console in parseEngineResponse
+        // Just ignore them here - they don't affect simulation results
       } else if (intermediate["type"] === "end") {
         self._completedReplicates++;
         if (self._replicateReducer.has(intermediate["replicate"])) {

--- a/editor/style/style.css
+++ b/editor/style/style.css
@@ -633,3 +633,155 @@ main {
   83.33% { border-color: #303030; }          /* Flash to dark (0.5s) */
   100% { border-color: #D0D0D0; }            /* Fade back (0.5s) */
 }
+
+/* Debug Panel Styles */
+#debug-panel {
+  display: none;
+  border-top: 1px solid #E0E0E0;
+  margin-top: 20px;
+  padding-top: 15px;
+}
+
+#debug-panel.visible {
+  display: block;
+}
+
+#debug-details summary {
+  cursor: pointer;
+  user-select: none;
+}
+
+#debug-details summary h3 {
+  margin: 0;
+  font-size: 16px;
+}
+
+#debug-controls {
+  margin-top: 15px;
+  padding: 10px;
+  background-color: #F5F5F5;
+  border-radius: 5px;
+}
+
+.debug-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.debug-filter-row label {
+  font-size: 12px;
+  font-weight: bold;
+  margin-left: 10px;
+}
+
+.debug-filter-row label:first-child {
+  margin-left: 0;
+}
+
+.debug-filter-row .sel select {
+  font-size: 12px;
+  padding: 3px 20px 3px 5px;
+  max-width: 150px;
+}
+
+.debug-entity-display {
+  display: inline-block;
+  min-width: 60px;
+  padding: 3px 8px;
+  background-color: #F0F0F0;
+  border: 1px solid #D0D0D0;
+  border-radius: 3px;
+  font-size: 12px;
+  font-family: monospace;
+}
+
+.debug-entity-btn {
+  padding: 3px 10px;
+  font-size: 11px;
+  border: 1px solid #A0A0A0;
+  border-radius: 3px;
+  background-color: #7070C0;
+  color: white;
+  cursor: pointer;
+  margin-left: 5px;
+}
+
+.debug-entity-btn:hover {
+  background-color: #5050C0;
+}
+
+.debug-entity-btn.secondary {
+  background-color: #E0E0E0;
+  color: black;
+}
+
+.debug-entity-btn.secondary:hover {
+  background-color: #C0C0C0;
+}
+
+.debug-stats {
+  margin-top: 10px;
+  font-size: 12px;
+  color: #666;
+}
+
+#debug-messages-container {
+  margin-top: 15px;
+  max-height: 300px;
+  overflow-y: auto;
+  border: 1px solid #D0D0D0;
+  border-radius: 4px;
+  background-color: #FAFAFA;
+}
+
+#debug-messages-list {
+  font-family: monospace;
+  font-size: 11px;
+  padding: 10px;
+}
+
+.debug-message {
+  padding: 4px 8px;
+  border-bottom: 1px dotted #E0E0E0;
+  line-height: 1.4;
+}
+
+.debug-message:last-child {
+  border-bottom: none;
+}
+
+.debug-message:hover {
+  background-color: #F0F0F0;
+}
+
+.debug-message-header {
+  color: #666;
+  font-size: 10px;
+}
+
+.debug-message-step {
+  color: #5050C0;
+  font-weight: bold;
+}
+
+.debug-message-entity {
+  color: #707070;
+}
+
+.debug-message-location {
+  color: #909090;
+}
+
+.debug-message-content {
+  color: #333;
+  margin-left: 10px;
+}
+
+.debug-no-messages {
+  padding: 20px;
+  text-align: center;
+  color: #999;
+  font-style: italic;
+}

--- a/examples/guide/hello_debug.josh
+++ b/examples/guide/hello_debug.josh
@@ -1,0 +1,43 @@
+start simulation Main
+
+  grid.size = 1000 m
+  grid.low = 33.7 degrees latitude, -115.4 degrees longitude
+  grid.high = 34.0 degrees latitude, -116.4 degrees longitude
+  grid.patch = "Default"
+
+  steps.low = 0 count
+  steps.high = 10 count
+
+  exportFiles.patch = "memory://editor/patches"
+  debugFiles.organism = "memory://editor/debug"
+
+end simulation
+
+start patch Default
+
+  ForeverTree.init = create 10 count of ForeverTree
+
+  export.averageAge.step = mean(ForeverTree.age)
+  export.averageHeight.step = mean(ForeverTree.height)
+
+end patch
+
+start organism ForeverTree
+
+  age.init = 0 year
+  age.step = prior.age + 1 year
+
+  height.init = 0 meters
+  height.step = prior.height + sample uniform from 0 meters to 1 meters
+
+  dbg.step = debug("age:", current.age, "height:", current.height)
+
+end organism
+
+start unit year
+
+  alias years
+  alias yr
+  alias yrs
+
+end unit

--- a/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
+++ b/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
@@ -101,7 +101,7 @@ IDENTIFIER_: [A-Za-z][A-Za-z0-9]*;
 WHITE_SPACE: [ \u000B\t\r\n] -> channel(HIDDEN);
 
 // Identifiers
-nakedIdentifier: (IDENTIFIER_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_|ORGANISM_);
+nakedIdentifier: (IDENTIFIER_|DEBUG_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_|ORGANISM_);
 identifier: nakedIdentifier (DOT_ (nakedIdentifier))*;
 
 // Values

--- a/src/main/java/org/joshsim/lang/io/DebugOutputFacadeBuilder.java
+++ b/src/main/java/org/joshsim/lang/io/DebugOutputFacadeBuilder.java
@@ -25,12 +25,20 @@ import org.joshsim.engine.value.type.EngineValue;
  *
  * <p>Supported path schemes depend on the ExportFacadeFactory implementation:</p>
  * <ul>
- *   <li>file:// - writes to local file system</li>
- *   <li>minio:// - writes to MinIO object storage (requires MinIO configuration)</li>
+ *   <li>file:// - writes to local file system (JVM only)</li>
+ *   <li>minio:// - writes to MinIO object storage (JVM only, requires MinIO configuration)</li>
  *   <li>stdout:// - writes to standard output</li>
+ *   <li>memory://editor/debug - writes to browser console via callback (WASM only)</li>
  * </ul>
  *
- * <p>Example usage:</p>
+ * <p>Example usage in Josh simulation for WASM/browser:</p>
+ * <pre>
+ * start simulation Example
+ *   debugFiles.organism = "memory://editor/debug"
+ * end simulation
+ * </pre>
+ *
+ * <p>Example usage in Java:</p>
  * <pre>
  * CombinedDebugOutputFacade debugFacade = DebugOutputFacadeBuilder.build(simEntity, factory);
  * debugFacade.start();
@@ -84,11 +92,10 @@ public class DebugOutputFacadeBuilder {
   /**
    * Creates an OutputStreamStrategy from a path string.
    *
-   * <p>Handles stdout:// specially, and delegates to JvmExportFacadeFactory for file:// and
-   * minio://. Other factory types (e.g., SandboxExportFacadeFactory for WASM) do not support
-   * debug file output and will throw an exception.</p>
+   * <p>Handles stdout:// specially, memory:// for sandbox environments (WASM), and delegates
+   * to JvmExportFacadeFactory for file:// and minio://.</p>
    *
-   * @param path The path string (e.g., "file:///tmp/debug.txt", "stdout://")
+   * @param path The path string (e.g., "file:///tmp/debug.txt", "stdout://", "memory://editor/debug")
    * @param exportFactory The export factory to use for creating strategies.
    * @return The appropriate OutputStreamStrategy for the path.
    * @throws IllegalArgumentException if the path scheme is unsupported or factory doesn't support
@@ -104,6 +111,18 @@ public class DebugOutputFacadeBuilder {
 
     ExportTarget target = ExportTargetParser.parse(cleanPath);
 
+    // Handle memory:// protocol for sandbox environments (WASM)
+    if (target.getProtocol().equals("memory")) {
+      if (exportFactory instanceof SandboxExportFacadeFactory sandboxFactory) {
+        return sandboxFactory.createDebugOutputStreamStrategy();
+      }
+      // memory:// in JVM environment - just ignore (no output)
+      throw new UnsupportedOperationException(
+          "memory:// debug output is only supported in sandbox/WASM environments. "
+          + "Use file:// or stdout:// for debug output in JVM environments."
+      );
+    }
+
     // Only JvmExportFacadeFactory supports file-based debug output
     // Other factories (e.g., SandboxExportFacadeFactory for WASM) don't support file I/O
     if (exportFactory instanceof JvmExportFacadeFactory jvmFactory) {
@@ -113,7 +132,7 @@ public class DebugOutputFacadeBuilder {
     // Non-JVM environments don't support debug file output
     throw new UnsupportedOperationException(
         "Debug file output is only supported in JVM environments. "
-        + "Use stdout:// for debug output in other environments, "
+        + "Use memory://editor/debug for WASM, stdout:// for console, "
         + "or remove debugFiles configuration."
     );
   }

--- a/src/main/java/org/joshsim/lang/io/DebugOutputFacadeBuilder.java
+++ b/src/main/java/org/joshsim/lang/io/DebugOutputFacadeBuilder.java
@@ -95,7 +95,7 @@ public class DebugOutputFacadeBuilder {
    * <p>Handles stdout:// specially, memory:// for sandbox environments (WASM), and delegates
    * to JvmExportFacadeFactory for file:// and minio://.</p>
    *
-   * @param path The path string (e.g., "file:///tmp/debug.txt", "stdout://", "memory://editor/debug")
+   * @param path The path string (e.g., "file:///tmp/debug.txt", "memory://editor/debug", etc).
    * @param exportFactory The export factory to use for creating strategies.
    * @return The appropriate OutputStreamStrategy for the path.
    * @throws IllegalArgumentException if the path scheme is unsupported or factory doesn't support

--- a/src/main/java/org/joshsim/lang/io/SandboxExportFacadeFactory.java
+++ b/src/main/java/org/joshsim/lang/io/SandboxExportFacadeFactory.java
@@ -109,6 +109,19 @@ public class SandboxExportFacadeFactory implements ExportFacadeFactory {
   }
 
   /**
+   * Creates an OutputStreamStrategy for debug output that writes through the callback.
+   *
+   * <p>This allows debug output to use the same callback mechanism as exports in
+   * sandbox environments (WebAssembly). The debug messages are prefixed with "[debug] "
+   * so JavaScript can distinguish them from export data.</p>
+   *
+   * @return An OutputStreamStrategy that writes debug messages through the sandbox callback.
+   */
+  public OutputStreamStrategy createDebugOutputStreamStrategy() {
+    return () -> new DebugRedirectOutputStream(callback);
+  }
+
+  /**
    * An OutputStream implementation that redirects output through an in-memory callback.
    *
    * <p>This class is thread-safe and can be used concurrently by multiple threads when
@@ -158,6 +171,73 @@ public class SandboxExportFacadeFactory implements ExportFacadeFactory {
       }
 
       callback.onWrite(buffer.toString());
+      buffer.setLength(0);
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+      flush();
+    }
+  }
+
+  /**
+   * An OutputStream for debug messages that prefixes output with "[debug] " marker.
+   *
+   * <p>This allows JavaScript to distinguish debug messages from export data. Each complete
+   * line written is prefixed with "[debug] " before being sent through the callback.</p>
+   */
+  public static class DebugRedirectOutputStream extends OutputStream {
+
+    private final SandboxExportCallback callback;
+    private final StringBuilder buffer;
+
+    /**
+     * Constructs a new DebugRedirectOutputStream with the specified callback.
+     *
+     * @param callback The callback to use for output redirection
+     */
+    public DebugRedirectOutputStream(SandboxExportCallback callback) {
+      this.callback = callback;
+      this.buffer = new StringBuilder();
+    }
+
+    @Override
+    public synchronized void write(int b) throws IOException {
+      buffer.append((char) b);
+      if (b == '\n') {
+        flush();
+      }
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+      write(b, 0, b.length);
+    }
+
+    @Override
+    public synchronized void write(byte[] b, int off, int len) throws IOException {
+      buffer.append(new String(b, off, len));
+      boolean containsNewline = buffer.indexOf("\n") != -1;
+      if (containsNewline) {
+        flush();
+      }
+    }
+
+    @Override
+    public synchronized void flush() throws IOException {
+      if (buffer.length() == 0) {
+        return;
+      }
+
+      // Prefix each line with [debug] marker for JavaScript parsing
+      String content = buffer.toString();
+      String[] lines = content.split("\n", -1);
+      for (int i = 0; i < lines.length; i++) {
+        String line = lines[i];
+        if (!line.isEmpty()) {
+          callback.onWrite("[debug] " + line + "\n");
+        }
+      }
       buffer.setLength(0);
     }
 


### PR DESCRIPTION
This PR introduces debug logic (from #334 ) into the browser, via a dropdown tab with some basic filtering. 

<img width="904" height="675" alt="image" src="https://github.com/user-attachments/assets/26a990c1-7774-484c-a23e-5cd55975d3b8" />

Using the following josh:

```
start simulation Main

  grid.size = 10000 m
  grid.low = 33.7 degrees latitude, -115.4 degrees longitude
  grid.high = 34.0 degrees latitude, -116.4 degrees longitude
  grid.patch = "Default"

  steps.low = 0 count
  steps.high = 10 count

  exportFiles.patch = "memory://editor/patches"
  debugFiles.organism = "memory://editor/debug"
  debugFiles.patch = "memory://editor/debug"

end simulation

start patch Default

  ForeverTree.init = create 10 count of ForeverTree

  export.averageAge.step = mean(ForeverTree.age)
  export.averageHeight.step = mean(ForeverTree.height)
  treeCount.step = count(ForeverTree)
  
  debug.step = debug("contains", current.treeCount, " trees")

end patch

start organism ForeverTree

  age.init = 0 year
  age.step = prior.age + 1 year

  height.init = 0 meters
  height.step = prior.height + sample uniform from 0 meters to 1 meters

  debug.step = debug("age:", current.age, "height:", current.height)

end organism

start unit year

  alias years
  alias yr
  alias yrs

end unit

```