### PR TITLE
Enable assertions and add canonical disperal tests

### DIFF
--- a/josh-tests/conformance/core/lifecycle/test_organism_dead_state_filtering.josh
+++ b/josh-tests/conformance/core/lifecycle/test_organism_dead_state_filtering.josh
@@ -1,0 +1,79 @@
+# @category: core
+# @subcategory: lifecycle
+# @priority: critical
+# @description: Organism state transition and dead filtering in patch .step
+#
+# Mirrors the canonical Joshua Tree lifecycle pattern:
+#   1. Trees start as "Alive" with age 0
+#   2. Trees age each step
+#   3. Trees transition to "Dead" when age > 2 years
+#   4. Patch filters dead trees: Tree.step = prior.Tree[prior.Tree.state != "Dead"]
+#   5. Population count decreases after deaths
+#
+# Timeline (5 trees, all created at step 0):
+#   Step 0: init -> age=0, state="Alive", count=5
+#   Step 1: age=1, state="Alive" (1 <= 2), count=5
+#   Step 2: age=2, state="Alive" (2 <= 2), count=5
+#   Step 3: age=3, state.step -> "Dead" (3 > 2).
+#           Patch Tree.step filters on prior.state which is "Alive" -> kept.
+#           Trees ARE now "Dead" at end of step 3.
+#   Step 4: Patch Tree.step filters on prior.state="Dead" -> removed. count=0.
+#
+# This tests:
+#   - Organism state machines work during .step
+#   - Filtering by prior.state in patch .step handler
+#   - Population management via collection filtering
+
+start simulation TestOrganismDeadStateFiltering
+  grid.size = 10 m
+  grid.low.x = 0 m
+  grid.low.y = 0 m
+  grid.high.x = 10 m
+  grid.high.y = 10 m
+  grid.patch = "Default"
+
+  steps.low = 0 count
+  steps.high = 5 count
+end simulation
+
+start patch Default
+  Tree.init = create 5 count of Tree
+
+  # Filter dead trees each step — exact pattern from canonical model
+  Tree.step = prior.Tree[prior.Tree.state != "Dead"]
+
+  # Track counts via patch .step exports (these also gate the step phase)
+  export.treeCount.step = count(Tree)
+
+  # At step 0, all trees should exist
+  assert.allPresent.step:if(meta.stepCount == 0 count) = count(Tree) == 5 count
+
+  # At step 2, all trees still alive (age=2, threshold is > 2)
+  assert.stillAlive.step:if(meta.stepCount == 2 count) = count(Tree) == 5 count
+
+  # At step 4, trees should be gone (died at step 3, filtered at step 4)
+  assert.removed.step:if(meta.stepCount == 4 count) = count(Tree) == 0 count
+end patch
+
+start organism Tree
+  age.init = 0 year
+  age.step = prior.age + 1 year
+
+  state.init = "Alive"
+
+  start state "Alive"
+    state.step:if(current.age > 2 years) = "Dead"
+  end state
+
+  start state "Dead"
+  end state
+end organism
+
+start unit year
+  alias years
+end unit
+
+start unit m
+  alias meter
+  alias meters
+end unit

