### PR TITLE
InspectExportsCommand for joshpy ergonomics

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -136,6 +136,73 @@ java -jar joshsim-fat.jar inspectJshd <file.jshd> <variable> <timestep> <x> <y>
 - `<x>`: X coordinate (grid space)
 - `<y>`: Y coordinate (grid space)
 
+#### `inspect-exports` - Export Path Extraction
+Parses a Josh script and extracts the configured export and debug file paths from a simulation without running it. Useful for build systems, CI/CD pipelines, and tooling that needs to know where simulation outputs will be written.
+
+```bash
+java -jar joshsim-fat.jar inspect-exports <script.josh> <SimulationName> [OPTIONS]
+```
+
+**Parameters:**
+- `<script.josh>`: Path to Josh script file to inspect
+- `<SimulationName>`: Name of simulation to extract paths from
+
+**Options:**
+- `--json`: Output in JSON format (default: true)
+
+**Output (JSON format):**
+```json
+{
+  "simulation": "Main",
+  "exportFiles": {
+    "patch": {
+      "raw": "\"file:///tmp/output.csv\"",
+      "protocol": "file",
+      "host": "",
+      "path": "/tmp/output.csv",
+      "fileType": "csv"
+    },
+    "meta": null,
+    "entity": null
+  },
+  "debugFiles": {
+    "organism": null,
+    "patch": null,
+    "agent": null,
+    "disturbance": null
+  }
+}
+```
+
+**Supported Export Types:**
+- `exportFiles.patch`: Patch-level simulation data
+- `exportFiles.meta`: Simulation metadata
+- `exportFiles.entity`: Sub-patch entities (organisms, agents, etc.)
+
+**Supported Debug Types:**
+- `debugFiles.organism`: Debug messages from organism entities
+- `debugFiles.patch`: Debug messages from patch entities
+- `debugFiles.agent`: Debug messages from agent entities
+- `debugFiles.disturbance`: Debug messages from disturbance entities
+
+**Notes:**
+- Template variables are returned as-is (not resolved), including:
+  - `{replicate}` - replicate number
+  - `{step}` - simulation step number
+  - `{variable}` - export variable name
+  - `{timestamp}` - execution timestamp
+  - Custom job parameters (e.g., `{scenario}`) from job configuration
+- Each path is parsed into components: protocol, host, path, and fileType
+- Returns `null` for unconfigured export/debug types
+
+**Exit Codes:**
+- `0`: Success
+- `1`: File not found
+- `2`: File read error
+- `3`: Parse error
+- `4`: Simulation not found
+- `5`: Export extraction error
+
 #### `server` - HTTP Server Mode
 Starts Josh as an HTTP server for web-based simulation execution and API access.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -150,59 +150,6 @@ java -jar joshsim-fat.jar inspect-exports <script.josh> <SimulationName> [OPTION
 **Options:**
 - `--json`: Output in JSON format (default: true)
 
-**Output (JSON format):**
-```json
-{
-  "simulation": "Main",
-  "exportFiles": {
-    "patch": {
-      "raw": "\"file:///tmp/output.csv\"",
-      "protocol": "file",
-      "host": "",
-      "path": "/tmp/output.csv",
-      "fileType": "csv"
-    },
-    "meta": null,
-    "entity": null
-  },
-  "debugFiles": {
-    "organism": null,
-    "patch": null,
-    "agent": null,
-    "disturbance": null
-  }
-}
-```
-
-**Supported Export Types:**
-- `exportFiles.patch`: Patch-level simulation data
-- `exportFiles.meta`: Simulation metadata
-- `exportFiles.entity`: Sub-patch entities (organisms, agents, etc.)
-
-**Supported Debug Types:**
-- `debugFiles.organism`: Debug messages from organism entities
-- `debugFiles.patch`: Debug messages from patch entities
-- `debugFiles.agent`: Debug messages from agent entities
-- `debugFiles.disturbance`: Debug messages from disturbance entities
-
-**Notes:**
-- Template variables are returned as-is (not resolved), including:
-  - `{replicate}` - replicate number
-  - `{step}` - simulation step number
-  - `{variable}` - export variable name
-  - `{timestamp}` - execution timestamp
-  - Custom job parameters (e.g., `{scenario}`) from job configuration
-- Each path is parsed into components: protocol, host, path, and fileType
-- Returns `null` for unconfigured export/debug types
-
-**Exit Codes:**
-- `0`: Success
-- `1`: File not found
-- `2`: File read error
-- `3`: Parse error
-- `4`: Simulation not found
-- `5`: Export extraction error
-
 #### `server` - HTTP Server Mode
 Starts Josh as an HTTP server for web-based simulation execution and API access.
 

--- a/src/main/java/org/joshsim/JoshSimCommander.java
+++ b/src/main/java/org/joshsim/JoshSimCommander.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Optional;
 import org.joshsim.command.DiscoverConfigCommand;
+import org.joshsim.command.InspectExportsCommand;
 import org.joshsim.command.InspectJshdCommand;
 import org.joshsim.command.PreprocessCommand;
 import org.joshsim.command.RunCommand;
@@ -62,7 +63,8 @@ import picocli.CommandLine;
         ServerCommand.class,
         PreprocessCommand.class,
         DiscoverConfigCommand.class,
-        InspectJshdCommand.class
+        InspectJshdCommand.class,
+        InspectExportsCommand.class
     }
 )
 public class JoshSimCommander {

--- a/src/main/java/org/joshsim/command/InspectExportsCommand.java
+++ b/src/main/java/org/joshsim/command/InspectExportsCommand.java
@@ -1,0 +1,226 @@
+/**
+ * Command line interface handler for inspecting export paths in Josh simulation files.
+ *
+ * <p>This class implements the 'inspect-exports' command which parses a Josh script file
+ * and extracts the exportFiles paths (patch, meta, entity) from a specified simulation.</p>
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.command;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import org.joshsim.JoshSimCommander;
+import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.geometry.grid.GridGeometryFactory;
+import org.joshsim.engine.value.engine.EngineValueFactory;
+import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.lang.bridge.ShadowingEntity;
+import org.joshsim.lang.interpret.JoshProgram;
+import org.joshsim.lang.io.ExportTarget;
+import org.joshsim.lang.io.ExportTargetParser;
+import org.joshsim.util.OutputOptions;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+
+/**
+ * Command handler for inspecting export paths in Josh simulation files.
+ *
+ * <p>Parses a Josh script file and extracts the exportFiles configuration from a specified
+ * simulation. Outputs the export paths for patch, meta, and entity exports in JSON format
+ * for programmatic consumption.</p>
+ */
+@Command(
+    name = "inspect-exports",
+    description = "Extract exportFiles paths from a simulation"
+)
+public class InspectExportsCommand implements Callable<Integer> {
+
+  @Parameters(index = "0", description = "Path to Josh file to inspect")
+  private File file;
+
+  @Parameters(index = "1", description = "Name of the simulation to inspect")
+  private String simulationName;
+
+  @Mixin
+  private OutputOptions output = new OutputOptions();
+
+  @Option(
+      names = "--json",
+      description = "Output in JSON format (default: true)",
+      defaultValue = "true"
+  )
+  private boolean jsonOutput = true;
+
+  @Override
+  public Integer call() {
+    JoshSimCommander.ProgramInitResult initResult = JoshSimCommander.getJoshProgram(
+        new GridGeometryFactory(),
+        file,
+        output
+    );
+
+    if (initResult.getFailureStep().isPresent()) {
+      JoshSimCommander.CommanderStepEnum failStep = initResult.getFailureStep().get();
+      return switch (failStep) {
+        case LOAD -> 1;
+        case READ -> 2;
+        case PARSE -> 3;
+        default -> 404;
+      };
+    }
+
+    JoshProgram program = initResult.getProgram().orElseThrow();
+
+    if (!program.getSimulations().hasPrototype(simulationName)) {
+      output.printError("Could not find simulation: " + simulationName);
+      return 4;
+    }
+
+    try {
+      EngineValueFactory valueFactory = new EngineValueFactory();
+      MutableEntity simEntityRaw = program.getSimulations().getProtoype(simulationName).build();
+      MutableEntity simEntity = new ShadowingEntity(valueFactory, simEntityRaw, simEntityRaw);
+
+      simEntity.startSubstep("constant");
+
+      Optional<EngineValue> patchExport = simEntity.getAttributeValue("exportFiles.patch");
+      Optional<EngineValue> metaExport = simEntity.getAttributeValue("exportFiles.meta");
+      Optional<EngineValue> entityExport = simEntity.getAttributeValue("exportFiles.entity");
+
+      Optional<EngineValue> debugOrganism = simEntity.getAttributeValue("debugFiles.organism");
+      Optional<EngineValue> debugPatch = simEntity.getAttributeValue("debugFiles.patch");
+      Optional<EngineValue> debugAgent = simEntity.getAttributeValue("debugFiles.agent");
+      Optional<EngineValue> debugDisturbance =
+          simEntity.getAttributeValue("debugFiles.disturbance");
+
+      simEntity.endSubstep();
+
+      if (jsonOutput) {
+        outputJson(patchExport, metaExport, entityExport,
+            debugOrganism, debugPatch, debugAgent, debugDisturbance);
+      } else {
+        outputPlain(patchExport, metaExport, entityExport,
+            debugOrganism, debugPatch, debugAgent, debugDisturbance);
+      }
+
+      return 0;
+    } catch (Exception e) {
+      output.printError("Error extracting export paths: " + e.getMessage());
+      return 5;
+    }
+  }
+
+  private void outputJson(
+      Optional<EngineValue> patchExport,
+      Optional<EngineValue> metaExport,
+      Optional<EngineValue> entityExport,
+      Optional<EngineValue> debugOrganism,
+      Optional<EngineValue> debugPatch,
+      Optional<EngineValue> debugAgent,
+      Optional<EngineValue> debugDisturbance
+  ) {
+    StringBuilder json = new StringBuilder();
+    json.append("{\n");
+    json.append("  \"simulation\": \"").append(escapeJson(simulationName)).append("\",\n");
+    json.append("  \"exportFiles\": {\n");
+
+    json.append("    \"patch\": ");
+    appendExportJson(json, patchExport);
+    json.append(",\n");
+
+    json.append("    \"meta\": ");
+    appendExportJson(json, metaExport);
+    json.append(",\n");
+
+    json.append("    \"entity\": ");
+    appendExportJson(json, entityExport);
+    json.append("\n");
+
+    json.append("  },\n");
+    json.append("  \"debugFiles\": {\n");
+
+    json.append("    \"organism\": ");
+    appendExportJson(json, debugOrganism);
+    json.append(",\n");
+
+    json.append("    \"patch\": ");
+    appendExportJson(json, debugPatch);
+    json.append(",\n");
+
+    json.append("    \"agent\": ");
+    appendExportJson(json, debugAgent);
+    json.append(",\n");
+
+    json.append("    \"disturbance\": ");
+    appendExportJson(json, debugDisturbance);
+    json.append("\n");
+
+    json.append("  }\n");
+    json.append("}");
+
+    output.printInfo(json.toString());
+  }
+
+  private void appendExportJson(StringBuilder json, Optional<EngineValue> exportValue) {
+    if (exportValue.isEmpty()) {
+      json.append("null");
+      return;
+    }
+
+    String rawPath = exportValue.get().getAsString();
+    ExportTarget target = ExportTargetParser.parse(rawPath);
+
+    json.append("{\n");
+    json.append("      \"raw\": \"").append(escapeJson(rawPath)).append("\",\n");
+    json.append("      \"protocol\": \"").append(escapeJson(target.getProtocol())).append("\",\n");
+    json.append("      \"host\": \"").append(escapeJson(target.getHost())).append("\",\n");
+    json.append("      \"path\": \"").append(escapeJson(target.getPath())).append("\",\n");
+    json.append("      \"fileType\": \"").append(escapeJson(target.getFileType())).append("\"\n");
+    json.append("    }");
+  }
+
+  private void outputPlain(
+      Optional<EngineValue> patchExport,
+      Optional<EngineValue> metaExport,
+      Optional<EngineValue> entityExport,
+      Optional<EngineValue> debugOrganism,
+      Optional<EngineValue> debugPatch,
+      Optional<EngineValue> debugAgent,
+      Optional<EngineValue> debugDisturbance
+  ) {
+    output.printInfo("Simulation: " + simulationName);
+    output.printInfo("Export Files:");
+    output.printInfo("  patch: " + (patchExport.map(v -> v.getAsString()).orElse("(not defined)")));
+    output.printInfo("  meta: " + (metaExport.map(v -> v.getAsString()).orElse("(not defined)")));
+    output.printInfo(
+          "  entity: " + (entityExport.map(v -> v.getAsString()).orElse("(not defined)"))
+    );
+    output.printInfo("Debug Files:");
+    output.printInfo(
+        "  organism: " + (debugOrganism.map(v -> v.getAsString()).orElse("(not defined)"))
+    );
+    output.printInfo("  patch: " + (debugPatch.map(v -> v.getAsString()).orElse("(not defined)")));
+    output.printInfo("  agent: " + (debugAgent.map(v -> v.getAsString()).orElse("(not defined)")));
+    output.printInfo(
+        "  disturbance: " + (debugDisturbance.map(v -> v.getAsString()).orElse("(not defined)"))
+    );
+  }
+
+  private String escapeJson(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t");
+  }
+}


### PR DESCRIPTION
A minimal feature to expose parsed exports and debugs from a josh file. This is nice to allow `joshpy` users to recover exports from a sweep without needing to explicitly configure where the csvs live (something that `josh` knows already from the parsed AST).