### PR TITLE
Debug / spatial timeit

### DIFF
--- a/examples/features/eval_duration.josh
+++ b/examples/features/eval_duration.josh
@@ -36,6 +36,6 @@ end organism
 start organism Shrub
 
   cover.init = sample uniform from 0% to 5%
-  cover.step = prior.cover + sample uniform from 0% to 0.5%
+  cover.step = limit prior.cover + sample uniform from 0% to 0.5% to [0%, 100%]
 
 end organism

--- a/examples/features/eval_duration.josh
+++ b/examples/features/eval_duration.josh
@@ -1,8 +1,31 @@
-start organism SimpleTree
+start simulation EvalDurationDemo
 
-  height.init = 1 m
-  height.step = prior.height + 1 m
+  grid.size = 1 count
+  grid.low = 0 count latitude, 0 count longitude
+  grid.high = 3 count latitude, 3 count longitude
 
-  heightEvalDuration.step = height.evalDuration
+  steps.low = 0 count
+  steps.high = 5 count
+
+  exportFiles.patch = "file:///tmp/eval_duration_demo.csv"
+
+end simulation
+
+
+start patch Default
+
+  Tree.init = create 500 count of Tree
+
+  export.avgHeight.step = mean(Tree.height)
+  export.avgHeightEvalMs.step = mean(Tree.height.evalDuration)
+  export.maxHeightEvalMs.step = max(Tree.height.evalDuration)
+
+end patch
+
+
+start organism Tree
+
+  height.init = sample uniform from 0 m to 10 m
+  height.step = prior.height + sample uniform from 0 m to 1 m
 
 end organism

--- a/examples/features/eval_duration_optimized.josh
+++ b/examples/features/eval_duration_optimized.josh
@@ -17,7 +17,7 @@ start patch Default
   Tree.init = create 200 count of Tree
 
   shrubPctCover.init = sample uniform from 0% to 50%
-  shrubPctCover.step = prior.shrubPctCover + sample uniform from 0% to 2.5%
+  shrubPctCover.step = limit prior.shrubPctCover + sample uniform from 0% to 2.5% to [0%, 100%]
 
   export.avgTreeHeight.step = mean(Tree.height)
   export.shrubPctCover.step = shrubPctCover

--- a/examples/features/eval_duration_optimized.josh
+++ b/examples/features/eval_duration_optimized.josh
@@ -7,7 +7,7 @@ start simulation MeadowModel
   steps.low = 0 count
   steps.high = 10 count
 
-  exportFiles.patch = "file:///tmp/eval_duration_before.csv"
+  exportFiles.patch = "file:///tmp/eval_duration_after.csv"
 
 end simulation
 
@@ -15,12 +15,14 @@ end simulation
 start patch Default
 
   Tree.init = create 200 count of Tree
-  Shrub.init = create 5000 count of Shrub
+
+  shrubPctCover.init = sample uniform from 0% to 50%
+  shrubPctCover.step = prior.shrubPctCover + sample uniform from 0% to 2.5%
 
   export.avgTreeHeight.step = mean(Tree.height)
-  export.avgShrubCover.step = mean(Shrub.cover)
+  export.shrubPctCover.step = shrubPctCover
   export.treeHeightMs.step = sum(Tree.height.evalDuration)
-  export.shrubCoverMs.step = sum(Shrub.cover.evalDuration)
+  export.shrubCoverMs.step = shrubPctCover.evalDuration
 
 end patch
 
@@ -29,13 +31,5 @@ start organism Tree
 
   height.init = sample uniform from 1 m to 5 m
   height.step = prior.height + sample uniform from 0 m to 0.5 m
-
-end organism
-
-
-start organism Shrub
-
-  cover.init = sample uniform from 0% to 5%
-  cover.step = prior.cover + sample uniform from 0% to 0.5%
 
 end organism

--- a/src/main/java/org/joshsim/JoshSimCommander.java
+++ b/src/main/java/org/joshsim/JoshSimCommander.java
@@ -27,6 +27,7 @@ import org.joshsim.command.RunRemoteCommand;
 import org.joshsim.command.ServerCommand;
 import org.joshsim.command.ValidateCommand;
 import org.joshsim.engine.geometry.EngineGeometryFactory;
+import org.joshsim.engine.value.engine.ValueSupportFactory;
 import org.joshsim.lang.interpret.JoshProgram;
 import org.joshsim.lang.io.InputOutputLayer;
 import org.joshsim.lang.io.JvmInputOutputLayerBuilder;