--- a/josh-tests/conformance/spatial/neighbors/test_canonical_dispersal_with_states.josh
+++ b/josh-tests/conformance/spatial/neighbors/test_canonical_dispersal_with_states.josh
@@ -1,0 +1,112 @@
+# @category: spatial
+# @subcategory: neighbors
+# @priority: critical
+# @description: Combined seed dispersal + organism states — canonical model pattern
+#
+# Mirrors the canonical Joshua Tree model's core loop:
+#   1. Organisms have states (Seedling -> Adult, no death in this test)
+#   2. Patch tracks organism counts via .step exports
+#   3. Patch computes seed production from adult trees at .end
+#   4. Seeds disperse to neighbors via patch-level `within` query
+#   5. Seed immigration summed from neighboring patches
+#
+# 5x5 grid with 10m cells, radius=15m.
+# All trees start as "Seedling" at age 0. At age > 1, transition to "Adult".
+# Adults produce seeds (isProducing = true). Seedlings do not.
+#
+# Key interactions tested:
+#   - Organism state transitions during .step
+#   - Counting organisms by state at .end (producerCount)
+#   - Patch-to-patch `within` query at .end phase
+#   - Cross-patch attribute access: sum(neighbors.emissionPerNeighbor)
+#   - Event phase ordering: .step (organisms age/transition) then .end (dispersal)
+#
+# Assertions use step 3 to ensure organisms have matured and prior is populated.
+
+start simulation TestCanonicalDispersalWithStates
+  grid.size = 10 m
+  grid.low.x = 0 m
+  grid.low.y = 0 m
+  grid.high.x = 50 m
+  grid.high.y = 50 m
+  grid.patch = "Default"
+
+  steps.low = 0 count
+  steps.high = 4 count
+end simulation
+
+start patch Default
+  Tree.init = create 3 count of Tree
+
+  # Track organism count (also ensures step phase runs)
+  export.treeCount.step = count(Tree)
+
+  # Count producers at .end (adults only)
+  producerCount.end = count(current.Tree[current.Tree.isProducing])
+
+  # Seed production from producing trees (2 seeds per producer)
+  localSeedProduction.end = current.producerCount * 2 count
+
+  # Neighbor count for dispersal
+  neighborCount.end = {
+    const neighbors = Default within 15 m radial at prior
+    const result = limit count(neighbors) - 1 count to [1, 100]
+    return result
+  }
+
+  # Per-neighbor emission
+  emissionPerNeighbor.end = current.localSeedProduction / current.neighborCount
+
+  # Immigration from neighbors
+  seedImmigration.end = {
+    const neighbors = Default within 15 m radial at prior
+    if (count(neighbors) > 1 count) {
+      return sum(neighbors.emissionPerNeighbor)
+    } else {
+      return 0 count
+    }
+  }
+
+  # --- Assertions ---
+
+  # At step 0: all 3 trees present, all seedlings
+  assert.initialCount.step:if(meta.stepCount == 0 count) = count(Tree) == 3 count
+
+  # At step 3: trees are age 3, should all be Adults and producing
+  assert.allProducing.end:if(meta.stepCount == 3 count) = current.producerCount == 3 count
+
+  # Seed production should be positive once trees are adults
+  assert.seedsProduced.end:if(meta.stepCount == 3 count) = current.localSeedProduction > 0 count
+
+  # Neighbor-based immigration should be positive when seeds are produced
+  assert.immigrationPositive.end:if(meta.stepCount == 3 count) = current.seedImmigration > 0 count
+
+  # Neighbor count should be reasonable (not the whole grid)
+  assert.neighborsBounded.end:if(meta.stepCount == 3 count) = current.neighborCount <= 20 count
+end patch
+
+start organism Tree
+  age.init = 0 year
+  age.step = prior.age + 1 year
+
+  state.init = "Seedling"
+  isProducing.init = false
+
+  start state "Seedling"
+    state.step:if(current.age > 1 year) = "Adult"
+    isProducing.step = false
+  end state
+
+  start state "Adult"
+    isProducing.step = true
+  end state
+end organism
+
+start unit year
+  alias years
+end unit
+
+start unit m
+  alias meter
+  alias meters
+end unit

