### PR TITLE
Add download/list/delete operations to MinioHandler

### DIFF
--- a/src/main/java/org/joshsim/util/MinioHandler.java
+++ b/src/main/java/org/joshsim/util/MinioHandler.java
@@ -5,10 +5,17 @@
 package org.joshsim.util;
 
 import io.minio.BucketExistsArgs;
+import io.minio.GetObjectArgs;
+import io.minio.ListObjectsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
+import io.minio.RemoveObjectArgs;
+import io.minio.Result;
 import io.minio.UploadObjectArgs;
+import io.minio.messages.Item;
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -139,6 +146,91 @@ public class MinioHandler {
     }
 
     return path + relativePath;
+  }
+
+  /**
+   * Download a file from MinIO to a local destination.
+   *
+   * @param objectPath The object path within the bucket (relative to base path)
+   * @param destination The local file to write to
+   * @throws Exception If the download fails
+   */
+  public void downloadFile(String objectPath, File destination) throws Exception {
+    String fullPath = constructObjectPath(objectPath);
+    try (InputStream stream = minioClient.getObject(
+        GetObjectArgs.builder()
+            .bucket(bucketName)
+            .object(fullPath)
+            .build());
+        FileOutputStream fos = new FileOutputStream(destination)) {
+      stream.transferTo(fos);
+    }
+    output.printInfo(
+        "Downloaded minio://" + bucketName + "/" + fullPath + " to " + destination.getPath()
+    );
+  }
+
+  /**
+   * Open an input stream to a MinIO object.
+   *
+   * <p>Caller is responsible for closing the returned stream.</p>
+   *
+   * @param objectPath The object path within the bucket (relative to base path)
+   * @return An InputStream for reading the object contents
+   * @throws Exception If the stream cannot be opened
+   */
+  public InputStream downloadStream(String objectPath) throws Exception {
+    String fullPath = constructObjectPath(objectPath);
+    return minioClient.getObject(
+        GetObjectArgs.builder()
+            .bucket(bucketName)
+            .object(fullPath)
+            .build()
+    );
+  }
+
+  /**
+   * List all object keys under a given prefix.
+   *
+   * @param prefix The prefix to list under (relative to base path)
+   * @return List of full object keys matching the prefix
+   * @throws Exception If listing fails
+   */
+  public List<String> listObjects(String prefix) throws Exception {
+    String fullPrefix = constructObjectPath(prefix);
+    List<String> keys = new ArrayList<>();
+    for (Result<Item> result : minioClient.listObjects(
+        ListObjectsArgs.builder()
+            .bucket(bucketName)
+            .prefix(fullPrefix)
+            .recursive(true)
+            .build())) {
+      keys.add(result.get().objectName());
+    }
+    return keys;
+  }
+
+  /**
+   * Delete all objects under a given prefix.
+   *
+   * @param prefix The prefix to delete under (relative to base path)
+   * @return The number of objects deleted
+   * @throws Exception If deletion fails
+   */
+  public int deleteObjects(String prefix) throws Exception {
+    List<String> keys = listObjects(prefix);
+    for (String key : keys) {
+      minioClient.removeObject(
+          RemoveObjectArgs.builder()
+              .bucket(bucketName)
+              .object(key)
+              .build()
+      );
+    }
+    if (!keys.isEmpty()) {
+      output.printInfo("Deleted " + keys.size() + " objects under " + prefix);
+    }
+    return keys.size();
   }
 
   /**

--- a/src/test/java/org/joshsim/util/MinioHandlerTest.java
+++ b/src/test/java/org/joshsim/util/MinioHandlerTest.java
@@ -6,14 +6,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.minio.BucketExistsArgs;
+import io.minio.GetObjectArgs;
+import io.minio.GetObjectResponse;
+import io.minio.ListObjectsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
+import io.minio.RemoveObjectArgs;
+import io.minio.Result;
+import io.minio.messages.Item;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import okhttp3.Headers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -106,5 +124,181 @@ public class MinioHandlerTest {
     );
 
     assertTrue(exception.getMessage().contains("connection failed"));
+  }
+
+  // --- Download tests ---
+
+  @TempDir
+  File tempDir;
+
+  private MinioHandler createHandler() throws Exception {
+    when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+    when(options.isEnsureBucketExists()).thenReturn(false);
+    return new MinioHandler(options, output);
+  }
+
+  @Test
+  void downloadFile_shouldWriteContentsToDestination() throws Exception {
+    // Setup
+    MinioHandler handler = createHandler();
+    byte[] content = "hello world".getBytes(StandardCharsets.UTF_8);
+    GetObjectResponse mockResponse = new GetObjectResponse(
+        Headers.of(), testBucket, "", "test/file.txt",
+        new ByteArrayInputStream(content)
+    );
+    when(minioClient.getObject(any(GetObjectArgs.class))).thenReturn(mockResponse);
+
+    File destination = new File(tempDir, "downloaded.txt");
+
+    // Execute
+    handler.downloadFile("test/file.txt", destination);
+
+    // Verify
+    assertTrue(destination.exists());
+    assertEquals("hello world", Files.readString(destination.toPath()));
+    verify(output).printInfo(contains("Downloaded"));
+  }
+
+  @Test
+  void downloadFile_shouldUseCorrectObjectPath() throws Exception {
+    // Setup - handler with a base path
+    when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+    when(options.isEnsureBucketExists()).thenReturn(false);
+    when(options.getObjectPath()).thenReturn("base/path");
+    MinioHandler handler = new MinioHandler(options, output);
+
+    byte[] content = "data".getBytes(StandardCharsets.UTF_8);
+    GetObjectResponse mockResponse = new GetObjectResponse(
+        Headers.of(), testBucket, "", "base/path/sub/file.txt",
+        new ByteArrayInputStream(content)
+    );
+    when(minioClient.getObject(any(GetObjectArgs.class))).thenReturn(mockResponse);
+
+    File destination = new File(tempDir, "out.txt");
+
+    // Execute
+    handler.downloadFile("sub/file.txt", destination);
+
+    // Verify the constructed path includes the base
+    ArgumentCaptor<GetObjectArgs> captor = ArgumentCaptor.forClass(GetObjectArgs.class);
+    verify(minioClient).getObject(captor.capture());
+    assertEquals("base/path/sub/file.txt", captor.getValue().object());
+  }
+
+  @Test
+  void downloadStream_shouldReturnInputStream() throws Exception {
+    // Setup
+    MinioHandler handler = createHandler();
+    byte[] content = "stream content".getBytes(StandardCharsets.UTF_8);
+    GetObjectResponse mockResponse = new GetObjectResponse(
+        Headers.of(), testBucket, "", "obj.txt",
+        new ByteArrayInputStream(content)
+    );
+    when(minioClient.getObject(any(GetObjectArgs.class))).thenReturn(mockResponse);
+
+    // Execute
+    try (InputStream stream = handler.downloadStream("obj.txt")) {
+      String result = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+      assertEquals("stream content", result);
+    }
+  }
+
+  @Test
+  void listObjects_shouldReturnObjectKeys() throws Exception {
+    // Setup
+    MinioHandler handler = createHandler();
+
+    Item item1 = new Item() {
+      @Override
+      public String objectName() {
+        return "prefix/file1.csv";
+      }
+    };
+    Item item2 = new Item() {
+      @Override
+      public String objectName() {
+        return "prefix/file2.csv";
+      }
+    };
+
+    @SuppressWarnings("unchecked")
+    Iterable<Result<Item>> results = Arrays.asList(
+        new Result<>(item1),
+        new Result<>(item2)
+    );
+    when(minioClient.listObjects(any(ListObjectsArgs.class))).thenReturn(results);
+
+    // Execute
+    List<String> keys = handler.listObjects("prefix/");
+
+    // Verify
+    assertEquals(2, keys.size());
+    assertEquals("prefix/file1.csv", keys.get(0));
+    assertEquals("prefix/file2.csv", keys.get(1));
+  }
+
+  @Test
+  void listObjects_shouldReturnEmptyListWhenNoneMatch() throws Exception {
+    // Setup
+    MinioHandler handler = createHandler();
+    @SuppressWarnings("unchecked")
+    Iterable<Result<Item>> results = Collections.emptyList();
+    when(minioClient.listObjects(any(ListObjectsArgs.class))).thenReturn(results);
+
+    // Execute
+    List<String> keys = handler.listObjects("nonexistent/");
+
+    // Verify
+    assertTrue(keys.isEmpty());
+  }
+
+  @Test
+  void deleteObjects_shouldDeleteAllListedObjects() throws Exception {
+    // Setup
+    MinioHandler handler = createHandler();
+
+    Item item1 = new Item() {
+      @Override
+      public String objectName() {
+        return "prefix/file1.csv";
+      }
+    };
+    Item item2 = new Item() {
+      @Override
+      public String objectName() {
+        return "prefix/file2.csv";
+      }
+    };
+
+    @SuppressWarnings("unchecked")
+    Iterable<Result<Item>> results = Arrays.asList(
+        new Result<>(item1),
+        new Result<>(item2)
+    );
+    when(minioClient.listObjects(any(ListObjectsArgs.class))).thenReturn(results);
+
+    // Execute
+    int deleted = handler.deleteObjects("prefix/");
+
+    // Verify
+    assertEquals(2, deleted);
+    verify(minioClient, times(2)).removeObject(any(RemoveObjectArgs.class));
+    verify(output).printInfo(contains("Deleted 2 objects"));
+  }
+
+  @Test
+  void deleteObjects_shouldReturnZeroWhenNothingToDelete() throws Exception {
+    // Setup
+    MinioHandler handler = createHandler();
+    @SuppressWarnings("unchecked")
+    Iterable<Result<Item>> results = Collections.emptyList();
+    when(minioClient.listObjects(any(ListObjectsArgs.class))).thenReturn(results);
+
+    // Execute
+    int deleted = handler.deleteObjects("empty/");
+
+    // Verify
+    assertEquals(0, deleted);
+    verify(minioClient, never()).removeObject(any(RemoveObjectArgs.class));
   }
 }


### PR DESCRIPTION
## Summary
- Extends `MinioHandler` with four new methods: `downloadFile()`, `downloadStream()`, `listObjects()`, `deleteObjects()`
- These are the read-side counterparts to the existing upload methods, needed for MinIO-based batch execution
- All methods respect the existing `basePath` convention via `constructObjectPath()`

## What changed

**`MinioHandler.java`** — 4 new public methods:
- `downloadFile(String objectPath, File destination)` — downloads object to local file via `getObject()` + `transferTo()`
- `downloadStream(String objectPath)` — returns `InputStream` for streaming reads (caller closes)
- `listObjects(String prefix)` — recursive listing via `listObjects()`, returns full object keys
- `deleteObjects(String prefix)` — lists then removes all objects under prefix, returns count

**`MinioHandlerTest.java`** — 7 new test cases:
- `downloadFile` writes correct contents to destination file
- `downloadFile` constructs correct object path with base path
- `downloadStream` returns readable InputStream
- `listObjects` returns matching keys
- `listObjects` returns empty list for no matches
- `deleteObjects` removes all listed objects
- `deleteObjects` returns zero and skips removal when nothing to delete

## Test plan
- [x] `./gradlew test` — all existing tests pass (no regressions)
- [x] `./gradlew checkstyleMain` + `checkstyleTest` — pass
- [x] `./gradlew fatJar` — builds cleanly
- [x] New unit tests for all 4 methods with mocked MinioClient

Part of #374 — PR 1 of 8 for enhanced remote execution targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)