### PR TITLE
Feat/inspect jshd csv

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -136,6 +136,19 @@ java -jar joshsim-fat.jar inspectJshd <file.jshd> <variable> <timestep> <x> <y>
 - `<x>`: X coordinate (grid space)
 - `<y>`: Y coordinate (grid space)
 
+**Options:**
+- `--to-csv <outputPath>`: Export the entire grid across all timesteps to a CSV file instead of inspecting a single value. When used, `<timestep>`, `<x>`, and `<y>` are not required. The CSV contains columns `x,y,timestep,value`. Grid metadata is printed to stdout as JSON:
+```json
+{
+  "minX": 0, "maxX": 922,
+  "minY": 0, "maxY": 1112,
+  "minTimestep": 0, "maxTimestep": 1,
+  "width": 923, "height": 1113,
+  "units": "K",
+  "csv": "/path/to/output.csv"
+}
+```
+
 #### `inspect-exports` - Export Path Extraction
 Parses a Josh script and extracts the configured export and debug file paths from a simulation without running it. Useful for build systems, CI/CD pipelines, and tooling that needs to know where simulation outputs will be written.
 

--- a/src/main/java/org/joshsim/command/InspectJshdCommand.java
+++ b/src/main/java/org/joshsim/command/InspectJshdCommand.java
@@ -7,15 +7,20 @@
 package org.joshsim.command;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.joshsim.engine.value.engine.EngineValueFactory;
 import org.joshsim.engine.value.type.EngineValue;
 import org.joshsim.geo.external.readers.JshdExternalDataReader;
+import org.joshsim.precompute.DoublePrecomputedGrid;
 import org.joshsim.util.OutputOptions;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 
@@ -26,7 +31,13 @@ import picocli.CommandLine.Parameters;
  * in JSHD binary files at specific grid coordinates and time points. This functionality is useful
  * for debugging preprocessed data files and validating that data has been correctly stored.
  *
- * <p>The command takes the following parameters:
+ * <p>The command supports two modes:
+ * <ul>
+ *   <li>Single-value mode: inspect a value at specific coordinates (default)</li>
+ *   <li>CSV export mode: dump the entire grid across all timesteps to a CSV file (--to-csv)</li>
+ * </ul>
+ *
+ * <p>In single-value mode, the command takes the following parameters:
  * <ul>
  *   <li>jshd file path - Path to the JSHD file to inspect</li>
  *   <li>variable name - Name of the variable to read (typically "data" for JSHD files)</li>
@@ -35,8 +46,9 @@ import picocli.CommandLine.Parameters;
  *   <li>y coordinate - Y coordinate in grid space</li>
  * </ul>
  *
- * <p>The command outputs the value found at the specified location along with its units,
- * or an appropriate error message if the value cannot be found or the inputs are invalid.
+ * <p>In CSV export mode, only the jshd file path and variable name are required. The CSV output
+ * includes all grid cells across all timesteps with columns: x, y, timestep, value. Grid metadata
+ * (bounds, dimensions, units) is printed to stdout.
  *
  * @see org.joshsim.geo.external.readers.JshdExternalDataReader
  * @see org.joshsim.precompute.DoublePrecomputedGrid
