### PR TITLE
Make local leader more permissive to intermittent failure

### DIFF
--- a/src/main/java/org/joshsim/command/RemoteResponseHandler.java
+++ b/src/main/java/org/joshsim/command/RemoteResponseHandler.java
@@ -46,7 +46,6 @@ public class RemoteResponseHandler {
   private final AtomicInteger completedReplicates;
   private final boolean useCumulativeProgress;
   private final boolean reportStepProgress;
-  private int lastProcessedReplicate = -1;
 
   /**
    * Creates a new RemoteResponseHandler.

--- a/src/main/java/org/joshsim/command/RunRemoteCommand.java
+++ b/src/main/java/org/joshsim/command/RunRemoteCommand.java
@@ -251,21 +251,21 @@ public class RunRemoteCommand implements Callable<Integer> {
       return HTTP_ERROR_CODE;
     } catch (IOException e) {
       if (isUsingJoshCloud()) {
-        output.printError("Josh Cloud execution failed: " + e.getMessage());
+        output.printError("Josh Cloud execution failed: " + getRootCauseMessage(e));
         output.printError("Please check your API key and network connection.");
         output.printError("Visit https://joshsim.org for support.");
       } else {
-        output.printError("Custom endpoint execution failed: " + e.getMessage());
+        output.printError("Custom endpoint execution failed: " + getRootCauseMessage(e));
         output.printError("Please verify your endpoint URL and API key.");
       }
       return NETWORK_ERROR_CODE;
     } catch (Exception e) {
       if (isUsingJoshCloud()) {
-        output.printError("Josh Cloud execution failed: " + e.getMessage());
+        output.printError("Josh Cloud execution failed: " + getRootCauseMessage(e));
         output.printError("Please check your API key and network connection.");
         output.printError("Visit https://joshsim.org for support.");
       } else {
-        output.printError("Custom endpoint execution failed: " + e.getMessage());
+        output.printError("Custom endpoint execution failed: " + getRootCauseMessage(e));
         output.printError("Please verify your endpoint URL and API key.");
       }
       return UNKNOWN_ERROR_CODE;
@@ -498,6 +498,23 @@ public class RunRemoteCommand implements Callable<Integer> {
   }
 
 
+
+  /**
+   * Walks the exception chain to find the first non-null, non-empty message.
+   *
+   * @param e The exception to inspect
+   * @return The first meaningful message found, or the exception class name as fallback
+   */
+  private String getRootCauseMessage(Exception e) {
+    Throwable current = e;
+    while (current != null) {
+      if (current.getMessage() != null && !current.getMessage().isEmpty()) {
+        return current.getMessage();
+      }
+      current = current.getCause();
+    }
+    return e.getClass().getSimpleName();
+  }
 
   /**
    * Determines if the current endpoint is Josh Cloud.

--- a/src/main/java/org/joshsim/pipeline/remote/ExternalFileEntry.java
+++ b/src/main/java/org/joshsim/pipeline/remote/ExternalFileEntry.java
@@ -1,0 +1,20 @@
+/**
+ * Record holding metadata for an external file to be streamed during remote execution.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.pipeline.remote;
+
+/**
+ * Metadata for an external file to be streamed during remote execution.
+ *
+ * <p>Instead of reading and serializing all external file data into a single in-memory String,
+ * this record captures the metadata needed to stream files from disk at request time. This avoids
+ * exceeding Java's String length limit (~2.1GB) for large binary files like JSHD datasets.</p>
+ *
+ * @param filename The logical filename (e.g., "data.jshd")
+ * @param isBinary Whether the file is binary (Base64 encoded) or text
+ * @param filePath The absolute or relative path to the file on disk
+ */
+public record ExternalFileEntry(String filename, boolean isBinary, String filePath) {}

--- a/src/main/java/org/joshsim/pipeline/remote/ParallelWorkerHandler.java
+++ b/src/main/java/org/joshsim/pipeline/remote/ParallelWorkerHandler.java
@@ -140,15 +140,21 @@ public class ParallelWorkerHandler {
         );
       }
 
