### PR TITLE
Add opt-in stageFromMinio for serverless /runBatch

### DIFF
--- a/K8S_PLANNING.md
+++ b/K8S_PLANNING.md
@@ -143,6 +143,7 @@ Design note: originally built `runFromMinio` and `preprocessFromMinio` as per-co
 ```
 POST /runBatch
 Form fields: apiKey, jobId, simulation, workDir
+Optional:    stageFromMinio (boolean), minioPrefix (required if staging)
 ```
 1. Validate API key via `ApiKeyUtil.checkApiKey()`
 2. Extract required form fields (`jobId`, `simulation`, `workDir`)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -204,6 +204,8 @@ Content-Type: multipart/form-data
 - `jobId` — Unique job identifier, returned in the response
 - `simulation` — Name of the simulation to run
 - `workDir` — Path to local directory containing pre-staged simulation files (.josh script, .jshd, .jshc)
+- `stageFromMinio` (optional) — Set to `"true"` to download inputs from MinIO into `workDir` before running. Controls input staging only, not outputs. For serverless environments where staging and execution must happen in the same request.
+- `minioPrefix` (optional, required when `stageFromMinio=true`) — Object prefix to download from (e.g., `batch-jobs/abc/inputs/`)
 
 **Response (success):**
 ```json

--- a/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
@@ -33,7 +33,10 @@ import org.joshsim.lang.io.InputOutputLayer;
 import org.joshsim.lang.io.JvmInputOutputLayerBuilder;
 import org.joshsim.lang.io.JvmMappedInputGetter;
 import org.joshsim.lang.parse.ParseResult;
+import org.joshsim.util.MinioHandler;
 import org.joshsim.util.MinioOptions;
+import org.joshsim.util.MinioStagingUtil;
+import org.joshsim.util.OutputOptions;
 
 
 /**
@@ -45,6 +48,15 @@ import org.joshsim.util.MinioOptions;
  *   <li>{@code jobId} — unique job identifier (returned in response)</li>
  *   <li>{@code simulation} — name of the simulation to run</li>
  *   <li>{@code workDir} — path to local directory containing pre-staged simulation files</li>
+ * </ul>
+ *
+ * <p>Optional form fields for serverless environments where staging and execution
+ * must happen atomically within the same request:</p>
+ * <ul>
+ *   <li>{@code stageFromMinio} — set to {@code "true"} to download inputs from MinIO
+ *       into {@code workDir} before running. Controls input staging only, not outputs.</li>
+ *   <li>{@code minioPrefix} — required when {@code stageFromMinio=true}. The object prefix
+ *       to download from (e.g., {@code batch-jobs/abc/inputs/}).</li>
  * </ul>
  */
 public class JoshSimBatchHandler implements HttpHandler {
@@ -134,6 +146,32 @@ public class JoshSimBatchHandler implements HttpHandler {
     String jobId = formData.getFirst("jobId").getValue();
     String simulation = formData.getFirst("simulation").getValue();
     File workDir = new File(formData.getFirst("workDir").getValue());
+
+    // Opt-in: stage inputs from MinIO before running (for serverless environments)
+    boolean shouldStage = formData.contains("stageFromMinio")
+        && "true".equalsIgnoreCase(formData.getFirst("stageFromMinio").getValue());
+
+    if (shouldStage) {
+      if (!formData.contains("minioPrefix")) {
+        sendJsonError(exchange, 400, jobId,
+            "minioPrefix is required when stageFromMinio=true");
+        return Optional.of(apiKey);
+      }
+      String minioPrefix = formData.getFirst("minioPrefix").getValue();
+      try {
+        if (!workDir.exists() && !workDir.mkdirs()) {
+          sendJsonError(exchange, 400, jobId,
+              "Failed to create workDir: " + workDir.getPath());
+          return Optional.of(apiKey);
+        }
+        MinioOptions minioOptions = new MinioOptions();
+        MinioHandler minio = new MinioHandler(minioOptions, new OutputOptions());
+        MinioStagingUtil.stageFromMinio(minio, minioPrefix, workDir, new OutputOptions());
+      } catch (Exception e) {
+        sendJsonError(exchange, 500, jobId, "Staging from MinIO failed: " + e.getMessage());
+        return Optional.of(apiKey);
+      }
+    }
 
     if (!workDir.exists() || !workDir.isDirectory()) {
       sendJsonError(exchange, 400, jobId,

--- a/src/main/java/org/joshsim/command/StageFromMinioCommand.java
+++ b/src/main/java/org/joshsim/command/StageFromMinioCommand.java
@@ -11,10 +11,10 @@
 package org.joshsim.command;
 
 import java.io.File;
-import java.util.List;
 import java.util.concurrent.Callable;
 import org.joshsim.util.MinioHandler;
 import org.joshsim.util.MinioOptions;
+import org.joshsim.util.MinioStagingUtil;
 import org.joshsim.util.OutputOptions;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -66,34 +66,7 @@ public class StageFromMinioCommand implements Callable<Integer> {
         return 1;
       }
 
-      String normalizedPrefix = normalizePrefix(prefix);
-      List<String> keys = minio.listObjects(normalizedPrefix);
-
-      if (keys.isEmpty()) {
-        output.printError("No objects found under prefix: " + normalizedPrefix);
-        return 1;
-      }
-
-      int downloaded = 0;
-      for (String key : keys) {
-        String relativePath = key.substring(normalizedPrefix.length());
-        if (relativePath.isEmpty()) {
-          continue;
-        }
-        File destination = new File(outputDir, relativePath);
-
-        // Create parent directories for nested objects
-        File parentDir = destination.getParentFile();
-        if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
-          output.printError("Failed to create directory: " + parentDir.getPath());
-          return 1;
-        }
-
-        minio.downloadFile(key, destination);
-        downloaded++;
-      }
-
-      output.printInfo("Downloaded " + downloaded + " file(s) to " + outputDir.getPath());
+      MinioStagingUtil.stageFromMinio(minio, prefix, outputDir, output);
       return 0;
 
     } catch (Exception e) {
@@ -102,10 +75,4 @@ public class StageFromMinioCommand implements Callable<Integer> {
     }
   }
 
-  private String normalizePrefix(String prefix) {
-    if (prefix.endsWith("/")) {
-      return prefix;
-    }
-    return prefix + "/";
-  }
 }

--- a/src/main/java/org/joshsim/util/MinioStagingUtil.java
+++ b/src/main/java/org/joshsim/util/MinioStagingUtil.java
@@ -1,0 +1,70 @@
+/**
+ * Shared utility for staging files from MinIO to a local directory.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+
+/**
+ * Downloads all objects under a MinIO prefix to a local directory.
+ *
+ * <p>Used by both {@link org.joshsim.command.StageFromMinioCommand} (CLI) and
+ * {@link org.joshsim.cloud.JoshSimBatchHandler} (server endpoint) to avoid
+ * duplicating staging logic.</p>
+ */
+public class MinioStagingUtil {
+
+  /**
+   * Downloads all objects under a MinIO prefix to a local directory.
+   *
+   * <p>Each object is written to {@code outputDir/<relative-path>} where the relative path
+   * is the object key with the prefix stripped. Parent directories are created as needed.</p>
+   *
+   * @param minio The MinIO handler for download operations.
+   * @param prefix The object prefix to download from (e.g., {@code batch-jobs/abc/inputs/}).
+   * @param outputDir The local directory to download files into. Must exist.
+   * @param output For logging progress and errors.
+   * @return The number of files downloaded.
+   * @throws IOException If directory creation or file download fails.
+   * @throws IllegalArgumentException If no objects are found under the prefix.
+   */
+  public static int stageFromMinio(MinioHandler minio, String prefix, File outputDir,
+      OutputOptions output) throws Exception {
+    String normalizedPrefix = prefix.endsWith("/") ? prefix : prefix + "/";
+    List<String> keys = minio.listObjects(normalizedPrefix);
+
+    if (keys.isEmpty()) {
+      throw new IllegalArgumentException("No objects found under prefix: " + normalizedPrefix);
+    }
+
+    int downloaded = 0;
+    for (String key : keys) {
+      String relativePath = key.substring(normalizedPrefix.length());
+      if (relativePath.isEmpty()) {
+        continue;
+      }
+      File destination = new File(outputDir, relativePath);
+
+      File parentDir = destination.getParentFile();
+      if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
+        throw new IOException("Failed to create directory: " + parentDir.getPath());
+      }
+
+      minio.downloadFile(key, destination);
+      downloaded++;
+    }
+
+    output.printInfo("Downloaded " + downloaded + " file(s) to " + outputDir.getPath());
+    return downloaded;
+  }
+
+  private MinioStagingUtil() {
+    // Utility class
+  }
+}

--- a/src/test/java/org/joshsim/cloud/JoshSimBatchHandlerTest.java
+++ b/src/test/java/org/joshsim/cloud/JoshSimBatchHandlerTest.java
@@ -162,6 +162,54 @@ class JoshSimBatchHandlerTest {
   }
 
   @Test
+  void whenStageFromMinioTrueButMissingPrefix_shouldReturn400() {
+    setupValidApiKey();
+    setupRequiredFields("job-stage-1", "TestSim", "/tmp/some-dir");
+
+    FormData.FormValue stageFlag = mock(FormData.FormValue.class);
+    when(formData.contains("stageFromMinio")).thenReturn(true);
+    when(formData.getFirst("stageFromMinio")).thenReturn(stageFlag);
+    when(stageFlag.getValue()).thenReturn("true");
+    when(formData.contains("minioPrefix")).thenReturn(false);
+
+    handler.processFormData(exchange, formData);
+
+    verify(exchange).setStatusCode(400);
+    assertTrue(responseBody.toString().contains("minioPrefix is required"));
+  }
+
+  @Test
+  void whenStageFromMinioFalse_shouldNotRequirePrefix() {
+    setupValidApiKey();
+    setupRequiredFields("job-no-stage", "TestSim", "/nonexistent");
+
+    FormData.FormValue stageFlag = mock(FormData.FormValue.class);
+    when(formData.contains("stageFromMinio")).thenReturn(true);
+    when(formData.getFirst("stageFromMinio")).thenReturn(stageFlag);
+    when(stageFlag.getValue()).thenReturn("false");
+    when(formData.contains("minioPrefix")).thenReturn(false);
+
+    handler.processFormData(exchange, formData);
+
+    // Should hit workDir validation (400), not minioPrefix validation
+    verify(exchange).setStatusCode(400);
+    assertTrue(responseBody.toString().contains("does not exist"));
+  }
+
+  @Test
+  void whenStageFromMinioAbsent_shouldNotRequirePrefix() {
+    setupValidApiKey();
+    setupRequiredFields("job-default", "TestSim", "/nonexistent");
+    when(formData.contains("stageFromMinio")).thenReturn(false);
+
+    handler.processFormData(exchange, formData);
+
+    // Should hit workDir validation (400), not minioPrefix validation
+    verify(exchange).setStatusCode(400);
+    assertTrue(responseBody.toString().contains("does not exist"));
+  }
+
+  @Test
   void processFormDataReturnsApiKeyOnSuccess() {
     setupValidApiKey();
     setupRequiredFields("job-1", "TestSim", "/nonexistent");


### PR DESCRIPTION
(Claude summary)

## Summary

Adds opt-in `stageFromMinio` flag to `/runBatch` and extracts shared staging logic into a reusable utility. This is needed for the Cloud Run deployment test — in serverless environments, the instance handling `/runBatch` may not be the same one that staged files, so staging must happen atomically within the request.

### What changed (on top of feat/enhanced_remote → dev #383)

- **New `MinioStagingUtil`** — extracts the staging logic from `StageFromMinioCommand` into a shared utility. Both the CLI command and the server handler now call the same code (DRY).
- **`StageFromMinioCommand`** — thinned to delegate to `MinioStagingUtil.stageFromMinio()`
- **`/runBatch` opt-in staging** — two new optional form fields:
  - `stageFromMinio="true"` — download inputs from MinIO into `workDir` before running
  - `minioPrefix` — required when staging; controls **input staging only**, not outputs
- Default behavior unchanged (thin handler, caller pre-stages)

### Why this is needed now

After #383 merges to `dev` and deploys to Cloud Run, we need to test the full `/runBatch` flow. Cloud Run is serverless — each request can land on a different instance. Without this flag, there's no way to guarantee the instance that runs the simulation has the staged files. With the flag:

```bash
curl -X POST https://josh-executor-prod-....run.app/runBatch \
  -F "apiKey=..." \
  -F "jobId=test-001" \
  -F "simulation=TestSim" \
  -F "workDir=/tmp/batch-work" \
  -F "stageFromMinio=true" \
  -F "minioPrefix=batch-jobs/test/inputs/"
```

The handler creates `workDir`, downloads from MinIO, then runs — all in one request.

## Test plan
- [x] `./gradlew checkstyleMain checkstyleTest` passes
- [x] `./gradlew test` passes
- [x] `./gradlew fatJar` builds
- [x] 3 new tests: missing prefix → 400, flag false → skips staging, flag absent → skips staging
- [ ] Integration test on Cloud Run after deploy

Closes #374 (partial — server-side infrastructure complete, client-side dispatch in PRs 5-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)