@@ -166,6 +167,34 @@ public class JoshSimCommander {
       OutputOptions output,
       InputOutputLayer inputOutputLayer
   ) {
+    return getJoshProgram(
+        new ValueSupportFactory(), geometryFactory, file, output, inputOutputLayer
+    );
+  }
+
+  /**
+   * Retrieves and initializes a Josh program with a caller-supplied ValueSupportFactory.
+   *
+   * <p>This overload allows the caller to supply a pre-configured {@link ValueSupportFactory} so
+   * that features like evalDuration profiling (via {@code TimedRecursiveValueResolverFactory}) are
+   * wired in at compile time when {@link org.joshsim.lang.interpret.ValueResolver} instances are
+   * created.</p>
+   *
+   * @param valueFactory The factory for creating engine values and value resolvers.
+   * @param geometryFactory The factory for creating geometry objects.
+   * @param file The file containing the Josh program code.
+   * @param output Options for handling output messages.
+   * @param inputOutputLayer The input/output layer to use for file access and exports.
+   * @return A ProgramInitResult containing either the initialized JoshProgram or information about
+   *     the failure.
+   */
+  public static ProgramInitResult getJoshProgram(
+      ValueSupportFactory valueFactory,
+      EngineGeometryFactory geometryFactory,
+      File file,
+      OutputOptions output,
+      InputOutputLayer inputOutputLayer
+  ) {
     if (!file.exists()) {
       output.printError("Could not find file: " + file);
       return new ProgramInitResult(CommanderStepEnum.LOAD);
@@ -197,7 +226,9 @@ public class JoshSimCommander {
       return new ProgramInitResult(CommanderStepEnum.PARSE);
     }
 
-    JoshProgram program = JoshSimFacade.interpret(geometryFactory, result, inputOutputLayer);
+    JoshProgram program = JoshSimFacadeUtil.interpret(
+        valueFactory, geometryFactory, result, inputOutputLayer
+    );
     assert program != null;
 
     return new ProgramInitResult(program);

--- a/src/main/java/org/joshsim/command/RunCommand.java
+++ b/src/main/java/org/joshsim/command/RunCommand.java
@@ -292,7 +292,16 @@ public class RunCommand implements Callable<Integer> {
         .withMinioOptions(minioOptions)
         .build();
 
+    // Create ValueSupportFactory before interpretation so that the profiler-enabled
+    // resolver factory is used when building ValueResolver instances at compile time.
+    boolean favorBigDecimal = !useFloat64;
+    ValueSupportFactory valueFactory = new ValueSupportFactory(
+        favorBigDecimal,
+        buildValueResolverFactory(enableProfiler)
+    );
+
     JoshSimCommander.ProgramInitResult initResult = JoshSimCommander.getJoshProgram(
+        valueFactory,
         geometryFactory,
         file,
         output,
@@ -336,13 +345,6 @@ public class RunCommand implements Callable<Integer> {
     JvmCompatibilityLayer compatLayer = new JvmCompatibilityLayer();
     compatLayer.setExportQueueCapacity(exportQueueSize);
     CompatibilityLayerKeeper.set(compatLayer);
-
-    // Set up ValueSupportFactory
-    boolean favorBigDecimal = !useFloat64;
-    ValueSupportFactory valueFactory = new ValueSupportFactory(
-        favorBigDecimal,
-        buildValueResolverFactory(enableProfiler)
-    );
 
     // Extract grid information for Earth-space detection (similar to JoshSimFacade)
     MutableEntity simEntityRaw = program.getSimulations().getProtoype(simulation).build();

--- a/src/main/java/org/joshsim/lang/interpret/TimedValueResolver.java
+++ b/src/main/java/org/joshsim/lang/interpret/TimedValueResolver.java
@@ -27,6 +27,9 @@ import org.joshsim.engine.value.type.EngineValue;
  *       per-entity profiling of dotted attributes without distribution awareness.</li>
  *   <li>For all other paths, delegates to the inner resolver and records the elapsed time.</li>
  * </ul>
+ *
+ * <p>Timing uses {@link System#nanoTime()} for microsecond-level resolution and reports fractional
+ * milliseconds (e.g. 0.042 ms).</p>
  */
 public class TimedValueResolver implements ValueResolver {
 
@@ -38,7 +41,7 @@ public class TimedValueResolver implements ValueResolver {
   private final boolean endsWithEvalDuration;
   private final String evalAttributePrefix;
   private final ValueResolver prefixResolver;
-  private long lastDurationMs;
+  private double lastDurationMs;
 
   /**
    * Creates a new TimedValueResolver decorating the given inner resolver.
@@ -62,7 +65,7 @@ public class TimedValueResolver implements ValueResolver {
     this.valueFactory = valueFactory;
     this.inner = inner;
     this.isEvalDuration = EVAL_DURATION_ATTR.equals(inner.getPath());
-    this.lastDurationMs = 0L;
+    this.lastDurationMs = 0.0;
     String innerPath = inner.getPath();
     this.endsWithEvalDuration = getEndsWithEvalDuration(this.isEvalDuration, innerPath);
     if (this.endsWithEvalDuration) {
@@ -132,21 +135,25 @@ public class TimedValueResolver implements ValueResolver {
     if (isEvalDuration) {
       return Optional.of(valueFactory.build(lastDurationMs, Units.MILLISECONDS));
     }
-    long start = System.currentTimeMillis();
+    long startNanos = System.nanoTime();
     if (endsWithEvalDuration) {
       try {
         prefixResolver.get(target);
       } finally {
-        lastDurationMs = System.currentTimeMillis() - start;
+        lastDurationMs = nanosToFractionalMs(System.nanoTime() - startNanos);
       }
       return Optional.of(valueFactory.build(lastDurationMs, Units.MILLISECONDS));
     } else {
       try {
         return inner.get(target);
       } finally {
-        lastDurationMs = System.currentTimeMillis() - start;
+        lastDurationMs = nanosToFractionalMs(System.nanoTime() - startNanos);
       }
     }
+  }
+
+  private static double nanosToFractionalMs(long nanos) {
+    return nanos / 1_000_000.0;
   }
 
   /**

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -1193,7 +1193,10 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
    * @return true if the resolver path matches the patch name, indicating a query for patches.
    */
   private boolean isQueryForPatch(ValueResolver resolver, String patchName) {
-    return resolver.toString().contains("RecursiveValueResolver(" + patchName + ")");
+    if (patchName == null) {
+      return false;
+    }
+    return patchName.equals(resolver.getPath());
   }
 
   @Override

--- a/src/test/java/org/joshsim/command/RunCommandArtifactUploadTest.java
+++ b/src/test/java/org/joshsim/command/RunCommandArtifactUploadTest.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.joshsim.JoshSimCommander;
+import org.joshsim.engine.value.engine.ValueSupportFactory;
 import org.joshsim.util.JoshTestFixtures;
 import org.joshsim.util.MinioOptions;
 import org.joshsim.util.OutputOptions;
@@ -70,6 +71,9 @@ class RunCommandArtifactUploadTest {
     // Allow getJoshProgram to work normally (pass-through)
     mockJoshSimCommander.when(() -> JoshSimCommander.getJoshProgram(
         any(), any(File.class), any(), any()
+    )).thenCallRealMethod();
+    mockJoshSimCommander.when(() -> JoshSimCommander.getJoshProgram(
+        any(ValueSupportFactory.class), any(), any(File.class), any(), any()
     )).thenCallRealMethod();
   }
 

--- a/src/test/java/org/joshsim/lang/interpret/EvalDurationDistributionTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/EvalDurationDistributionTest.java
@@ -216,10 +216,10 @@ public class EvalDurationDistributionTest {
     assertTrue(size.isPresent(), "Result should have a definite size");
     assertEquals(100, size.get(), "Result should have one value per entity");
 
-    long min = Long.MAX_VALUE;
-    long max = Long.MIN_VALUE;
+    double min = Double.MAX_VALUE;
+    double max = Double.MIN_VALUE;
     for (EngineValue val : resolved.getAsDistribution().getContents(100, false)) {
-      long ms = val.getAsInt();
+      double ms = val.getAsDecimal().doubleValue();
       if (ms < min) {
         min = ms;
       }


### PR DESCRIPTION
`isQueryForPatch()` previously checked for whether the query was for a patch or a patch's attribute, for spatial queries, with a pretty brittle string check:
```
resolver.toString().contains("RecursiveValueResolver(" + patchName + ")")
```

Now we just check whether the name of the patch matches the full path the resolver is resolving.