-      // Wait for all tasks to complete
+      // Wait for all tasks to complete, collecting errors instead of failing fast
+      List<Exception> failures = new ArrayList<>();
       for (Future<?> future : futures) {
         try {
           future.get();
         } catch (Exception e) {
-          System.err.println("Exception in worker task execution: "
-              + e.getClass().getSimpleName() + ": " + e.getMessage());
-          throw new RuntimeException("Worker task execution failed", e);
+          System.err.println("Worker task failed: " + e.getMessage());
+          failures.add(e);
         }
+      }
+      if (!failures.isEmpty()) {
+        RuntimeException aggregate = new RuntimeException(
+            failures.size() + " of " + tasks.size() + " worker task(s) failed");
+        failures.forEach(aggregate::addSuppressed);
+        throw aggregate;
       }
     } finally {
       executor.shutdown();

--- a/src/main/java/org/joshsim/pipeline/remote/StreamingFormBodyPublisher.java
+++ b/src/main/java/org/joshsim/pipeline/remote/StreamingFormBodyPublisher.java
@@ -1,0 +1,314 @@
+/**
+ * Utility for streaming form-encoded HTTP request bodies from disk.
+ *
+ * <p>Writes an {@code application/x-www-form-urlencoded} body to a piped stream, streaming
+ * the {@code externalData} field from disk files rather than loading everything into a single
+ * Java String. This avoids hitting Java's ~2.1GB String length limit when large JSHD files
+ * are Base64-encoded and URL-encoded.</p>
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.pipeline.remote;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.net.URLEncoder;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Streams a form-encoded HTTP body from disk files, avoiding in-memory String construction.
+ *
+ * <p>Small fields (code, name, apiKey, etc.) are URL-encoded normally. The {@code externalData}
+ * field is streamed from disk: binary files are read in chunks, Base64-encoded via a wrapping
+ * OutputStream, and URL-encoded via simple character substitution. Text files are read as strings,
+ * tab-replaced, and URL-encoded directly.</p>
+ */
+public class StreamingFormBodyPublisher {
+
+  private static final int BUFFER_SIZE = 8192;
+
+  /**
+   * Creates a streaming body publisher for the given form fields and external files.
+   *
+   * @param smallFields Map of small field name-value pairs to URL-encode normally
+   * @param externalFiles List of external file entries to stream as the externalData field
+   * @return An HttpRequest.BodyPublisher that streams the body from disk
+   */
+  public static HttpRequest.BodyPublisher create(
+      Map<String, String> smallFields,
+      List<ExternalFileEntry> externalFiles) {
+    return create(smallFields, externalFiles, null);
+  }
+
+  /**
+   * Creates a streaming body publisher for the given form fields and external data.
+   *
+   * <p>If {@code externalFiles} is non-empty, the externalData field is streamed from
+   * disk files. Otherwise, if {@code externalDataString} is non-null, it is used as a
+   * pre-serialized external data value (server-side pass-through).</p>
+   *
+   * @param smallFields Map of small field name-value pairs to URL-encode normally
+   * @param externalFiles List of external file entries to stream as the externalData field
+   * @param externalDataString Pre-serialized external data string (used when files are empty)
+   * @return An HttpRequest.BodyPublisher that streams the body
+   */
+  public static HttpRequest.BodyPublisher create(
+      Map<String, String> smallFields,
+      List<ExternalFileEntry> externalFiles,
+      String externalDataString) {
+
+    return HttpRequest.BodyPublishers.ofInputStream(() -> {
+      PipedInputStream pipedIn = new PipedInputStream(65536);
+      PipedOutputStream pipedOut;
+      try {
+        pipedOut = new PipedOutputStream(pipedIn);
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to create piped stream", e);
+      }
+
+      Thread writerThread = new Thread(() -> {
+        try {
+          writeFormBody(pipedOut, smallFields, externalFiles, externalDataString);
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to write streaming form body", e);
+        } finally {
+          try {
+            pipedOut.close();
+          } catch (IOException ignored) {
+            // Closing the pipe is best-effort
+          }
+        }
+      }, "streaming-form-body-writer");
+      writerThread.setDaemon(true);
+      writerThread.start();
+
+      return pipedIn;
+    });
+  }
+
+  /**
+   * Writes the complete form body to the output stream.
+   *
+   * @param out The output stream to write to
+   * @param smallFields Map of small field name-value pairs
+   * @param externalFiles List of external file entries
+   * @param externalDataString Pre-serialized external data string (fallback when files empty)
+   * @throws IOException if writing fails
+   */
+  static void writeFormBody(
+      OutputStream out,
+      Map<String, String> smallFields,
+      List<ExternalFileEntry> externalFiles,
+      String externalDataString) throws IOException {
+
+    boolean first = true;
+
+    // Write small fields as normal URL-encoded key=value pairs
+    for (Map.Entry<String, String> entry : smallFields.entrySet()) {
+      if (!first) {
+        out.write('&');
+      }
+      first = false;
+
+      String encoded = URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8)
+          + "="
+          + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8);
+      out.write(encoded.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Write externalData field: stream from files if available, else use pre-serialized string
+    if (!externalFiles.isEmpty()) {
+      if (!first) {
+        out.write('&');
+      }
+      out.write("externalData=".getBytes(StandardCharsets.UTF_8));
+      writeExternalData(out, externalFiles);
+    } else if (externalDataString != null) {
+      if (!first) {
+        out.write('&');
+      }
+      out.write("externalData=".getBytes(StandardCharsets.UTF_8));
+      writeUrlEncoded(out, externalDataString);
+    }
+
+    out.flush();
+  }
+
+  /**
+   * Streams the externalData value from disk files in the wire format.
+   *
+   * <p>Wire format: {@code filename\tbinary_flag\tcontent\t} for each file,
+   * all URL-encoded. Tab delimiters are encoded as {@code %09}.</p>
+   *
+   * @param out The output stream to write to
+   * @param externalFiles The external file entries to stream
+   * @throws IOException if reading or writing fails
+   */
+  private static void writeExternalData(
+      OutputStream out,
+      List<ExternalFileEntry> externalFiles) throws IOException {
+
+    for (ExternalFileEntry entry : externalFiles) {
+      // Write: URL-encoded filename
+      writeUrlEncoded(out, entry.filename());
+      // Write: URL-encoded tab delimiter
+      out.write("%09".getBytes(StandardCharsets.UTF_8));
+
+      // Write: URL-encoded binary flag
+      writeUrlEncoded(out, entry.isBinary() ? "1" : "0");
+      // Write: URL-encoded tab delimiter
+      out.write("%09".getBytes(StandardCharsets.UTF_8));
+
+      // Write: URL-encoded content (streamed from disk)
+      if (entry.isBinary()) {
+        streamBinaryFileContent(out, entry.filePath());
+      } else {
+        streamTextFileContent(out, entry.filePath());
+      }
+
+      // Write: URL-encoded tab delimiter
+      out.write("%09".getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  /**
+   * Streams a binary file as Base64-encoded, URL-encoded content without intermediate Strings.
+   *
+   * <p>Uses {@code Base64.getEncoder().wrap()} to stream Base64 encoding directly through
+   * a URL-encoding filter OutputStream. The file is read in chunks, Base64-encoded on the fly,
+   * and each Base64 byte is URL-encoded via simple character substitution. This avoids creating
+   * any intermediate String that could exceed Java's ~2.1GB limit.</p>
+   *
+   * @param out The output stream to write to
+   * @param filePath Path to the binary file
+   * @throws IOException if reading or writing fails
+   */
+  private static void streamBinaryFileContent(OutputStream out, String filePath)
+      throws IOException {
+    // Chain: file bytes → Base64 encoder → URL-encoding filter → output stream
+    // No intermediate Strings are created at any point.
+    Base64UrlEncodingOutputStream urlEncodingOut = new Base64UrlEncodingOutputStream(out);
+    try (InputStream fileIn = Files.newInputStream(Paths.get(filePath));
+         OutputStream b64Out = Base64.getEncoder().wrap(urlEncodingOut)) {
+      byte[] buffer = new byte[BUFFER_SIZE];
+      int bytesRead;
+      while ((bytesRead = fileIn.read(buffer)) != -1) {
+        b64Out.write(buffer, 0, bytesRead);
+      }
+    }
+    // Closing b64Out flushes Base64 padding; urlEncodingOut does not close the delegate
+  }
+
+  /**
+   * Streams a text file as URL-encoded content with tab replacement.
+   *
+   * <p>Text files are small enough to read into memory. Tabs are replaced with
+   * spaces for safety (matching the original serialization behavior), then the
+   * content is URL-encoded.</p>
+   *
+   * @param out The output stream to write to
+   * @param filePath Path to the text file
+   * @throws IOException if reading or writing fails
+   */
+  private static void streamTextFileContent(OutputStream out, String filePath)
+      throws IOException {
+    String content = Files.readString(Paths.get(filePath), StandardCharsets.UTF_8);
+    content = content.replace("\t", "    "); // Tab replacement for safety
+    writeUrlEncoded(out, content);
+  }
+
+  /**
+   * URL-encodes a string and writes it to the output stream.
+   *
+   * @param out The output stream to write to
+   * @param value The string value to URL-encode and write
+   * @throws IOException if writing fails
+   */
+  private static void writeUrlEncoded(OutputStream out, String value) throws IOException {
+    String encoded = URLEncoder.encode(value, StandardCharsets.UTF_8);
+    out.write(encoded.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * OutputStream filter that URL-encodes Base64 output bytes via character substitution.
+   *
+   * <p>The Base64 alphabet (A-Z, a-z, 0-9, +, /, =) only requires percent-encoding
+   * of three characters: {@code +} → {@code %2B}, {@code /} → {@code %2F},
+   * {@code =} → {@code %3D}. All other characters pass through unchanged.</p>
+   *
+   * <p>Closing this stream does NOT close the delegate, since the caller manages
+   * the delegate's lifecycle.</p>
+   */
+  static class Base64UrlEncodingOutputStream extends OutputStream {
+    private final OutputStream delegate;
+
+    Base64UrlEncodingOutputStream(OutputStream delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      switch (b) {
+        case '+' -> delegate.write(PERCENT_2B, 0, 3);
+        case '/' -> delegate.write(PERCENT_2F, 0, 3);
+        case '=' -> delegate.write(PERCENT_3D, 0, 3);
+        default -> delegate.write(b);
+      }
+    }
+
+    @Override
+    public void write(byte[] bytes, int off, int len) throws IOException {
+      // Bulk-process to avoid per-byte overhead. Worst case: every byte expands to 3.
+      byte[] buf = new byte[len * 3];
+      int pos = 0;
+
+      for (int i = off; i < off + len; i++) {
+        switch (bytes[i]) {
+          case '+' -> {
+            buf[pos++] = '%';
+            buf[pos++] = '2';
+            buf[pos++] = 'B';
+          }
+          case '/' -> {
+            buf[pos++] = '%';
+            buf[pos++] = '2';
+            buf[pos++] = 'F';
+          }
+          case '=' -> {
+            buf[pos++] = '%';
+            buf[pos++] = '3';
+            buf[pos++] = 'D';
+          }
+          default -> buf[pos++] = bytes[i];
+        }
+      }
+
+      delegate.write(buf, 0, pos);
+    }
+
+    @Override
+    public void flush() throws IOException {
+      delegate.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+      // Intentionally do NOT close delegate — caller manages it
+      flush();
+    }
+
+    private static final byte[] PERCENT_2B = {'%', '2', 'B'};
+    private static final byte[] PERCENT_2F = {'%', '2', 'F'};
+    private static final byte[] PERCENT_3D = {'%', '3', 'D'};
+  }
+}

--- a/src/main/java/org/joshsim/util/ProgressCalculator.java
+++ b/src/main/java/org/joshsim/util/ProgressCalculator.java
@@ -61,7 +61,7 @@ public class ProgressCalculator {
    * @param currentStepInReplicate The current step within the active replicate (0-based)
    * @return ProgressUpdate indicating whether to report and what message to show
    */
-  public ProgressUpdate updateStep(long currentStepInReplicate) {
+  public synchronized ProgressUpdate updateStep(long currentStepInReplicate) {
     // Calculate per-replicate progress (0-100% within current replicate)
     double currentPercentage = (double) currentStepInReplicate / totalStepsPerReplicate * 100.0;
 
@@ -89,7 +89,7 @@ public class ProgressCalculator {
    * @param completedReplicateNumber The replicate number that just completed
    * @return ProgressUpdate with a completion message
    */
-  public ProgressUpdate updateReplicateCompleted(int completedReplicateNumber) {
+  public synchronized ProgressUpdate updateReplicateCompleted(int completedReplicateNumber) {
     // Per-replicate completion is always 100%
     double currentPercentage = 100.0;
 
@@ -181,7 +181,7 @@ public class ProgressCalculator {
    * @param nextReplicateNumber The replicate number starting next (1-based)
    * @throws IllegalArgumentException if nextReplicateNumber is invalid
    */
-  public void resetForNextReplicate(int nextReplicateNumber) {
+  public synchronized void resetForNextReplicate(int nextReplicateNumber) {
     if (nextReplicateNumber < 1 || nextReplicateNumber > totalReplicates) {
       throw new IllegalArgumentException("Invalid replicate number: " + nextReplicateNumber
           + " (must be between 1 and " + totalReplicates + ")");

--- a/src/test/java/org/joshsim/command/RunRemoteCommandErrorMessageTest.java
+++ b/src/test/java/org/joshsim/command/RunRemoteCommandErrorMessageTest.java
@@ -1,0 +1,108 @@
+/**
+ * Tests for RunRemoteCommand root-cause error message extraction.
+ *
+ * <p>Verifies that the getRootCauseMessage helper walks the exception chain
+ * to find the first non-null message, which fixes the issue where nested
+ * exceptions caused "null" to be printed as the error message.</p>
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the private getRootCauseMessage method via reflection to verify
+ * it correctly walks the exception chain.
+ */
+public class RunRemoteCommandErrorMessageTest {
+
+  /**
+   * Invokes the private getRootCauseMessage method on RunRemoteCommand via reflection.
+   */
+  private String invokeGetRootCauseMessage(Exception e) throws Exception {
+    RunRemoteCommand command = new RunRemoteCommand();
+    Method method = RunRemoteCommand.class.getDeclaredMethod(
+        "getRootCauseMessage", Exception.class
+    );
+    method.setAccessible(true);
+    return (String) method.invoke(command, e);
+  }
+
+  @Test
+  public void testDirectMessage() throws Exception {
+    Exception e = new RuntimeException("direct message");
+    assertEquals("direct message", invokeGetRootCauseMessage(e));
+  }
+
+  @Test
+  public void testNullMessageWithCause() throws Exception {
+    // Simulates: RuntimeException(null) wrapping IOException("real cause")
+    Exception cause = new java.io.IOException("real cause");
+    Exception wrapper = new RuntimeException((String) null, cause);
+
+    assertEquals("real cause", invokeGetRootCauseMessage(wrapper));
+  }
+
+  @Test
+  public void testDeepChainWithNullMessages() throws Exception {
+    // Simulates: RuntimeException(null) -> RuntimeException(null) -> IOException("deep root")
+    Exception root = new java.io.IOException("deep root cause");
+    Exception mid = new RuntimeException((String) null, root);
+    Exception outer = new RuntimeException((String) null, mid);
+
+    assertEquals("deep root cause", invokeGetRootCauseMessage(outer));
+  }
+
+  @Test
+  public void testEmptyMessageSkipped() throws Exception {
+    // Empty string should be skipped
+    Exception cause = new RuntimeException("actual message");
+    Exception wrapper = new RuntimeException("", cause);
+
+    assertEquals("actual message", invokeGetRootCauseMessage(wrapper));
+  }
+
+  @Test
+  public void testAllNullMessagesFallbackToClassName() throws Exception {
+    // When entire chain has null messages, fall back to class name
+    Exception inner = new RuntimeException((String) null);
+    Exception outer = new RuntimeException((String) null, inner);
+
+    assertEquals("RuntimeException", invokeGetRootCauseMessage(outer));
+  }
+
+  @Test
+  public void testFirstNonNullMessageReturned() throws Exception {
+    // Should return the first non-null message in the chain, not the deepest
+    Exception deep = new RuntimeException("deep");
+    Exception mid = new RuntimeException("mid", deep);
+    Exception outer = new RuntimeException((String) null, mid);
+
+    assertEquals("mid", invokeGetRootCauseMessage(outer));
+  }
+
+  @Test
+  public void testTypicalWorkerFailureChain() throws Exception {
+    // Simulates the real failure chain:
+    // RuntimeException(null)
+    //   -> ExecutionException(cause) — getMessage() returns "java.lang.RuntimeException: ..."
+    //     -> RuntimeException("Error processing wire response stream")
+    //       -> ClosedChannelException(null)
+    Exception closedChannel = new java.nio.channels.ClosedChannelException();
+    Exception wireError = new RuntimeException("Error processing wire response stream",
+        closedChannel);
+    Exception execException = new java.util.concurrent.ExecutionException(wireError);
+    Exception aggregate = new RuntimeException((String) null, execException);
+
+    // ExecutionException.getMessage() includes the cause's toString(), so it's non-null
+    String result = invokeGetRootCauseMessage(aggregate);
+    assertTrue(result.contains("Error processing wire response stream"),
+        "Expected message containing root cause, got: " + result);
+  }
+}

--- a/src/test/java/org/joshsim/pipeline/remote/ParallelWorkerHandlerErrorCollectionTest.java
+++ b/src/test/java/org/joshsim/pipeline/remote/ParallelWorkerHandlerErrorCollectionTest.java
@@ -1,0 +1,206 @@
+/**
+ * Tests for ParallelWorkerHandler error-collection behavior.
+ *
+ * <p>Verifies that when some workers fail, all other workers are still allowed to complete
+ * before the method throws. This prevents cascading ClosedChannelExceptions.</p>
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.pipeline.remote;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.undertow.Undertow;
+import io.undertow.util.Headers;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that ParallelWorkerHandler collects errors from all workers instead of
+ * failing fast on the first error (which would abandon still-running workers).
+ */
+public class ParallelWorkerHandlerErrorCollectionTest {
+
+  private Undertow server;
+
+  /**
+   * Stops the local Undertow server after each test to release any bound ports
+   * and clean up resources.
+   */
+  @AfterEach
+  public void tearDown() {
+    if (server != null) {
+      server.stop();
+    }
+  }
+
+  /**
+   * Starts a local Undertow server that returns HTTP 500 for specific replicate numbers
+   * and successful streaming responses for others.
+   */
+  private int startMockWorkerServer(Set<Integer> failReplicates,
+      Set<Integer> completedReplicates) {
+    server = Undertow.builder()
+        .addHttpListener(0, "127.0.0.1")
+        .setHandler(exchange -> {
+          exchange.getRequestReceiver().receiveFullString((ex, body) -> {
+            // We use the 'name' param to encode replicate number for test control
+            String name = "";
+            for (String param : body.split("&")) {
+              if (param.startsWith("name=")) {
+                name = java.net.URLDecoder.decode(
+                    param.substring(5), java.nio.charset.StandardCharsets.UTF_8);
+              }
+            }
+
+            int replicateNum = -1;
+            try {
+              replicateNum = Integer.parseInt(name);
+            } catch (NumberFormatException e) {
+              // not a number, treat as normal
+            }
+
+            if (failReplicates.contains(replicateNum)) {
+              ex.setStatusCode(500);
+              ex.getResponseSender().send("Internal Server Error");
+            } else {
+              completedReplicates.add(replicateNum);
+              ex.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
+              ex.setStatusCode(200);
+              // Send a minimal valid streaming response (progress + end)
+              ex.getResponseSender().send(
+                  "[progress 1]\n[end " + replicateNum + "]\n");
+            }
+          });
+        })
+        .build();
+    server.start();
+
+    // Extract the actual bound port
+    return ((java.net.InetSocketAddress)
+        server.getListenerInfo().get(0).getAddress()).getPort();
+  }
+
+  @Test
+  public void testAllWorkersCompleteWhenSomeFail() {
+    // Arrange: 5 tasks, replicates 2 and 4 will fail with HTTP 500
+    Set<Integer> failReplicates = ConcurrentHashMap.newKeySet();
+    failReplicates.add(2);
+    failReplicates.add(4);
+    Set<Integer> completedReplicates = ConcurrentHashMap.newKeySet();
+
+    int port = startMockWorkerServer(failReplicates, completedReplicates);
+    String workerUrl = "http://127.0.0.1:" + port;
+
+    AtomicInteger cumulativeStepCount = new AtomicInteger(0);
+    ParallelWorkerHandler handler = new ParallelWorkerHandler(workerUrl, 5, cumulativeStepCount);
+
+    List<WorkerTask> tasks = new ArrayList<>();
+    for (int i = 1; i <= 5; i++) {
+      // Use simulationName to encode replicate number for server-side routing
+      tasks.add(new WorkerTask("code", String.valueOf(i), "key", "", false, i, ""));
+    }
+
+    // Act: execute — should throw aggregate exception
+    RuntimeException exception = assertThrows(RuntimeException.class, () ->
+        handler.executeInParallel(tasks, null, (line, rep, ex, counter) -> {
+          // no-op response handler for this test
+        })
+    );
+
+    // Assert: aggregate exception mentions 2 failures out of 5
+    assertTrue(exception.getMessage().contains("2 of 5 worker task(s) failed"),
+        "Expected aggregate message, got: " + exception.getMessage());
+    assertEquals(2, exception.getSuppressed().length,
+        "Expected 2 suppressed exceptions");
+
+    // Assert: the 3 non-failing workers completed successfully
+    assertTrue(completedReplicates.contains(1), "Replicate 1 should have completed");
+    assertTrue(completedReplicates.contains(3), "Replicate 3 should have completed");
+    assertTrue(completedReplicates.contains(5), "Replicate 5 should have completed");
+  }
+
+  @Test
+  public void testAllWorkersSucceed() {
+    // Arrange: no failures
+    Set<Integer> failReplicates = ConcurrentHashMap.newKeySet();
+    Set<Integer> completedReplicates = ConcurrentHashMap.newKeySet();
+
+    int port = startMockWorkerServer(failReplicates, completedReplicates);
+    String workerUrl = "http://127.0.0.1:" + port;
+
+    AtomicInteger cumulativeStepCount = new AtomicInteger(0);
+    ParallelWorkerHandler handler = new ParallelWorkerHandler(workerUrl, 3, cumulativeStepCount);
+
+    List<WorkerTask> tasks = new ArrayList<>();
+    for (int i = 1; i <= 3; i++) {
+      tasks.add(new WorkerTask("code", String.valueOf(i), "key", "", false, i, ""));
+    }
+
+    // Act: should not throw
+    handler.executeInParallel(tasks, null, (line, rep, ex, counter) -> {
+      // no-op
+    });
+
+    // Assert: all 3 completed
+    assertEquals(3, completedReplicates.size());
+  }
+
+  @Test
+  public void testAllWorkersFail() {
+    // Arrange: all fail
+    Set<Integer> failReplicates = ConcurrentHashMap.newKeySet();
+    failReplicates.add(1);
+    failReplicates.add(2);
+    Set<Integer> completedReplicates = ConcurrentHashMap.newKeySet();
+
+    int port = startMockWorkerServer(failReplicates, completedReplicates);
+    String workerUrl = "http://127.0.0.1:" + port;
+
+    AtomicInteger cumulativeStepCount = new AtomicInteger(0);
+    ParallelWorkerHandler handler = new ParallelWorkerHandler(workerUrl, 2, cumulativeStepCount);
+
+    List<WorkerTask> tasks = new ArrayList<>();
+    for (int i = 1; i <= 2; i++) {
+      tasks.add(new WorkerTask("code", String.valueOf(i), "key", "", false, i, ""));
+    }
+
+    // Act
+    RuntimeException exception = assertThrows(RuntimeException.class, () ->
+        handler.executeInParallel(tasks, null, (line, rep, ex, counter) -> {})
+    );
+
+    // Assert
+    assertTrue(exception.getMessage().contains("2 of 2 worker task(s) failed"));
+    assertEquals(2, exception.getSuppressed().length);
+    assertTrue(completedReplicates.isEmpty(), "No replicates should have completed");
+  }
+
+  @Test
+  public void testEmptyTaskList() {
+    // Arrange
+    Set<Integer> failReplicates = ConcurrentHashMap.newKeySet();
+    Set<Integer> completedReplicates = ConcurrentHashMap.newKeySet();
+
+    int port = startMockWorkerServer(failReplicates, completedReplicates);
+    String workerUrl = "http://127.0.0.1:" + port;
+
+    AtomicInteger cumulativeStepCount = new AtomicInteger(0);
+    ParallelWorkerHandler handler = new ParallelWorkerHandler(workerUrl, 5, cumulativeStepCount);
+
+    // Act: empty list should return immediately without error
+    handler.executeInParallel(Collections.emptyList(), null, (line, rep, ex, counter) -> {});
+
+    // Assert
+    assertTrue(completedReplicates.isEmpty());
+  }
+}

--- a/src/test/java/org/joshsim/pipeline/remote/StreamingFormBodyPublisherTest.java
+++ b/src/test/java/org/joshsim/pipeline/remote/StreamingFormBodyPublisherTest.java
@@ -1,0 +1,306 @@
+/**
+ * Unit tests for StreamingFormBodyPublisher.
+ *
+ * <p>Verifies that the streaming form body produces output identical to the original
+ * in-memory approach (URLEncoder.encode on concatenated strings), and that large files
+ * can be streamed without exceeding memory limits.</p>
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.pipeline.remote;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for StreamingFormBodyPublisher.
+ *
+ * <p>Tests wire-format compatibility with the original in-memory serialization approach,
+ * correct handling of text and binary files, and large-file streaming.</p>
+ */
+public class StreamingFormBodyPublisherTest {
+
+  /**
+   * Verifies that the streaming output for a binary file matches the original
+   * in-memory URLEncoder.encode(Base64.encode(bytes)) approach exactly.
+   */
+  @Test
+  public void testBinaryFileWireFormatCompatibility(@TempDir Path tempDir) throws Exception {
+    // Create a binary file with bytes that exercise all Base64 special characters
+    byte[] binaryData = {1, 2, 3, 4, 5, (byte) 0xFF, (byte) 0xFE, 0, 127, (byte) 0x80};
+    Path binaryFile = tempDir.resolve("test.jshd");
+    Files.write(binaryFile, binaryData);
+
+    // === Original approach (in-memory) ===
+    String base64 = Base64.getEncoder().encodeToString(binaryData);
+    String originalExternalData = "test.jshd\t1\t" + base64 + "\t";
+    String originalFormBody = "code=" + URLEncoder.encode("sim code", StandardCharsets.UTF_8)
+        + "&name=" + URLEncoder.encode("TestSim", StandardCharsets.UTF_8)
+        + "&apiKey=" + URLEncoder.encode("key-123", StandardCharsets.UTF_8)
+        + "&favorBigDecimal=" + URLEncoder.encode("true", StandardCharsets.UTF_8)
+        + "&externalData=" + URLEncoder.encode(originalExternalData, StandardCharsets.UTF_8);
+
+    // === New streaming approach ===
+    Map<String, String> smallFields = new LinkedHashMap<>();
+    smallFields.put("code", "sim code");
+    smallFields.put("name", "TestSim");
+    smallFields.put("apiKey", "key-123");
+    smallFields.put("favorBigDecimal", "true");
+
+    List<ExternalFileEntry> files = List.of(
+        new ExternalFileEntry("test.jshd", true, binaryFile.toString())
+    );
+
+    String streamedFormBody = captureFormBody(smallFields, files, null);
+
+    // Parse both form bodies into field maps and compare
+    Map<String, String> originalFields = parseFormData(originalFormBody);
+    Map<String, String> streamedFields = parseFormData(streamedFormBody);
+
+    assertEquals(originalFields.get("code"), streamedFields.get("code"));
+    assertEquals(originalFields.get("name"), streamedFields.get("name"));
+    assertEquals(originalFields.get("apiKey"), streamedFields.get("apiKey"));
+    assertEquals(originalFields.get("favorBigDecimal"), streamedFields.get("favorBigDecimal"));
+    assertEquals(originalFields.get("externalData"), streamedFields.get("externalData"));
+  }
+
+  /**
+   * Verifies that the streaming output for a text file matches the original approach.
+   */
+  @Test
+  public void testTextFileWireFormatCompatibility(@TempDir Path tempDir) throws Exception {
+    // Create a text file with tabs (which get replaced) and special characters
+    String textContent = "Hello\tWorld\nLine 2 with special chars: é & <>";
+    Path textFile = tempDir.resolve("config.jshc");
+    Files.writeString(textFile, textContent);
+
+    // === Original approach ===
+    String processedContent = textContent.replace("\t", "    ");
+    String originalExternalData = "config.jshc\t0\t" + processedContent + "\t";
+    // === New streaming approach ===
+    List<ExternalFileEntry> files = List.of(
+        new ExternalFileEntry("config.jshc", false, textFile.toString())
+    );
+
+    String streamedFormBody = captureFormBody(Map.of(), files, null);
+    // Extract just the externalData value
+    Map<String, String> fields = parseFormData(streamedFormBody);
+    String streamedExternalData = fields.get("externalData");
+
+    assertEquals(originalExternalData, streamedExternalData);
+  }
+
+  /**
+   * Verifies wire-format compatibility with mixed text and binary files.
+   */
+  @Test
+  public void testMixedFilesWireFormatCompatibility(@TempDir Path tempDir) throws Exception {
+    // Create test files
+    byte[] binaryData = {10, 20, 30};
+    Path binaryFile = tempDir.resolve("data.jshd");
+    Files.write(binaryFile, binaryData);
+
+    String textContent = "key,value\na,1\nb,2";
+    Path textFile = tempDir.resolve("params.csv");
+    Files.writeString(textFile, textContent);
+
+    // === Original approach ===
+    String base64 = Base64.getEncoder().encodeToString(binaryData);
+    String originalExternalData = "data.jshd\t1\t" + base64 + "\t"
+        + "params.csv\t0\t" + textContent + "\t";
+
+    // === New streaming approach ===
+    List<ExternalFileEntry> files = List.of(
+        new ExternalFileEntry("data.jshd", true, binaryFile.toString()),
+        new ExternalFileEntry("params.csv", false, textFile.toString())
+    );
+
+    String streamedFormBody = captureFormBody(Map.of(), files, null);
+    Map<String, String> fields = parseFormData(streamedFormBody);
+
+    assertEquals(originalExternalData, fields.get("externalData"));
+  }
+
+  /**
+   * Verifies that pre-serialized external data string (server-side path) is encoded correctly.
+   */
+  @Test
+  public void testPreSerializedStringFallback() throws Exception {
+    String preSerializedData = "config.jshc\t0\tsome content\t";
+
+    Map<String, String> smallFields = new LinkedHashMap<>();
+    smallFields.put("code", "test");
+
+    String formBody = captureFormBody(smallFields, List.of(), preSerializedData);
+    Map<String, String> fields = parseFormData(formBody);
+
+    assertEquals("test", fields.get("code"));
+    assertEquals(preSerializedData, fields.get("externalData"));
+  }
+
+  /**
+   * Verifies that empty external files produce no externalData field.
+   */
+  @Test
+  public void testEmptyExternalFiles() throws Exception {
+    Map<String, String> smallFields = new LinkedHashMap<>();
+    smallFields.put("code", "test");
+
+    String formBody = captureFormBody(smallFields, List.of(), null);
+
+    assertEquals("code=test", formBody);
+    assertFalse(formBody.contains("externalData"));
+  }
+
+  /**
+   * Verifies that the Base64UrlEncodingOutputStream correctly encodes all special characters.
+   */
+  @Test
+  public void testBase64UrlEncodingOutputStream() throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    StreamingFormBodyPublisher.Base64UrlEncodingOutputStream encoder =
+        new StreamingFormBodyPublisher.Base64UrlEncodingOutputStream(baos);
+
+    // Write a mix of safe and special Base64 characters
+    // "AB+/=CD" in ASCII bytes
+    encoder.write(new byte[]{'A', 'B', '+', '/', '=', 'C', 'D'}, 0, 7);
+    encoder.flush();
+
+    assertEquals("AB%2B%2F%3DCD", baos.toString(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Verifies single-byte writes through Base64UrlEncodingOutputStream.
+   */
+  @Test
+  public void testBase64UrlEncodingSingleByteWrites() throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    StreamingFormBodyPublisher.Base64UrlEncodingOutputStream encoder =
+        new StreamingFormBodyPublisher.Base64UrlEncodingOutputStream(baos);
+
+    encoder.write('+');
+    encoder.write('A');
+    encoder.write('/');
+    encoder.write('=');
+    encoder.flush();
+
+    assertEquals("%2BA%2F%3D", baos.toString(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Stress test: stream a 10MB binary file and verify the output decodes correctly.
+   *
+   * <p>This verifies that the streaming Base64 + URL-encoding pipeline works end-to-end
+   * for non-trivial file sizes without creating intermediate giant Strings.</p>
+   */
+  @Test
+  public void testLargeBinaryFileStreaming(@TempDir Path tempDir) throws Exception {
+    // Create a 10MB binary file with random data
+    int size = 10 * 1024 * 1024; // 10MB
+    byte[] largeData = new byte[size];
+    new Random(42).nextBytes(largeData); // Deterministic seed for reproducibility
+    Path largeFile = tempDir.resolve("large.jshd");
+    Files.write(largeFile, largeData);
+
+    // Stream through the publisher
+    List<ExternalFileEntry> files = List.of(
+        new ExternalFileEntry("large.jshd", true, largeFile.toString())
+    );
+
+    String formBody = captureFormBody(Map.of(), files, null);
+    Map<String, String> fields = parseFormData(formBody);
+    String externalData = fields.get("externalData");
+
+    // Parse the wire format: filename\tbinary_flag\tcontent\t
+    String[] parts = externalData.split("\t", -1);
+    assertEquals("large.jshd", parts[0]);
+    assertEquals("1", parts[1]);
+
+    // Decode Base64 content and verify it matches original data
+    byte[] decodedData = Base64.getDecoder().decode(parts[2]);
+    assertArrayEquals(largeData, decodedData);
+  }
+
+  /**
+   * Verifies that streaming produces identical Base64 output to the in-memory approach
+   * for a file whose Base64 contains all three special characters (+, /, =).
+   */
+  @Test
+  public void testBase64SpecialCharacterConsistency(@TempDir Path tempDir) throws Exception {
+    // Craft bytes that produce +, /, and = in Base64
+    // 0xFB, 0xEF, 0xBE gives "/++=" in Base64 (approximately)
+    // Use a range of values to guarantee all three appear
+    byte[] data = new byte[256];
+    for (int i = 0; i < 256; i++) {
+      data[i] = (byte) i;
+    }
+    Path file = tempDir.resolve("special.jshd");
+    Files.write(file, data);
+
+    // In-memory approach
+    String expectedBase64 = Base64.getEncoder().encodeToString(data);
+    // Streaming approach
+    List<ExternalFileEntry> files = List.of(
+        new ExternalFileEntry("special.jshd", true, file.toString())
+    );
+    String formBody = captureFormBody(Map.of(), files, null);
+    Map<String, String> fields = parseFormData(formBody);
+    String externalData = fields.get("externalData");
+    String[] parts = externalData.split("\t", -1);
+
+    // The Base64 content should be identical
+    assertEquals(expectedBase64, parts[2]);
+
+    // Verify all three special chars were present (test exercises the substitution paths)
+    assertTrue(expectedBase64.contains("+"), "Test data should produce + in Base64");
+    assertTrue(expectedBase64.contains("/"), "Test data should produce / in Base64");
+    assertTrue(expectedBase64.contains("="), "Test data should produce = in Base64");
+  }
+
+  /**
+   * Captures the form body output as a String by writing directly to a ByteArrayOutputStream.
+   */
+  private String captureFormBody(
+      Map<String, String> smallFields,
+      List<ExternalFileEntry> externalFiles,
+      String externalDataString) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    StreamingFormBodyPublisher.writeFormBody(baos, smallFields, externalFiles, externalDataString);
+    return baos.toString(StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Parses a URL-encoded form body into a map of field names to decoded values.
+   */
+  private Map<String, String> parseFormData(String formData) {
+    Map<String, String> fields = new HashMap<>();
+    for (String pair : formData.split("&")) {
+      String[] kv = pair.split("=", 2);
+      if (kv.length == 2) {
+        String key = URLDecoder.decode(kv[0], StandardCharsets.UTF_8);
+        String value = URLDecoder.decode(kv[1], StandardCharsets.UTF_8);
+        fields.put(key, value);
+      }
+    }
+    return fields;
+  }
+}

--- a/src/test/java/org/joshsim/util/ProgressCalculatorConcurrencyTest.java
+++ b/src/test/java/org/joshsim/util/ProgressCalculatorConcurrencyTest.java
@@ -1,0 +1,145 @@
+/**
+ * Concurrency tests for ProgressCalculator.
+ *
+ * <p>Verifies that synchronized methods prevent state corruption when
+ * multiple threads call updateStep, updateReplicateCompleted, and
+ * resetForNextReplicate concurrently.</p>
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that ProgressCalculator's synchronized methods do not corrupt state
+ * under concurrent access from multiple worker threads.
+ */
+public class ProgressCalculatorConcurrencyTest {
+
+  @Test
+  public void testConcurrentUpdateStepDoesNotCorruptState() throws Exception {
+    // Arrange: 1000 steps, 10 replicates — shared across 10 threads
+    ProgressCalculator calc = new ProgressCalculator(1000, 10);
+    int threadCount = 10;
+    int stepsPerThread = 100;
+
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    List<Future<?>> futures = new ArrayList<>();
+
+    // Act: all threads call updateStep concurrently
+    for (int t = 0; t < threadCount; t++) {
+      final int threadId = t;
+      futures.add(executor.submit(() -> {
+        try {
+          startLatch.await(); // Synchronize start
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        for (int step = 0; step < stepsPerThread; step++) {
+          ProgressUpdate update = calc.updateStep(threadId * stepsPerThread + step);
+          assertNotNull(update);
+        }
+      }));
+    }
+
+    startLatch.countDown(); // Release all threads simultaneously
+
+    // Assert: no exceptions
+    for (Future<?> future : futures) {
+      assertDoesNotThrow(() -> future.get(10, TimeUnit.SECONDS));
+    }
+
+    executor.shutdown();
+  }
+
+  @Test
+  public void testConcurrentResetAndUpdateDoNotCorruptState() throws Exception {
+    // Simulates the pattern where END responses trigger resetForNextReplicate
+    // while other threads are still calling updateStep
+    ProgressCalculator calc = new ProgressCalculator(100, 5);
+    int threadCount = 5;
+
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    List<Future<?>> futures = new ArrayList<>();
+
+    // Mix of updateStep and replicate-completion calls
+    for (int t = 0; t < threadCount; t++) {
+      final int threadId = t;
+      futures.add(executor.submit(() -> {
+        try {
+          startLatch.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        for (int i = 0; i < 50; i++) {
+          ProgressUpdate update = calc.updateStep(i * 2);
+          assertNotNull(update);
+        }
+        ProgressUpdate endUpdate = calc.updateReplicateCompleted(threadId + 1);
+        assertNotNull(endUpdate);
+      }));
+    }
+
+    startLatch.countDown();
+
+    for (Future<?> future : futures) {
+      assertDoesNotThrow(() -> future.get(10, TimeUnit.SECONDS));
+    }
+
+    executor.shutdown();
+  }
+
+  @Test
+  public void testConcurrentResetForNextReplicate() throws Exception {
+    // Multiple threads competing to reset — should not throw or corrupt
+    ProgressCalculator calc = new ProgressCalculator(100, 100);
+    int threadCount = 10;
+
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    List<Future<?>> futures = new ArrayList<>();
+
+    for (int t = 0; t < threadCount; t++) {
+      final int threadId = t;
+      futures.add(executor.submit(() -> {
+        try {
+          startLatch.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        // Each thread cycles through resets and updates
+        for (int rep = 1; rep <= 10; rep++) {
+          calc.resetForNextReplicate(((threadId * 10 + rep - 1) % 100) + 1);
+          for (int step = 0; step < 10; step++) {
+            calc.updateStep(step * 10);
+          }
+        }
+      }));
+    }
+
+    startLatch.countDown();
+
+    for (Future<?> future : futures) {
+      assertDoesNotThrow(() -> future.get(10, TimeUnit.SECONDS));
+    }
+
+    executor.shutdown();
+  }
+}


### PR DESCRIPTION
Local leader was greedily killing http connections to all other workers if any one failed. We now are a bit more permissive and collect failures in aggregate 