--- a/josh-tests/conformance/spatial/neighbors/test_patch_neighbor_dispersal.josh
+++ b/josh-tests/conformance/spatial/neighbors/test_patch_neighbor_dispersal.josh
@@ -1,0 +1,91 @@
+# @category: spatial
+# @subcategory: neighbors
+# @priority: critical
+# @description: Patch-level within query for seed dispersal accounting
+#
+# Mirrors the canonical Joshua Tree seed dispersal pattern:
+#   1. Each patch produces seeds locally (fixed 10 count)
+#   2. neighborCount.end = count(Default within R radial at prior) - 1
+#   3. emissionPerNeighbor.end = localProduction / neighborCount
+#   4. immigration.end = sum(neighbors.emissionPerNeighbor)
+#
+# 7x7 grid with 10m cells, radius=15m (1.5 grid cells).
+# Edge-intersection at radius=1.5 grid cells:
+#   Interior (e.g. 3,3): 13 patches -> neighborCount = 12
+#   Corner (0,0): 6 patches -> neighborCount = 5
+#
+# Key behavior tested:
+#   - Patch-to-patch `Default within R radial at prior` returns patches
+#   - `neighbors.attribute` accesses resolved .end values on other patches
+#   - Seed accounting: division by local neighborCount + summation from neighbors
+#
+# Assertions use step 2 to ensure prior spatial index is populated.
+
+start simulation TestPatchNeighborDispersal
+  grid.size = 10 m
+  grid.low.x = 0 m
+  grid.low.y = 0 m
+  grid.high.x = 70 m
+  grid.high.y = 70 m
+  grid.patch = "Default"
+
+  steps.low = 0 count
+  steps.high = 3 count
+end simulation
+
+start patch Default
+  Tree.init = create 1 count of Tree
+
+  # Each patch produces a fixed amount of seeds
+  localProduction.step = 10 count
+
+  # Raw count from within query (before subtracting self)
+  rawNeighborCount.end = {
+    const neighbors = Default within 15 m radial at prior
+    return count(neighbors)
+  }
+
+  # Count neighboring patches (subtract self, clamp to [1, 100])
+  neighborCount.end = {
+    const neighbors = Default within 15 m radial at prior
+    const result = limit count(neighbors) - 1 count to [1, 100]
+    return result
+  }
+
+  # Divide production across neighbors
+  emissionPerNeighbor.end = current.localProduction / current.neighborCount
+
+  # Sum immigration from all neighbors' per-neighbor emissions
+  immigration.end = {
+    const neighbors = Default within 15 m radial at prior
+    if (count(neighbors) > 1 count) {
+      return sum(neighbors.emissionPerNeighbor)
+    } else {
+      return 0 count
+    }
+  }
+
+  # At step 2+, within query should find more than just self
+  # (prior spatial index is populated from step 1 onward)
+  assert.findNeighbors.end:if(meta.stepCount == 2 count) = current.rawNeighborCount > 1 count
+
+  # Immigration should be positive when neighbors exist
+  assert.positiveImmigration.end:if(meta.stepCount == 2 count) = current.immigration > 0 count
+
+  # Neighbor count should be bounded (not the whole 49-patch grid)
+  assert.neighborsBounded.end:if(meta.stepCount == 2 count) = current.neighborCount <= 20 count
+end patch
+
+start organism Tree
+  age.init = 0 year
+  age.step = prior.age + 1 year
+end organism
+
+start unit year
+  alias years
+end unit
+
+start unit m
+  alias meter
+  alias meters
+end unit

--- a/src/main/java/org/joshsim/lang/bridge/ShadowingEntity.java
+++ b/src/main/java/org/joshsim/lang/bridge/ShadowingEntity.java
@@ -103,6 +103,13 @@ public class ShadowingEntity implements MutableEntity {
     this.here = here;
     this.meta = meta;
 
+    Optional<EngineValue> checkAssertionsMaybe = meta.getAttributeValue("checkAssertions");
+    if (checkAssertionsMaybe.isPresent()) {
+      checkAssertions = checkAssertionsMaybe.get().getAsBoolean();
+    } else {
+      checkAssertions = true;
+    }
+
     scope = new EntityScope(inner);
 
     // Initialize array-based caches


### PR DESCRIPTION
A critical bugfix - organisms `assertions` have never been firing(!) because the `ShadowingEntity.java`'s checkAssertions was never actually set in the constructor. This led to several conformance tests having their assertions _never_ be checked at the organism level, masking some bugs we will be addressing with upcoming PRs! :melting_face: 