@@ -53,14 +65,24 @@ public class InspectJshdCommand implements Callable<Integer> {
   @Parameters(index = "1", description = "Name of the variable to inspect")
   private String variable;
 
-  @Parameters(index = "2", description = "Time step to inspect")
+  @Parameters(index = "2", description = "Time step to inspect (ignored with --to-csv)",
+      defaultValue = "")
   private String timestep;
 
-  @Parameters(index = "3", description = "X coordinate (grid space)")
+  @Parameters(index = "3", description = "X coordinate in grid space (ignored with --to-csv)",
+      defaultValue = "")
   private String xcoordinate;
 
-  @Parameters(index = "4", description = "Y coordinate (grid space)")
+  @Parameters(index = "4", description = "Y coordinate in grid space (ignored with --to-csv)",
+      defaultValue = "")
   private String ycoordinate;
+
+  @Option(
+      names = "--to-csv",
+      description = "Export entire grid to CSV file (all timesteps, all locations)",
+      defaultValue = ""
+  )
+  private String csvOutputPath;
 
   @Mixin
   private OutputOptions output = new OutputOptions();
@@ -79,7 +101,100 @@ public class InspectJshdCommand implements Callable<Integer> {
       return 2;
     }
 
+    if (csvOutputPath != null && !csvOutputPath.isEmpty()) {
+      return exportToCsv();
+    } else {
+      return inspectSingleValue();
+    }
+  }
+
+  private Integer exportToCsv() {
+    EngineValueFactory valueFactory = new EngineValueFactory();
+    try (JshdExternalDataReader reader = new JshdExternalDataReader(valueFactory)) {
+      reader.open(jshdFile.getAbsolutePath());
+
+      if (!reader.getVariableNames().contains(variable)) {
+        output.printError("Variable '" + variable + "' not found in JSHD file. "
+            + "Available variables: " + reader.getVariableNames());
+        return 6;
+      }
+
+      DoublePrecomputedGrid grid = reader.getGrid();
+
+      // Print metadata as JSON to stdout
+      StringBuilder json = new StringBuilder();
+      json.append("{\n");
+
+      long minX = grid.getMinX();
+      json.append("  \"minX\": ").append(minX).append(",\n");
+
+      long maxX = grid.getMaxX();
+      json.append("  \"maxX\": ").append(maxX).append(",\n");
+
+      long minY = grid.getMinY();
+      json.append("  \"minY\": ").append(minY).append(",\n");
+
+      long maxY = grid.getMaxY();
+      json.append("  \"maxY\": ").append(maxY).append(",\n");
+
+      long minTimestep = grid.getMinTimestep();
+      json.append("  \"minTimestep\": ").append(minTimestep).append(",\n");
+
+      long maxTimestep = grid.getMaxTimestep();
+      json.append("  \"maxTimestep\": ").append(maxTimestep).append(",\n");
+
+      json.append("  \"width\": ").append(grid.getWidth()).append(",\n");
+      json.append("  \"height\": ").append(grid.getHeight()).append(",\n");
+
+      String units = grid.getUnits().toString();
+      json.append("  \"units\": \"").append(units).append("\",\n");
+      json.append("  \"csv\": \"").append(new File(csvOutputPath).getAbsolutePath()).append("\"\n");
+      json.append("}");
+
+      // Write CSV
+      File csvFile = new File(csvOutputPath);
+      try (PrintWriter writer = new PrintWriter(new FileWriter(csvFile))) {
+        writer.println("x,y,timestep,value");
+
+        for (long t = minTimestep; t <= maxTimestep; t++) {
+          for (long y = minY; y <= maxY; y++) {
+            for (long x = minX; x <= maxX; x++) {
+              EngineValue val = grid.getAt(x, y, t);
+              writer.printf("%d,%d,%d,%s%n", x, y, t, val.getAsDecimal().toString());
+            }
+          }
+        }
+      }
+
+      output.printInfo(json.toString());
+      return 0;
+
+    } catch (IOException e) {
+      output.printError("Error writing CSV file: " + e.getMessage());
+      return 9;
+    } catch (Exception e) {
+      output.printError("Error inspecting JSHD file: " + e.getMessage());
+      return 8;
+    }
+  }
+
+  private Integer inspectSingleValue() {
     // Parse coordinates and timestep
+    if (timestep == null || timestep.isEmpty()) {
+      output.printError("Time step is required when not using --to-csv.");
+      return 3;
+    }
+
+    if (xcoordinate == null || xcoordinate.isEmpty()) {
+      output.printError("X coordinate is required when not using --to-csv.");
+      return 4;
+    }
+
+    if (ycoordinate == null || ycoordinate.isEmpty()) {
+      output.printError("Y coordinate is required when not using --to-csv.");
+      return 5;
+    }
+
     long timePoint;
     try {
       timePoint = Long.parseLong(timestep);

--- a/src/test/java/org/joshsim/command/InspectJshdCommandTest.java
+++ b/src/test/java/org/joshsim/command/InspectJshdCommandTest.java
@@ -392,6 +392,95 @@ public class InspectJshdCommandTest {
   }
 
   @Test
+  public void testToCsvExportsAllData() throws IOException {
+    Path csvOutput = tempDir.resolve("output.csv");
+
+    InspectJshdCommand command = new InspectJshdCommand();
+    setField(command, "jshdFile", testJshdFile.toFile());
+    setField(command, "variable", "data");
+    setField(command, "csvOutputPath", csvOutput.toString());
+
+    Integer result = command.call();
+    assertEquals(0, result);
+
+    // Verify JSON metadata was printed to stdout
+    String stdoutOutput = outContent.toString();
+    assertTrue(stdoutOutput.contains("\"minX\": 0"));
+    assertTrue(stdoutOutput.contains("\"maxX\": 2"));
+    assertTrue(stdoutOutput.contains("\"minY\": 0"));
+    assertTrue(stdoutOutput.contains("\"maxY\": 2"));
+    assertTrue(stdoutOutput.contains("\"minTimestep\": 0"));
+    assertTrue(stdoutOutput.contains("\"maxTimestep\": 1"));
+    assertTrue(stdoutOutput.contains("\"width\": 3"));
+    assertTrue(stdoutOutput.contains("\"height\": 3"));
+    assertTrue(stdoutOutput.contains("\"units\": \"meters\""));
+    assertTrue(stdoutOutput.contains("\"csv\": \""));
+
+    // Verify CSV file was created and has correct content
+    assertTrue(csvOutput.toFile().exists());
+    java.util.List<String> lines = Files.readAllLines(csvOutput);
+
+    // Header + 3x3 grid * 2 timesteps = 1 + 18 = 19 lines
+    assertEquals(19, lines.size());
+    assertEquals("x,y,timestep,value", lines.get(0));
+
+    // First data line: x=0, y=0, timestep=0, value=1
+    assertEquals("0,0,0,1", lines.get(1));
+
+    // Check a known non-zero value: x=1, y=1, timestep=0, value=2
+    // Row order: t=0, y=0: (0,0),(1,0),(2,0), y=1: (0,1),(1,1),(2,1), y=2: (0,2),(1,2),(2,2)
+    // So (1,1,0) is at index 1 + 3 + 1 = 5 (0-indexed line 4)
+    assertEquals("1,1,0,2", lines.get(5));
+
+    // Check timestep 1 value: (0,0,1) = 4.0, starts at line 10 (after 9 data lines for t=0)
+    assertEquals("0,0,1,4", lines.get(10));
+  }
+
+  @Test
+  public void testToCsvWithInvalidVariable() {
+    Path csvOutput = tempDir.resolve("output.csv");
+
+    InspectJshdCommand command = new InspectJshdCommand();
+    setField(command, "jshdFile", testJshdFile.toFile());
+    setField(command, "variable", "nonexistent");
+    setField(command, "csvOutputPath", csvOutput.toString());
+
+    Integer result = command.call();
+    assertEquals(6, result);
+  }
+
+  @Test
+  public void testToCsvWithFileNotFound() {
+    Path csvOutput = tempDir.resolve("output.csv");
+    File nonExistentFile = new File("nonexistent.jshd");
+
+    InspectJshdCommand command = new InspectJshdCommand();
+    setField(command, "jshdFile", nonExistentFile);
+    setField(command, "variable", "data");
+    setField(command, "csvOutputPath", csvOutput.toString());
+
+    Integer result = command.call();
+    assertEquals(1, result);
+  }
+
+  @Test
+  public void testSingleValueModeRequiresTimestep() {
+    InspectJshdCommand command = new InspectJshdCommand();
+    setField(command, "jshdFile", testJshdFile.toFile());
+    setField(command, "variable", "data");
+    setField(command, "timestep", "");
+    setField(command, "xcoordinate", "0");
+    setField(command, "ycoordinate", "0");
+    setField(command, "csvOutputPath", "");
+
+    Integer result = command.call();
+    assertEquals(3, result);
+
+    String errOutput = errContent.toString();
+    assertTrue(errOutput.contains("Time step is required"));
+  }
+
+  @Test
   public void testValidateCorrectVariableName() {
     InspectJshdCommand command = new InspectJshdCommand();
     setField(command, "jshdFile", testJshdFile.toFile());


### PR DESCRIPTION
Small update to inspectJshd, which exports csv data to verify Josh correctly interpreted external data. Mostly provided as a way to sanity check preprocessed data using `joshpy`.  

```
- `--to-csv <outputPath>`: Export the entire grid across all timesteps to a CSV file instead of inspecting a single value. When used, `<timestep>`, `<x>`, and `<y>` are not required. The CSV contains columns `x,y,timestep,value`. Grid metadata is printed to stdout as JSON:

{
  "minX": 0, "maxX": 922,
  "minY": 0, "maxY": 1112,
  "minTimestep": 0, "maxTimestep": 1,
  "width": 923, "height": 1113,
  "units": "K",
  "csv": "/path/to/output.csv"
}
```