### PR TITLE
Jshd margin issue / externalData concurrency

### DIFF
--- a/src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java
+++ b/src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java
@@ -6,8 +6,8 @@
 
 package org.joshsim.lang.bridge;
 
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,7 +50,7 @@ public class MinimalEngineBridge implements EngineBridge {
   private final EntityPrototypeStore prototypeStore;
   private final Map<String, DataGridLayer> externalData;
   private final ExternalResourceGetter externalResourceGetter;
-  private final Map<String, Config> configData;
+  private final Map<String, Optional<Config>> configData;
   private final ConfigGetter configGetter;
 
   private Optional<Replicate> replicate;
@@ -85,7 +85,7 @@ public class MinimalEngineBridge implements EngineBridge {
     this.prototypeStore = prototypeStore;
     this.externalResourceGetter = externalResourceGetter;
     this.configGetter = configGetter;
-    this.configData = new HashMap<>();
+    this.configData = new ConcurrentHashMap<>();
 
     replicate = Optional.empty();
 
@@ -105,7 +105,7 @@ public class MinimalEngineBridge implements EngineBridge {
 
     absoluteStep = 0;
     inStep = false;
-    externalData = new HashMap<>();
+    externalData = new ConcurrentHashMap<>();
   }
 
   /**
@@ -129,7 +129,7 @@ public class MinimalEngineBridge implements EngineBridge {
     this.prototypeStore = prototypeStore;
     this.externalResourceGetter = externalResourceGetter;
     this.configGetter = configGetter;
-    this.configData = new HashMap<>();
+    this.configData = new ConcurrentHashMap<>();
     this.replicate = Optional.of(replicate);
 
     simulation.startSubstep("constant");
@@ -148,7 +148,7 @@ public class MinimalEngineBridge implements EngineBridge {
 
     absoluteStep = 0;
     inStep = false;
-    externalData = new HashMap<>();
+    externalData = new ConcurrentHashMap<>();
   }
 
   @Override
@@ -192,17 +192,14 @@ public class MinimalEngineBridge implements EngineBridge {
 
   @Override
   public EngineValue getExternal(GeoKey key, String name, long step) {
-    if (!externalData.containsKey(name)) {
-      // Append .jshd extension to external resource name before loading
-      String fileName = name.endsWith(".jshd") ? name : name + ".jshd";
-      externalData.put(name, externalResourceGetter.getResource(fileName));
-    }
-    return externalData.get(name).getAt(key, step);
+    String fileName = name.endsWith(".jshd") ? name : name + ".jshd";
+    DataGridLayer layer = externalData.computeIfAbsent(name,
+        k -> externalResourceGetter.getResource(fileName));
+    return layer.getAt(key, step);
   }
 
   @Override
   public Optional<EngineValue> getConfigOptional(String name) {
-    // Extract the actual config variable from the dot notation
     String[] parts = name.split("\\.", 2);
     if (parts.length != 2) {
       return Optional.empty();
@@ -210,20 +207,16 @@ public class MinimalEngineBridge implements EngineBridge {
     String configName = parts[0];
     String variableName = parts[1];
 
-    // Append .jshc extension to config name before looking it up
     String configFileName = configName.endsWith(".jshc") ? configName : configName + ".jshc";
 
-    if (!configData.containsKey(configName)) {
-      Optional<Config> configOptional = configGetter.getConfig(configFileName);
-      if (configOptional.isEmpty()) {
-        // Config file not found
-        return Optional.empty();
-      }
-      configData.put(configName, configOptional.get());
+    Optional<Config> configOptional = configData.computeIfAbsent(configName,
+        k -> configGetter.getConfig(configFileName));
+
+    if (configOptional.isEmpty()) {
+      return Optional.empty();
     }
 
-    Config config = configData.get(configName);
-    EngineValue value = config.getValue(variableName);
+    EngineValue value = configOptional.get().getValue(variableName);
     return Optional.ofNullable(value);
   }
 

--- a/src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java
+++ b/src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java
@@ -7,10 +7,10 @@
 package org.joshsim.lang.bridge;
 
 import java.util.Iterator;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.joshsim.engine.config.Config;
 import org.joshsim.engine.entity.base.Entity;
 import org.joshsim.engine.entity.base.GeoKey;

--- a/src/main/java/org/joshsim/lang/bridge/QueryCacheEngineBridge.java
+++ b/src/main/java/org/joshsim/lang/bridge/QueryCacheEngineBridge.java
@@ -7,8 +7,8 @@
 package org.joshsim.lang.bridge;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.joshsim.engine.entity.base.Entity;
@@ -57,7 +57,7 @@ public class QueryCacheEngineBridge extends MinimalEngineBridge {
         externalResourceGetter,
         configGetter
     );
-    cachedPatchesByGeometry = new HashMap<>();
+    cachedPatchesByGeometry = new ConcurrentHashMap<>();
   }
 
   /**
@@ -87,14 +87,14 @@ public class QueryCacheEngineBridge extends MinimalEngineBridge {
         configGetter,
         replicate
     );
-    cachedPatchesByGeometry = new HashMap<>();
+    cachedPatchesByGeometry = new ConcurrentHashMap<>();
   }
 
   @Override
   public List<Entity> getPriorPatches(GeometryMomento geometryMomento) {
-    if (cachedPatchesByGeometry.containsKey(geometryMomento)) {
+    List<GeoKey> keys = cachedPatchesByGeometry.get(geometryMomento);
+    if (keys != null) {
       // Cache hit: retrieve patches by keys using direct iteration
-      List<GeoKey> keys = cachedPatchesByGeometry.get(geometryMomento);
       long priorTimestep = getPriorTimestep();
 
       List<Entity> result = new ArrayList<>(keys.size());
@@ -114,7 +114,7 @@ public class QueryCacheEngineBridge extends MinimalEngineBridge {
         }
       }
 
-      cachedPatchesByGeometry.put(geometryMomento, geoKeys);
+      cachedPatchesByGeometry.putIfAbsent(geometryMomento, geoKeys);
       return entities;
     }
   }

--- a/src/main/java/org/joshsim/lang/bridge/QueryCacheEngineBridge.java
+++ b/src/main/java/org/joshsim/lang/bridge/QueryCacheEngineBridge.java
@@ -8,9 +8,9 @@ package org.joshsim.lang.bridge;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.joshsim.engine.entity.base.Entity;
 import org.joshsim.engine.entity.base.GeoKey;
 import org.joshsim.engine.entity.base.MutableEntity;

--- a/src/main/java/org/joshsim/precompute/DoublePrecomputedGrid.java
+++ b/src/main/java/org/joshsim/precompute/DoublePrecomputedGrid.java
@@ -126,6 +126,34 @@ public class DoublePrecomputedGrid extends UniformPrecomputedGrid<Double> {
     int horizCut = (int) (x - getMinX());
     int vertCut = (int) (y - getMinY());
     int timestepCut = (int) (timestep - getMinTimestep());
+
+    if (horizCut < 0 || horizCut >= getWidth()) {
+      throw new IllegalArgumentException(String.format(
+          "Horizontal out of bounds (%d < 0 || %d >= %d)",
+          horizCut,
+          horizCut,
+          getWidth()
+      ));
+    }
+
+    if (vertCut < 0 || vertCut >= getHeight()) {
+      throw new IllegalArgumentException(String.format(
+          "Vertical out of bounds (%d < 0 || %d >= %d)",
+          vertCut,
+          vertCut,
+          getHeight()
+      ));
+    }
+
+    if (timestepCut < 0 || timestepCut > (getMaxTimestep() - getMinTimestep())) {
+      throw new IllegalArgumentException(String.format(
+          "Timestep out of bounds (%d < 0 || %d >= %d)",
+          timestepCut,
+          timestepCut,
+          (getMaxTimestep() - getMinTimestep())
+      ));
+    }
+
     double value = innerValues[timestepCut][vertCut][horizCut];
     return factory.buildForNumber(value, units);
   }

--- a/src/main/java/org/joshsim/precompute/ExtentsTransformer.java
+++ b/src/main/java/org/joshsim/precompute/ExtentsTransformer.java
@@ -7,6 +7,7 @@
 package org.joshsim.precompute;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import org.joshsim.engine.geometry.HaversineUtil;
 import org.joshsim.engine.geometry.PatchBuilderExtents;
 
@@ -38,8 +39,8 @@ public class ExtentsTransformer {
         new HaversineUtil.HaversinePoint(extents.getTopLeftX(), extents.getBottomRightY())
     );
 
-    BigDecimal gridWidth = width.divide(sizeMeters, 0, BigDecimal.ROUND_CEILING);
-    BigDecimal gridHeight = height.divide(sizeMeters, 0, BigDecimal.ROUND_CEILING);
+    BigDecimal gridWidth = width.divide(sizeMeters, 0, RoundingMode.CEILING);
+    BigDecimal gridHeight = height.divide(sizeMeters, 0, RoundingMode.CEILING);
 
     return new PatchBuilderExtents(
         BigDecimal.ZERO,

--- a/src/main/java/org/joshsim/precompute/PatchKeyConverter.java
+++ b/src/main/java/org/joshsim/precompute/PatchKeyConverter.java
@@ -24,7 +24,6 @@ public class PatchKeyConverter {
   private final PatchBuilderExtents geoExtents;
   private final HaversineUtil.HaversinePoint startPoint;
   private final BigDecimal patchWidth;
-  private final BigDecimal patchWidthHalf;
 
   /**
    * Create a utility which performs conversions from patch keys in geoExtents to grid-space.
@@ -35,7 +34,6 @@ public class PatchKeyConverter {
   public PatchKeyConverter(PatchBuilderExtents geoExtents, BigDecimal patchWidth) {
     this.geoExtents = geoExtents;
     this.patchWidth = patchWidth;
-    this.patchWidthHalf = patchWidth.divide(new BigDecimal(2));
     this.startPoint = new HaversineUtil.HaversinePoint(
         geoExtents.getTopLeftX(),
         geoExtents.getTopLeftY()
@@ -63,16 +61,8 @@ public class PatchKeyConverter {
     );
 
     // Convert distances to grid cell indices by dividing by patch width
-    BigDecimal gridX = horizontalDistance.subtract(patchWidthHalf).divide(
-        patchWidth,
-        0,
-        RoundingMode.HALF_UP
-    );
-    BigDecimal gridY = verticalDistance.subtract(patchWidthHalf).divide(
-        patchWidth,
-        0,
-        RoundingMode.HALF_UP
-    );
+    BigDecimal gridX = horizontalDistance.divide(patchWidth, 0, RoundingMode.FLOOR);
+    BigDecimal gridY = verticalDistance.divide(patchWidth, 0, RoundingMode.FLOOR);
 
     return new ProjectedValue(gridX, gridY, value);
   }

--- a/src/test/java/org/joshsim/lang/bridge/MinimalEngineBridgeConcurrencyTest.java
+++ b/src/test/java/org/joshsim/lang/bridge/MinimalEngineBridgeConcurrencyTest.java
@@ -1,0 +1,198 @@
+package org.joshsim.lang.bridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.joshsim.engine.config.Config;
+import org.joshsim.engine.entity.base.GeoKey;
+import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.entity.prototype.EntityPrototypeStore;
+import org.joshsim.engine.geometry.grid.GridGeometryFactory;
+import org.joshsim.engine.simulation.Replicate;
+import org.joshsim.engine.value.converter.Converter;
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.engine.EngineValueFactory;
+import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.precompute.DataGridLayer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+class MinimalEngineBridgeConcurrencyTest {
+
+  private static final int THREAD_COUNT = 16;
+
+  @Mock(lenient = true) private MutableEntity mockSimulation;
+  @Mock(lenient = true) private Replicate mockReplicate;
+  @Mock(lenient = true) private Converter mockConverter;
+  @Mock(lenient = true) private EntityPrototypeStore mockPrototypeStore;
+
+  private EngineValueFactory engineValueFactory;
+
+  @BeforeEach
+  void setUp() {
+    engineValueFactory = new EngineValueFactory();
+  }
+
+  @Test
+  void getExternalConcurrentAccessShouldNotThrowNpe() throws Exception {
+    AtomicInteger callCount = new AtomicInteger(0);
+    DataGridLayer mockLayer = mock(DataGridLayer.class);
+    GeoKey mockKey = mock(GeoKey.class);
+    EngineValue mockValue = engineValueFactory.build(1.0, Units.of("mm"));
+
+    when(mockLayer.getAt(mockKey, 0L)).thenReturn(mockValue);
+
+    ExternalResourceGetter externalGetter = name -> {
+      callCount.incrementAndGet();
+      try {
+        Thread.sleep(10); // simulate slow I/O
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return mockLayer;
+    };
+
+    MinimalEngineBridge bridge = new MinimalEngineBridge(
+        engineValueFactory,
+        new GridGeometryFactory(),
+        mockSimulation,
+        mockConverter,
+        mockPrototypeStore,
+        externalGetter,
+        new org.joshsim.engine.config.NoOpConfigGetter(),
+        mockReplicate
+    );
+
+    CyclicBarrier barrier = new CyclicBarrier(THREAD_COUNT);
+    ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+    List<Future<EngineValue>> futures = new ArrayList<>();
+
+    for (int i = 0; i < THREAD_COUNT; i++) {
+      futures.add(executor.submit(() -> {
+        barrier.await();
+        return bridge.getExternal(mockKey, "Precipitation", 0L);
+      }));
+    }
+
+    for (Future<EngineValue> future : futures) {
+      EngineValue result = future.get();
+      assertNotNull(result, "getExternal should never return null under concurrency");
+    }
+
+    assertEquals(1, callCount.get(),
+        "getResource should be called exactly once via computeIfAbsent");
+
+    executor.shutdown();
+  }
+
+  @Test
+  void getConfigOptionalConcurrentAccessShouldNotThrowNpe() throws Exception {
+    AtomicInteger callCount = new AtomicInteger(0);
+    Config mockConfig = mock(Config.class);
+    EngineValue mockValue = engineValueFactory.build(42.0, Units.of("meters"));
+    when(mockConfig.getValue("testVar")).thenReturn(mockValue);
+
+    ConfigGetter configGetter = name -> {
+      callCount.incrementAndGet();
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return Optional.of(mockConfig);
+    };
+
+    MinimalEngineBridge bridge = new MinimalEngineBridge(
+        engineValueFactory,
+        new GridGeometryFactory(),
+        mockSimulation,
+        mockConverter,
+        mockPrototypeStore,
+        mock(ExternalResourceGetter.class),
+        configGetter,
+        mockReplicate
+    );
+
+    CyclicBarrier barrier = new CyclicBarrier(THREAD_COUNT);
+    ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+    List<Future<Optional<EngineValue>>> futures = new ArrayList<>();
+
+    for (int i = 0; i < THREAD_COUNT; i++) {
+      futures.add(executor.submit(() -> {
+        barrier.await();
+        return bridge.getConfigOptional("test.testVar");
+      }));
+    }
+
+    for (Future<Optional<EngineValue>> future : futures) {
+      Optional<EngineValue> result = future.get();
+      assertNotNull(result, "getConfigOptional should never return null under concurrency");
+    }
+
+    assertEquals(1, callCount.get(),
+        "getConfig should be called exactly once via computeIfAbsent");
+
+    executor.shutdown();
+  }
+
+  @Test
+  void queryCacheBridgeConcurrentPriorPatchesShouldNotThrowNpe() throws Exception {
+    GeoKey mockKey = mock(GeoKey.class);
+    MutableEntity mockPatch = mock(MutableEntity.class);
+    when(mockPatch.getKey()).thenReturn(Optional.of(mockKey));
+
+    org.joshsim.engine.geometry.EngineGeometry mockGeometry = mock(
+        org.joshsim.engine.geometry.EngineGeometry.class);
+    GeometryMomento mockMomento = mock(GeometryMomento.class);
+    when(mockMomento.build()).thenReturn(mockGeometry);
+
+    when(mockReplicate.query(
+        org.mockito.ArgumentMatchers.any(org.joshsim.engine.simulation.Query.class)))
+        .thenReturn(List.of(mockPatch));
+    when(mockReplicate.getPatchByKey(mockKey, -1L)).thenReturn(mockPatch);
+
+    QueryCacheEngineBridge bridge = new QueryCacheEngineBridge(
+        engineValueFactory,
+        new GridGeometryFactory(),
+        mockSimulation,
+        mockConverter,
+        mockPrototypeStore,
+        mock(ExternalResourceGetter.class),
+        new org.joshsim.engine.config.NoOpConfigGetter(),
+        mockReplicate
+    );
+
+    CyclicBarrier barrier = new CyclicBarrier(THREAD_COUNT);
+    ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+    List<Future<List<org.joshsim.engine.entity.base.Entity>>> futures = new ArrayList<>();
+
+    for (int i = 0; i < THREAD_COUNT; i++) {
+      futures.add(executor.submit(() -> {
+        barrier.await();
+        return bridge.getPriorPatches(mockMomento);
+      }));
+    }
+
+    for (Future<List<org.joshsim.engine.entity.base.Entity>> future : futures) {
+      List<org.joshsim.engine.entity.base.Entity> result = future.get();
+      assertNotNull(result, "getPriorPatches should never return null under concurrency");
+    }
+
+    executor.shutdown();
+  }
+}

--- a/src/test/java/org/joshsim/precompute/DoublePrecomputedGridTest.java
+++ b/src/test/java/org/joshsim/precompute/DoublePrecomputedGridTest.java
@@ -2,6 +2,7 @@
 package org.joshsim.precompute;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -110,5 +111,33 @@ class DoublePrecomputedGridTest {
     assertEquals(mockEngineValue, result2);
     assertEquals(mockEngineValue, result3);
     assertEquals(mockEngineValue, result4);
+  }
+
+  @Test
+  void testGetAtOutOfBoundsX() {
+    assertThrows(IllegalArgumentException.class,
+        () -> grid.getAt(-1, 0, 0),
+        "Should throw for negative x");
+    assertThrows(IllegalArgumentException.class,
+        () -> grid.getAt(11, 0, 0),
+        "Should throw for x >= width");
+  }
+
+  @Test
+  void testGetAtOutOfBoundsY() {
+    assertThrows(IllegalArgumentException.class,
+        () -> grid.getAt(0, -1, 0),
+        "Should throw for negative y");
+    assertThrows(IllegalArgumentException.class,
+        () -> grid.getAt(0, 11, 0),
+        "Should throw for y >= height");
+  }
+
+  @Test
+  void testGetAtMaxValidPosition() {
+    // Max valid position is (10, 10, 10) for an 11x11x11 grid starting at (0,0)
+    when(mockFactory.buildForNumber(0.0, testUnits)).thenReturn(mockEngineValue);
+    EngineValue result = grid.getAt(10, 10, 10);
+    assertEquals(mockEngineValue, result);
   }
 }

--- a/src/test/java/org/joshsim/precompute/PatchKeyConverterTest.java
+++ b/src/test/java/org/joshsim/precompute/PatchKeyConverterTest.java
@@ -162,4 +162,170 @@ class PatchKeyConverterTest {
     assertEquals(0, result.getY().compareTo(expectedY));
     assertEquals(0, result.getValue().compareTo(BigDecimal.ONE));
   }
+
+  @Test
+  void convertAtGridOriginShouldProduceZeroZero() {
+    // A point at the top-left corner (same as start point) should map to (0, 0)
+    BigDecimal sfLong = new BigDecimal("-122.45");
+    BigDecimal sfLat = new BigDecimal("37.73");
+
+    GeoKey originKey = makeGeoKey(sfLong, sfLat);
+    PatchKeyConverter.ProjectedValue result = converter.convert(originKey, BigDecimal.ONE);
+
+    assertEquals(0, result.getX().compareTo(BigDecimal.ZERO),
+        "Origin point should have gridX = 0, got " + result.getX());
+    assertEquals(0, result.getY().compareTo(BigDecimal.ZERO),
+        "Origin point should have gridY = 0, got " + result.getY());
+  }
+
+  @Test
+  void convertAtHalfCellOffsetShouldProduceZeroZero() {
+    // A point slightly offset (less than one patchWidth) from origin should still be (0, 0)
+    // Use a longitude slightly east of SF (about 2km east, less than 5km patch width)
+    BigDecimal nearSfLong = new BigDecimal("-122.43");
+    BigDecimal sfLat = new BigDecimal("37.73");
+
+    GeoKey nearKey = makeGeoKey(nearSfLong, sfLat);
+    PatchKeyConverter.ProjectedValue result = converter.convert(nearKey, BigDecimal.ONE);
+
+    assertEquals(0, result.getX().compareTo(BigDecimal.ZERO),
+        "Half-cell offset should have gridX = 0, got " + result.getX());
+    assertEquals(0, result.getY().compareTo(BigDecimal.ZERO),
+        "Half-cell offset should have gridY = 0, got " + result.getY());
+  }
+
+  @Test
+  void convertAtExactlyOnePatchWidthShouldProduceOneOne() {
+    // A point at exactly one patchWidth distance should map to (1, 1)
+    // LA is ~74 patches east and ~81 patches south of SF at 5km patches
+    // We need a point that is exactly 5000m east and 5000m south
+    // For this test, create a converter with known simple extents
+    PatchBuilderExtents simpleExtents = new PatchBuilderExtents(
+        new BigDecimal("-122.45"),
+        new BigDecimal("37.73"),
+        new BigDecimal("-118.24"),
+        new BigDecimal("34.05")
+    );
+    PatchKeyConverter simpleConverter = new PatchKeyConverter(simpleExtents, PATCH_WIDTH);
+
+    // LA key should produce grid indices > 0
+    GeoKey laKey = makeGeoKey(new BigDecimal("-118.24"), new BigDecimal("34.05"));
+    PatchKeyConverter.ProjectedValue result = simpleConverter.convert(laKey, BigDecimal.ONE);
+
+    // With FLOOR rounding, the LA point should still map to (74, 81) since
+    // both formulas agree at large distances
+    assertEquals(0, result.getX().compareTo(new BigDecimal("74")),
+        "LA gridX should be 74, got " + result.getX());
+    assertEquals(0, result.getY().compareTo(new BigDecimal("81")),
+        "LA gridY should be 81, got " + result.getY());
+  }
+
+  private GeoKey makeGeoKey(BigDecimal longitude, BigDecimal latitude) {
+    return new GeoKey(new Entity() {
+      @Override
+      public Optional<EngineGeometry> getGeometry() {
+        return Optional.of(new EngineGeometry() {
+          @Override
+          public BigDecimal getCenterX() {
+            return longitude;
+          }
+
+          @Override
+          public BigDecimal getCenterY() {
+            return latitude;
+          }
+
+          @Override
+          public EngineGeometry getCenter() {
+            return this;
+          }
+
+          @Override
+          public boolean intersects(EngineGeometry other) {
+            return false;
+          }
+
+          @Override
+          public boolean intersects(BigDecimal locationX, BigDecimal locationY) {
+            return false;
+          }
+
+          @Override
+          public EarthShape getOnEarth() {
+            return null;
+          }
+
+          @Override
+          public GridShape getOnGrid() {
+            return null;
+          }
+        });
+      }
+
+      @Override
+      public String getName() {
+        return "TestPatch";
+      }
+
+      @Override
+      public Optional<EngineValue> getAttributeValue(String name) {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<EngineValue> getAttributeValue(int index) {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<Integer> getAttributeIndex(String name) {
+        return Optional.empty();
+      }
+
+      @Override
+      public Map<String, Integer> getAttributeNameToIndex() {
+        return Collections.emptyMap();
+      }
+
+      @Override
+      public String[] getIndexToAttributeName() {
+        return null;
+      }
+
+      @Override
+      public Set<String> getAttributeNames() {
+        return Set.of();
+      }
+
+      @Override
+      public EntityType getEntityType() {
+        return null;
+      }
+
+      @Override
+      public Entity freeze() {
+        return null;
+      }
+
+      @Override
+      public Optional<GeoKey> getKey() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Map<String, List<EventHandlerGroup>> getResolvedHandlers() {
+        return Collections.emptyMap();
+      }
+
+      @Override
+      public boolean usesState() {
+        return false;
+      }
+
+      @Override
+      public int getStateIndex() {
+        return -1;
+      }
+    });
+  }
 }


### PR DESCRIPTION
We were dealing with some intermittent failures when multiple threads call `getExternal()` or `getConfigOptional()` at the same time -> updaed to `CouncrrentHashMap` as we do throughout the codebase in similar situations and update to compute / putIfAbsent rather than unconditional to avoid collisions. 

Also we were seeing a slight shift of external data generation leading to the bottom right of the grid being missing - previously we subtracted half a cell width and rounded, with the idea being that we resolve to the whole number index of a josh cell index. However, I think this was causing cells at the origin to land at -1 and be thrown away, leading cells at the edges to just never resolve even when data exists. So now we use floor(distance / patchWidth) which seems more correct anyway (A point 0–5000m from the origin maps to cell 0, 5000–10000m maps to cell 1, etc)