### PR TITLE
Add preprocessFromMinio command for MinIO-based preprocessing

### DIFF
--- a/src/main/java/org/joshsim/JoshSimCommander.java
+++ b/src/main/java/org/joshsim/JoshSimCommander.java
@@ -22,6 +22,7 @@ import org.joshsim.command.DiscoverConfigCommand;
 import org.joshsim.command.InspectExportsCommand;
 import org.joshsim.command.InspectJshdCommand;
 import org.joshsim.command.PreprocessCommand;
+import org.joshsim.command.PreprocessFromMinioCommand;
 import org.joshsim.command.RunCommand;
 import org.joshsim.command.RunFromMinioCommand;
 import org.joshsim.command.RunRemoteCommand;
@@ -67,7 +68,8 @@ import picocli.CommandLine;
         DiscoverConfigCommand.class,
         InspectJshdCommand.class,
         InspectExportsCommand.class,
-        RunFromMinioCommand.class
+        RunFromMinioCommand.class,
+        PreprocessFromMinioCommand.class
     }
 )
 public class JoshSimCommander {

--- a/src/main/java/org/joshsim/command/PreprocessFromMinioCommand.java
+++ b/src/main/java/org/joshsim/command/PreprocessFromMinioCommand.java
@@ -1,0 +1,286 @@
+/**
+ * Command for running a single-timestep preprocess job from MinIO-staged inputs.
+ *
+ * <p>Downloads a data file and Josh script from MinIO, preprocesses a single timestep
+ * determined by JOB_COMPLETION_INDEX, and uploads the resulting .jshd file back to MinIO.
+ * Designed for use by K8s batch pods or any machine with MinIO access.</p>
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.command;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.stream.Stream;
+import org.apache.sis.referencing.CRS;
+import org.joshsim.JoshSimCommander;
+import org.joshsim.engine.config.JshcConfigGetter;
+import org.joshsim.engine.entity.base.GeoKey;
+import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.geometry.EngineGeometryFactory;
+import org.joshsim.engine.geometry.PatchBuilderExtents;
+import org.joshsim.engine.geometry.PatchSet;
+import org.joshsim.engine.geometry.grid.GridGeometryFactory;
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.engine.ValueSupportFactory;
+import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.geo.external.ExternalGeoMapper;
+import org.joshsim.geo.external.ExternalGeoMapperBuilder;
+import org.joshsim.geo.external.NearestNeighborInterpolationStrategy;
+import org.joshsim.geo.external.NoopExternalCoordinateTransformer;
+import org.joshsim.geo.geometry.EarthGeometryFactory;
+import org.joshsim.lang.bridge.EngineBridge;
+import org.joshsim.lang.bridge.GridFromSimFactory;
+import org.joshsim.lang.bridge.GridInfoExtractor;
+import org.joshsim.lang.bridge.QueryCacheEngineBridge;
+import org.joshsim.lang.bridge.ShadowingEntity;
+import org.joshsim.lang.interpret.JoshProgram;
+import org.joshsim.lang.io.InputGetterStrategy;
+import org.joshsim.lang.io.JvmInputOutputLayerBuilder;
+import org.joshsim.precompute.BinaryGridSerializationStrategy;
+import org.joshsim.precompute.DataGridLayer;
+import org.joshsim.precompute.ExtentsTransformer;
+import org.joshsim.precompute.JshdExternalGetter;
+import org.joshsim.precompute.PatchKeyConverter;
+import org.joshsim.precompute.StreamToPrecomputedGridUtil;
+import org.joshsim.util.MinioHandler;
+import org.joshsim.util.MinioOptions;
+import org.joshsim.util.OutputOptions;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+
+/**
+ * Preprocesses a single timestep from MinIO-staged inputs.
+ *
+ * <p>Downloads a data file and Josh script from MinIO, runs preprocessing for one timestep
+ * (determined by JOB_COMPLETION_INDEX + stepsLow from metadata), and uploads the resulting
+ * .jshd file back to MinIO. Enables distributed preprocessing across K8s indexed jobs or
+ * manual parallelism on multiple machines.</p>
+ */
+@Command(
+    name = "preprocessFromMinio",
+    description = "Preprocess a single timestep from MinIO-staged inputs"
+)
+public class PreprocessFromMinioCommand implements Callable<Integer> {
+
+  private static final int MINIO_ERROR_CODE = 100;
+  private static final int UNKNOWN_ERROR_CODE = 404;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Option(
+      names = "--job-id",
+      description = "Job ID (UUID prefix in MinIO under batch-jobs/<job-id>/inputs/)",
+      required = true
+  )
+  private String jobId;
+
+  @Mixin
+  private MinioOptions minioOptions = new MinioOptions();
+
+  @Mixin
+  private OutputOptions output = new OutputOptions();
+
+  @Override
+  public Integer call() {
+    try {
+      int timestepIndex = getTimestepIndex();
+      output.printInfo("Preprocessing timestep index " + timestepIndex + " for job " + jobId);
+
+      // Download inputs from MinIO
+      MinioHandler minio = new MinioHandler(minioOptions, output);
+      File tempDir = Files.createTempDirectory("josh-preprocess-" + jobId).toFile();
+
+      // Download and parse metadata
+      File metadataFile = new File(tempDir, "metadata.json");
+      minio.downloadFile("batch-jobs/" + jobId + "/inputs/metadata.json", metadataFile);
+      JsonNode metadata = MAPPER.readTree(metadataFile);
+
+      final String simulation = metadata.get("simulation").asText();
+      final String dataFileName = metadata.get("dataFile").asText();
+      final String variable = metadata.get("variable").asText();
+      final String unitsStr = metadata.get("units").asText();
+      final String crsCode = metadata.has("crs") ? metadata.get("crs").asText() : "EPSG:4326";
+      final String horizCoord = metadata.has("xCoord") ? metadata.get("xCoord").asText() : "lon";
+      final String vertCoord = metadata.has("yCoord") ? metadata.get("yCoord").asText() : "lat";
+      final String timeDim = metadata.has("timeDim") ? metadata.get("timeDim").asText()
+          : "calendar_year";
+      long stepsLow = metadata.has("stepsLow") ? metadata.get("stepsLow").asLong() : 0;
+
+      Optional<Double> defaultValue = Optional.empty();
+      if (metadata.has("defaultValue") && !metadata.get("defaultValue").isNull()) {
+        defaultValue = Optional.of(metadata.get("defaultValue").asDouble());
+      }
+
+      // Compute the actual timestep to process
+      long timestep = stepsLow + timestepIndex;
+      output.printInfo("Processing timestep " + timestep + " (index " + timestepIndex
+          + ", stepsLow " + stepsLow + ")");
+
+      // Download Josh script
+      File scriptFile = new File(tempDir, "code.josh");
+      minio.downloadFile("batch-jobs/" + jobId + "/inputs/code.josh", scriptFile);
+
+      // Download data file
+      File dataFile = new File(tempDir, dataFileName);
+      minio.downloadFile("batch-jobs/" + jobId + "/inputs/" + dataFileName, dataFile);
+
+      // Parse Josh program
+      JoshSimCommander.ProgramInitResult initResult = JoshSimCommander.getJoshProgram(
+          new GridGeometryFactory(), scriptFile, output
+      );
+      if (initResult.getFailureStep().isPresent()) {
+        JoshSimCommander.CommanderStepEnum failStep = initResult.getFailureStep().get();
+        return switch (failStep) {
+          case LOAD -> 1;
+          case READ -> 2;
+          case PARSE -> 3;
+          default -> UNKNOWN_ERROR_CODE;
+        };
+      }
+
+      JoshProgram program = initResult.getProgram().orElseThrow();
+      if (!program.getSimulations().hasPrototype(simulation)) {
+        output.printError("Could not find simulation: " + simulation);
+        return 4;
+      }
+
+      // Run preprocessing for this single timestep
+      File outputJshd = new File(tempDir, "partial-" + timestepIndex + ".jshd");
+      int result = runPreprocessTimestep(
+          program, simulation, dataFile.getAbsolutePath(), variable, unitsStr,
+          crsCode, horizCoord, vertCoord, timeDim, timestep, defaultValue, outputJshd
+      );
+      if (result != 0) {
+        return result;
+      }
+
+      // Upload result to MinIO
+      String outputPath = "batch-jobs/" + jobId + "/results/partial-" + timestepIndex + ".jshd";
+      boolean uploaded = minio.uploadFile(outputJshd, outputPath);
+      if (!uploaded) {
+        output.printError("Failed to upload result to MinIO");
+        return MINIO_ERROR_CODE;
+      }
+
+      output.printInfo("Timestep " + timestep + " complete for job " + jobId);
+      return 0;
+
+    } catch (Exception e) {
+      output.printError("preprocessFromMinio failed: " + e.getMessage());
+      return MINIO_ERROR_CODE;
+    }
+  }
+
+  /**
+   * Gets the timestep index from the JOB_COMPLETION_INDEX environment variable.
+   *
+   * @return The timestep index (0-based), defaulting to 0 if env var is not set
+   */
+  int getTimestepIndex() {
+    String indexStr = System.getenv("JOB_COMPLETION_INDEX");
+    if (indexStr == null || indexStr.isEmpty()) {
+      return 0;
+    }
+    return Integer.parseInt(indexStr);
+  }
+
+  /**
+   * Runs preprocessing for a single timestep, mirroring PreprocessCommand logic.
+   */
+  private int runPreprocessTimestep(JoshProgram program, String simulation, String dataFilePath,
+      String variable, String unitsStr, String crsCode, String horizCoord, String vertCoord,
+      String timeDim, long timestep, Optional<Double> defaultValue, File outputFile) {
+
+    ValueSupportFactory valueFactory = new ValueSupportFactory();
+
+    // Build geo mapper for single timestep
+    ExternalGeoMapperBuilder geoMapperBuilder = new ExternalGeoMapperBuilder(valueFactory);
+    geoMapperBuilder.addCrsCode(crsCode);
+    geoMapperBuilder.addInterpolationStrategy(new NearestNeighborInterpolationStrategy());
+    geoMapperBuilder.addCoordinateTransformer(new NoopExternalCoordinateTransformer());
+    geoMapperBuilder.addDimensions(horizCoord, vertCoord, timeDim);
+    geoMapperBuilder.forceTimestep(timestep);
+
+    final ExternalGeoMapper mapper = geoMapperBuilder.build();
+    mapper.setUseParallelProcessing(true);
+
+    // Build simulation entity and grid
+    MutableEntity simEntityRaw = program.getSimulations().getProtoype(simulation).build();
+    MutableEntity simEntity = new ShadowingEntity(valueFactory, simEntityRaw, simEntityRaw);
+    GridInfoExtractor extractor = new GridInfoExtractor(simEntity, valueFactory);
+    EngineValue size = extractor.getSize();
+
+    CoordinateReferenceSystem crs;
+    try {
+      crs = CRS.forCode(crsCode);
+    } catch (Exception e) {
+      output.printError("Failed to read CRS code: " + e);
+      return 1;
+    }
+    EngineGeometryFactory geometryFactory = new EarthGeometryFactory(crs);
+
+    InputGetterStrategy inputStrategy = new JvmInputOutputLayerBuilder().build().getInputStrategy();
+    EngineBridge bridge = new QueryCacheEngineBridge(
+        valueFactory, geometryFactory, simEntity, program.getConverter(),
+        program.getPrototypes(),
+        new JshdExternalGetter(inputStrategy, valueFactory),
+        new JshcConfigGetter(inputStrategy, valueFactory)
+    );
+    GridFromSimFactory gridFactory = new GridFromSimFactory(bridge);
+    PatchSet patchSet = gridFactory.build(simEntity, crsCode);
+
+    String startStr = extractor.getStartStr();
+    String endStr = extractor.getEndStr();
+    PatchBuilderExtents extents = gridFactory.buildExtents(startStr, endStr);
+    PatchKeyConverter patchKeyConverter = new PatchKeyConverter(extents, size.getAsDecimal());
+
+    // Stream data for single timestep
+    DataGridLayer grid = StreamToPrecomputedGridUtil.streamToGrid(
+        valueFactory,
+        (ts) -> {
+          Stream<Map.Entry<GeoKey, EngineValue>> geoStream;
+          try {
+            geoStream = mapper.streamVariableTimeStepToPatches(
+                dataFilePath, variable, (int) ts, patchSet
+            );
+          } catch (IOException e) {
+            throw new RuntimeException("Failed to stream patches: " + e);
+          }
+          return geoStream.map(
+              (entry) -> patchKeyConverter.convert(
+                  entry.getKey(), entry.getValue().getAsDecimal()
+              )
+          );
+        },
+        ExtentsTransformer.transformToGrid(extents, size.getAsDecimal()),
+        timestep,
+        timestep,
+        Units.of(unitsStr),
+        defaultValue
+    );
+
+    // Serialize to binary file
+    BinaryGridSerializationStrategy serializer = new BinaryGridSerializationStrategy(valueFactory);
+    try (FileOutputStream fos = new FileOutputStream(outputFile)) {
+      serializer.serialize(grid, fos);
+      fos.flush();
+    } catch (IOException e) {
+      output.printError("Failed to write .jshd: " + e.getMessage());
+      return 5;
+    }
+
+    output.printInfo("Preprocessed timestep " + timestep + " to " + outputFile.getName());
+    return 0;
+  }
+}

--- a/src/test/java/org/joshsim/command/PreprocessFromMinioCommandTest.java
+++ b/src/test/java/org/joshsim/command/PreprocessFromMinioCommandTest.java
@@ -1,0 +1,38 @@
+package org.joshsim.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Unit tests for PreprocessFromMinioCommand.
+ */
+public class PreprocessFromMinioCommandTest {
+
+  @Test
+  void getTimestepIndex_shouldDefaultToZeroWhenEnvNotSet() {
+    PreprocessFromMinioCommand command = new PreprocessFromMinioCommand();
+    int index = command.getTimestepIndex();
+    assertEquals(0, index);
+  }
+
+  @Test
+  void command_shouldRequireJobId() {
+    try {
+      var field = PreprocessFromMinioCommand.class.getDeclaredField("jobId");
+      var option = field.getAnnotation(picocli.CommandLine.Option.class);
+      assertEquals(true, option.required());
+    } catch (NoSuchFieldException e) {
+      throw new AssertionError("Expected --job-id field on PreprocessFromMinioCommand", e);
+    }
+  }
+
+  @Test
+  void command_shouldBeRegisteredWithCorrectName() {
+    var annotation = PreprocessFromMinioCommand.class.getAnnotation(
+        picocli.CommandLine.Command.class
+    );
+    assertEquals("preprocessFromMinio", annotation.name());
+  }
+}


### PR DESCRIPTION
## Summary
- New `preprocessFromMinio` CLI command that downloads data file + Josh script from MinIO, preprocesses a single timestep with `--parallel`, and uploads the resulting `.jshd` back to MinIO
- Registered in `JoshSimCommander` as a new subcommand
- Reads `JOB_COMPLETION_INDEX` env var for timestep index (K8s indexed job support, defaults to 0)

## What changed

**New: `PreprocessFromMinioCommand.java`** (~260 lines)

Flow:
1. Read `JOB_COMPLETION_INDEX` env var → timestep index (default 0)
2. Download from `batch-jobs/<job-id>/inputs/`: `metadata.json`, `code.josh`, data file
3. Parse `metadata.json` for simulation name, data file name, variable, units, CRS, coordinate names, time dimension, stepsLow, defaultValue
4. Compute actual timestep: `stepsLow + index`
5. Parse Josh program, build geo mapper with forced single timestep, run preprocessing (mirrors `PreprocessCommand` logic)
6. Upload resulting `partial-<INDEX>.jshd` to MinIO at `batch-jobs/<job-id>/results/`

**Modified: `JoshSimCommander.java`** — added import and registration of `PreprocessFromMinioCommand`

**New: `PreprocessFromMinioCommandTest.java`** — tests for timestep index defaulting, required `--job-id`, command name

## metadata.json schema for preprocessing
```json
{
  "simulation": "SimName",
  "dataFile": "temperature.nc",
  "variable": "tas",
  "units": "K",
  "crs": "EPSG:4326",
  "xCoord": "lon",
  "yCoord": "lat",
  "timeDim": "calendar_year",
  "stepsLow": 0,
  "defaultValue": null
}
```

## Integration test (GCS MinIO-compatible storage)

Staged a checkerboard GeoTIFF + Josh script to `josh-storage` bucket, ran `preprocessFromMinio`:

```
$ java -jar joshsim-fat.jar preprocessFromMinio \
  --job-id=preprocess-test-001 \
  --minio-endpoint=https://storage.googleapis.com \
  --minio-bucket=josh-storage ...

Preprocessing timestep index 0 for job preprocess-test-001
Downloaded ...metadata.json
Processing timestep 0 (index 0, stepsLow 0)
Downloaded ...code.josh
Downloaded ...grid_10x10_checkerboard.tiff
Preprocessed timestep 0 to partial-0.jshd
Uploaded partial-0.jshd to minio://josh-storage/batch-jobs/preprocess-test-001/results/partial-0.jshd
Timestep 0 complete for job preprocess-test-001
```

Results in MinIO:
```
batch-jobs/preprocess-test-001/inputs/code.josh (949 bytes)
batch-jobs/preprocess-test-001/inputs/grid_10x10_checkerboard.tiff (772 bytes)
batch-jobs/preprocess-test-001/inputs/metadata.json (242 bytes)
batch-jobs/preprocess-test-001/results/partial-0.jshd (8,218,448 bytes)
```

## Test plan
- [x] `./gradlew test` — full suite passes, no regressions
- [x] `./gradlew checkstyleMain` + `checkstyleTest` — pass
- [x] `./gradlew fatJar` — builds, `preprocessFromMinio` appears in help
- [x] Integration test against GCS with real GeoTIFF preprocessing

Part of #374 — PR 3 of 8 for enhanced remote execution targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)