### PR TITLE
Make /runBatch async with MinIO status tracking

### DIFF
--- a/K8S_PLANNING.md
+++ b/K8S_PLANNING.md
@@ -12,9 +12,9 @@ Cloud Run has hard ceilings (32 GiB memory, 60-min timeout, 8 vCPUs) that block 
 
 ## Workflow
 
-All PRs build into `feat/enhanced_remote`. For each PR: branch off → implement → open PR targeting `feat/enhanced_remote` → review → merge → demonstrate with real model run. Final rollup PR targets `dev` after colleague review.
+PRs 1–4 built into `feat/enhanced_remote`. Rollup PR #383 merged `feat/enhanced_remote` → `dev`. PRs 4a and 4b target `dev` directly. Subsequent PRs (5+) will also target `dev`.
 
-**Important:** PRs target `feat/enhanced_remote`, NOT `dev`.
+For each PR: branch off → implement → open PR → review → merge → demonstrate with real model run.
 
 ## Architecture
 
@@ -80,7 +80,7 @@ Used for `KubernetesTarget` only. Cleaner fluent DSL than official `io.kubernete
 ## PR Plan
 
 ```
-PR1 ✅ → PR2 ✅ → PR3 ✅ (cleanup) → PR4 ✅ (/runBatch) → PR5 (profiles) → PR6 (batchRemote) → PR7 (K8sTarget) → PR8 (Dockerfile) → PR9 (preprocessBatch)
+PR1 ✅ → PR2 ✅ → PR3 ✅ (cleanup) → PR4 ✅ (/runBatch) → PR4a ✅ (stageFromMinio opt-in) → PR4b ✅ (async+status) → PR5 (profiles) → PR6 (batchRemote) → PR7 (K8sTarget) → PR8 (Dockerfile) → PR9 (preprocessBatch)
 ```
 
 ### Regression gates (every PR)
@@ -171,6 +171,53 @@ Optional:    stageFromMinio (boolean), minioPrefix (required if staging)
 **Role in target system:** This is the server-side handler for `HttpBatchTarget` (PR 6). Any machine running `joshsim server` gets `/runBatch`. Users register it as an HTTP target profile.
 
 **Risk: LOW — additive endpoint, existing handlers untouched**
+
+---
+
+### PR 4a ✅: Opt-in stageFromMinio for serverless `/runBatch` — #384
+**Branch: `feat/server-run-batch` (merged into `feat/enhanced_remote`)**
+
+Added opt-in `stageFromMinio` form field to `/runBatch` so serverless environments (Cloud Run, Lambda) can stage and execute atomically within a single request instead of requiring a separate staging step.
+
+**Changes:**
+- `cloud/JoshSimBatchHandler.java` — added `stageFromMinio` (boolean) and `minioPrefix` form fields, auto-creates `workDir` if staging
+- `util/MinioStagingUtil.java` (~70 lines) — extracted shared staging logic from `StageFromMinioCommand` so both the CLI command and server handler can reuse it
+- `command/StageFromMinioCommand.java` — refactored to delegate to `MinioStagingUtil`
+
+**Design note:** This keeps staging and execution as separate concerns at the abstraction level — `MinioStagingUtil` is a reusable utility, not handler-specific logic. The opt-in flag is for environments where the network topology makes a separate staging step impractical (e.g., Cloud Run containers that boot, execute, and die).
+
+**Risk: LOW — additive field, existing behavior unchanged when field omitted**
+
+---
+
+### PR 4b ✅: Make `/runBatch` async with MinIO status tracking — #387
+**Branch: `feat/async-run-batch`**
+
+Changed `/runBatch` from synchronous (blocks until simulation completes) to asynchronous (returns 202 immediately, writes status to MinIO). This enables concurrent batch jobs against serverless workers.
+
+**Changes:**
+- `cloud/JoshSimBatchHandler.java` — simulation runs in `CompletableFuture.runAsync()` on a `BATCH_EXECUTOR` thread pool; handler returns 202 with `statusPath` immediately; `runBatchWithStatus()` writes `running`/`complete`/`error` lifecycle to MinIO
+- `util/MinioHandler.java` — added `putBytes(byte[], String, String)` for writing small JSON payloads directly to MinIO
+- `llms-full.txt` — updated `/runBatch` docs: 202 response, status file lifecycle, polling workflow
+
+**Status file lifecycle (`batch-status/<jobId>/status.json`):**
+- `{"status":"running","jobId":"...","startedAt":"..."}`
+- `{"status":"complete","jobId":"...","completedAt":"..."}`
+- `{"status":"error","jobId":"...","message":"...","failedAt":"..."}`
+
+Status writes are best-effort — missing MinIO credentials don't prevent simulation execution.
+
+**Client workflow:**
+1. POST `/runBatch` → 202 with `statusPath`
+2. Poll `status.json` in MinIO until `complete` or `error`
+3. Results land via `minio://` export paths in the Josh script
+
+**Test:**
+- [x] 11+1 unit tests for `JoshSimBatchHandler` (existing validation tests + new 202 acceptance test)
+- [x] 3 unit tests for `MinioHandler.putBytes()`
+- [x] `./gradlew test` passes, `./gradlew checkstyleMain` passes
+
+**Risk: LOW — same endpoint, additive behavior (async vs sync), validation errors still synchronous**
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -185,7 +185,7 @@ The server exposes the following API endpoints:
 
 - `POST /runReplicate` — Execute a single simulation replicate via HTTP streaming. Code and data are sent in the request body; results stream back in wire format.
 - `POST /runReplicates` — Leader endpoint that coordinates multiple replicates across workers.
-- `POST /runBatch` — Execute a simulation from a local directory of pre-staged files. Results are written to MinIO via `minio://` export paths in the Josh script. Returns JSON status instead of streaming results. Staging is a separate concern (use `stageFromMinio` CLI command or equivalent before calling this endpoint).
+- `POST /runBatch` — Asynchronously execute a simulation from a local directory of pre-staged files. Returns 202 Accepted immediately with a `statusPath` for polling. Results are written to MinIO via `minio://` export paths in the Josh script. Job status is tracked via a `status.json` file in MinIO. Staging is a separate concern (use `stageFromMinio` CLI command or equivalent before calling this endpoint).
 - `POST /parse` — Parse Josh code and return the AST or errors.
 - `POST /discoverConfig` — Discover configuration variables in Josh code.
 - `GET /health` — Health check endpoint (returns "healthy").
@@ -207,20 +207,31 @@ Content-Type: multipart/form-data
 - `stageFromMinio` (optional) — Set to `"true"` to download inputs from MinIO into `workDir` before running. Controls input staging only, not outputs. For serverless environments where staging and execution must happen in the same request.
 - `minioPrefix` (optional, required when `stageFromMinio=true`) — Object prefix to download from (e.g., `batch-jobs/abc/inputs/`)
 
-**Response (success):**
+**Response (accepted — 202):**
 ```json
-{"status": "complete", "jobId": "integration-test-001"}
+{"status": "accepted", "jobId": "integration-test-001", "statusPath": "batch-status/integration-test-001/status.json"}
 ```
 
-**Response (error):**
+**Response (validation error — 400/401/500):**
 ```json
 {"status": "error", "jobId": "integration-test-001", "message": "..."}
 ```
 
+Validation errors (missing fields, bad API key, invalid workDir, staging failures) are returned synchronously before the simulation starts.
+
+**Status file in MinIO (`batch-status/<jobId>/status.json`):**
+
+The server writes a status file to MinIO at job lifecycle boundaries:
+- Running: `{"status": "running", "jobId": "...", "startedAt": "..."}`
+- Complete: `{"status": "complete", "jobId": "...", "completedAt": "..."}`
+- Error: `{"status": "error", "jobId": "...", "message": "...", "failedAt": "..."}`
+
+Status writes are best-effort — if the status writer cannot be initialized (e.g., missing MinIO credentials), the simulation still runs but no status file is written.
+
 **Workflow:**
 1. Stage simulation files to MinIO using `stageToMinio` (client side)
-2. Download staged files to a local directory using `stageFromMinio` (worker side)
-3. POST to `/runBatch` with the local directory path as `workDir`
+2. POST to `/runBatch` — returns 202 immediately with `statusPath`
+3. Poll `status.json` in MinIO until status is `"complete"` or `"error"`
 4. Results land in MinIO via `minio://` export paths in the Josh script
 5. Retrieve results using `stageFromMinio` (client side)
 

--- a/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -159,30 +160,11 @@ public class JoshSimBatchHandler implements HttpHandler {
     String jobId = formData.getFirst("jobId").getValue();
     File workDir = new File(formData.getFirst("workDir").getValue());
 
-    // Opt-in: stage inputs from MinIO before running (for serverless environments)
-    boolean shouldStage = formData.contains("stageFromMinio")
-        && "true".equalsIgnoreCase(formData.getFirst("stageFromMinio").getValue());
-
-    if (shouldStage) {
-      if (!formData.contains("minioPrefix")) {
-        sendJsonError(exchange, 400, jobId,
-            "minioPrefix is required when stageFromMinio=true");
-        return Optional.of(apiKey);
-      }
-      String minioPrefix = formData.getFirst("minioPrefix").getValue();
-      try {
-        if (!workDir.exists() && !workDir.mkdirs()) {
-          sendJsonError(exchange, 400, jobId,
-              "Failed to create workDir: " + workDir.getPath());
-          return Optional.of(apiKey);
-        }
-        MinioOptions minioOptions = new MinioOptions();
-        MinioHandler minio = new MinioHandler(minioOptions, new OutputOptions());
-        MinioStagingUtil.stageFromMinio(minio, minioPrefix, workDir, new OutputOptions());
-      } catch (Exception e) {
-        sendJsonError(exchange, 500, jobId, "Staging from MinIO failed: " + e.getMessage());
-        return Optional.of(apiKey);
-      }
+    Optional<String> stagingError = stageInputsIfRequested(formData, jobId, workDir);
+    if (stagingError.isPresent()) {
+      sendJsonError(exchange, stagingError.get().startsWith("5") ? 500 : 400, jobId,
+          stagingError.get().substring(4));
+      return Optional.of(apiKey);
     }
 
     if (!workDir.exists() || !workDir.isDirectory()) {
@@ -191,16 +173,7 @@ public class JoshSimBatchHandler implements HttpHandler {
       return Optional.of(apiKey);
     }
 
-    MinioHandler statusMinioInit = null;
-    try {
-      MinioOptions statusMinioOptions = new MinioOptions();
-      statusMinioInit = new MinioHandler(statusMinioOptions, new OutputOptions());
-    } catch (Exception e) {
-      System.err.println("[batch] Status tracking unavailable for job " + jobId
-          + ": " + e.getMessage());
-    }
-    final MinioHandler statusMinio = statusMinioInit;
-
+    MinioHandler statusMinio = initStatusMinio(jobId);
     String simulation = formData.getFirst("simulation").getValue();
     String statusPath = "batch-status/" + jobId + "/status.json";
     sendJsonAccepted(exchange, jobId, statusPath);
@@ -213,19 +186,64 @@ public class JoshSimBatchHandler implements HttpHandler {
     return Optional.of(apiKey);
   }
 
+  /**
+   * Stage inputs from MinIO into workDir if the stageFromMinio flag is set.
+   *
+   * @return Empty if staging succeeded or was not requested; error message prefixed with
+   *     HTTP status code (e.g. "400:message") if staging failed.
+   */
+  private Optional<String> stageInputsIfRequested(FormData formData, String jobId, File workDir) {
+    boolean shouldStage = formData.contains("stageFromMinio")
+        && "true".equalsIgnoreCase(formData.getFirst("stageFromMinio").getValue());
+
+    if (!shouldStage) {
+      return Optional.empty();
+    }
+
+    if (!formData.contains("minioPrefix")) {
+      return Optional.of("400:minioPrefix is required when stageFromMinio=true");
+    }
+
+    String minioPrefix = formData.getFirst("minioPrefix").getValue();
+    try {
+      if (!workDir.exists() && !workDir.mkdirs()) {
+        return Optional.of("400:Failed to create workDir: " + workDir.getPath());
+      }
+      MinioOptions minioOptions = new MinioOptions();
+      MinioHandler minio = new MinioHandler(minioOptions, new OutputOptions());
+      MinioStagingUtil.stageFromMinio(minio, minioPrefix, workDir, new OutputOptions());
+    } catch (Exception e) {
+      return Optional.of("500:Staging from MinIO failed: " + e.getMessage());
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Initialize a MinioHandler for writing status files. Returns null if MinIO
+   * credentials are unavailable (status tracking degrades gracefully).
+   */
+  private MinioHandler initStatusMinio(String jobId) {
+    try {
+      return new MinioHandler(new MinioOptions(), new OutputOptions());
+    } catch (Exception e) {
+      System.err.println("[batch] Status tracking unavailable for job " + jobId
+          + ": " + e.getMessage());
+      return null;
+    }
+  }
+
   private void runBatchWithStatus(MinioHandler statusMinio, String jobId,
       String simulation, File workDir, String statusPath, String apiKey) {
-    writeStatus(statusMinio, statusPath, String.format(
-        "{\"status\":\"running\",\"jobId\":\"%s\",\"startedAt\":\"%s\"}",
-        jobId, Instant.now().toString()
+    writeStatus(statusMinio, statusPath, buildStatusJson(
+        "running", jobId, "startedAt", Instant.now().toString()
     ));
 
     try {
       executeBatchJob(jobId, simulation, workDir);
 
-      writeStatus(statusMinio, statusPath, String.format(
-          "{\"status\":\"complete\",\"jobId\":\"%s\",\"completedAt\":\"%s\"}",
-          jobId, Instant.now().toString()
+      writeStatus(statusMinio, statusPath, buildStatusJson(
+          "complete", jobId, "completedAt", Instant.now().toString()
       ));
     } catch (Exception e) {
       SecurityUtil.logSecureError(apiDataLayer, apiKey, "batch", e, null);
@@ -233,9 +251,8 @@ public class JoshSimBatchHandler implements HttpHandler {
       String safeMessage = e.getMessage() != null
           ? e.getMessage().replace("\"", "\\\"").replace("\n", " ")
           : "unknown error";
-      writeStatus(statusMinio, statusPath, String.format(
-          "{\"status\":\"error\",\"jobId\":\"%s\",\"message\":\"%s\",\"failedAt\":\"%s\"}",
-          jobId, safeMessage, Instant.now().toString()
+      writeStatus(statusMinio, statusPath, buildStatusJson(
+          "error", jobId, "failedAt", Instant.now().toString(), "message", safeMessage
       ));
     }
   }
@@ -303,12 +320,11 @@ public class JoshSimBatchHandler implements HttpHandler {
   private void sendJsonAccepted(HttpServerExchange exchange, String jobId, String statusPath) {
     exchange.setStatusCode(202);
     exchange.getResponseHeaders().put(new HttpString("Content-Type"), "application/json");
-    exchange.getResponseSender().send(
-        String.format(
-            "{\"status\":\"accepted\",\"jobId\":\"%s\",\"statusPath\":\"%s\"}",
-            jobId, statusPath
-        )
-    );
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("status", "accepted");
+    fields.put("jobId", jobId);
+    fields.put("statusPath", statusPath);
+    exchange.getResponseSender().send(toJson(fields));
   }
 
   private void sendJsonError(HttpServerExchange exchange, int statusCode, String jobId,
@@ -316,9 +332,42 @@ public class JoshSimBatchHandler implements HttpHandler {
     exchange.setStatusCode(statusCode);
     exchange.getResponseHeaders().put(new HttpString("Content-Type"), "application/json");
     String safeMessage = message.replace("\"", "\\\"").replace("\n", " ");
-    exchange.getResponseSender().send(
-        String.format("{\"status\":\"error\",\"jobId\":\"%s\",\"message\":\"%s\"}",
-            jobId, safeMessage)
-    );
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("status", "error");
+    fields.put("jobId", jobId);
+    fields.put("message", safeMessage);
+    exchange.getResponseSender().send(toJson(fields));
+  }
+
+  /**
+   * Build a JSON status string with the given status, jobId, and additional key-value pairs.
+   *
+   * @param status The status value (running, complete, error)
+   * @param jobId The job identifier
+   * @param extra Additional key-value pairs (must be even number of args)
+   * @return JSON string
+   */
+  private String buildStatusJson(String status, String jobId, String... extra) {
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("status", status);
+    fields.put("jobId", jobId);
+    for (int i = 0; i < extra.length; i += 2) {
+      fields.put(extra[i], extra[i + 1]);
+    }
+    return toJson(fields);
+  }
+
+  private static String toJson(Map<String, String> fields) {
+    StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    for (Map.Entry<String, String> entry : fields.entrySet()) {
+      if (!first) {
+        sb.append(",");
+      }
+      sb.append("\"").append(entry.getKey()).append("\":\"").append(entry.getValue()).append("\"");
+      first = false;
+    }
+    sb.append("}");
+    return sb.toString();
   }
 }

--- a/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
@@ -20,9 +20,14 @@ import io.undertow.server.handlers.form.FormParserFactory;
 import io.undertow.util.HttpString;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.joshsim.JoshSimFacadeUtil;
 import org.joshsim.compat.CompatibilityLayerKeeper;
 import org.joshsim.compat.JvmCompatibilityLayer;
@@ -60,6 +65,14 @@ import org.joshsim.util.OutputOptions;
  * </ul>
  */
 public class JoshSimBatchHandler implements HttpHandler {
+
+  private static final ExecutorService BATCH_EXECUTOR =
+      Executors.newCachedThreadPool(runnable -> {
+        Thread thread = new Thread(runnable);
+        thread.setName("batch-sim-" + thread.threadId());
+        thread.setDaemon(true);
+        return thread;
+      });
 
   private final CloudApiDataLayer apiDataLayer;
 
@@ -144,7 +157,6 @@ public class JoshSimBatchHandler implements HttpHandler {
     }
 
     String jobId = formData.getFirst("jobId").getValue();
-    String simulation = formData.getFirst("simulation").getValue();
     File workDir = new File(formData.getFirst("workDir").getValue());
 
     // Opt-in: stage inputs from MinIO before running (for serverless environments)
@@ -179,15 +191,69 @@ public class JoshSimBatchHandler implements HttpHandler {
       return Optional.of(apiKey);
     }
 
+    MinioHandler statusMinioInit = null;
     try {
-      executeBatchJob(jobId, simulation, workDir);
-      sendJsonSuccess(exchange, jobId);
+      MinioOptions statusMinioOptions = new MinioOptions();
+      statusMinioInit = new MinioHandler(statusMinioOptions, new OutputOptions());
     } catch (Exception e) {
-      SecurityUtil.logSecureError(apiDataLayer, apiKey, "batch", e, null);
-      sendJsonError(exchange, 500, jobId, "Batch execution failed: " + e.getMessage());
+      System.err.println("[batch] Status tracking unavailable for job " + jobId
+          + ": " + e.getMessage());
     }
+    final MinioHandler statusMinio = statusMinioInit;
+
+    String simulation = formData.getFirst("simulation").getValue();
+    String statusPath = "batch-status/" + jobId + "/status.json";
+    sendJsonAccepted(exchange, jobId, statusPath);
+
+    String capturedApiKey = apiKey;
+    CompletableFuture.runAsync(() -> {
+      runBatchWithStatus(statusMinio, jobId, simulation, workDir, statusPath, capturedApiKey);
+    }, BATCH_EXECUTOR);
 
     return Optional.of(apiKey);
+  }
+
+  private void runBatchWithStatus(MinioHandler statusMinio, String jobId,
+      String simulation, File workDir, String statusPath, String apiKey) {
+    writeStatus(statusMinio, statusPath, String.format(
+        "{\"status\":\"running\",\"jobId\":\"%s\",\"startedAt\":\"%s\"}",
+        jobId, Instant.now().toString()
+    ));
+
+    try {
+      executeBatchJob(jobId, simulation, workDir);
+
+      writeStatus(statusMinio, statusPath, String.format(
+          "{\"status\":\"complete\",\"jobId\":\"%s\",\"completedAt\":\"%s\"}",
+          jobId, Instant.now().toString()
+      ));
+    } catch (Exception e) {
+      SecurityUtil.logSecureError(apiDataLayer, apiKey, "batch", e, null);
+
+      String safeMessage = e.getMessage() != null
+          ? e.getMessage().replace("\"", "\\\"").replace("\n", " ")
+          : "unknown error";
+      writeStatus(statusMinio, statusPath, String.format(
+          "{\"status\":\"error\",\"jobId\":\"%s\",\"message\":\"%s\",\"failedAt\":\"%s\"}",
+          jobId, safeMessage, Instant.now().toString()
+      ));
+    }
+  }
+
+  private void writeStatus(MinioHandler statusMinio, String statusPath, String statusJson) {
+    if (statusMinio == null) {
+      return;
+    }
+    try {
+      statusMinio.putBytes(
+          statusJson.getBytes(StandardCharsets.UTF_8),
+          statusPath,
+          "application/json"
+      );
+    } catch (Exception e) {
+      System.err.println("[batch] Failed to write status to " + statusPath
+          + ": " + e.getMessage());
+    }
   }
 
   private void executeBatchJob(String jobId, String simulation, File workDir) throws Exception {
@@ -234,11 +300,14 @@ public class JoshSimBatchHandler implements HttpHandler {
     );
   }
 
-  private void sendJsonSuccess(HttpServerExchange exchange, String jobId) {
-    exchange.setStatusCode(200);
+  private void sendJsonAccepted(HttpServerExchange exchange, String jobId, String statusPath) {
+    exchange.setStatusCode(202);
     exchange.getResponseHeaders().put(new HttpString("Content-Type"), "application/json");
     exchange.getResponseSender().send(
-        String.format("{\"status\":\"complete\",\"jobId\":\"%s\"}", jobId)
+        String.format(
+            "{\"status\":\"accepted\",\"jobId\":\"%s\",\"statusPath\":\"%s\"}",
+            jobId, statusPath
+        )
     );
   }
 

--- a/src/main/java/org/joshsim/util/MinioHandler.java
+++ b/src/main/java/org/joshsim/util/MinioHandler.java
@@ -9,10 +9,12 @@ import io.minio.GetObjectArgs;
 import io.minio.ListObjectsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
 import io.minio.RemoveObjectArgs;
 import io.minio.Result;
 import io.minio.UploadObjectArgs;
 import io.minio.messages.Item;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
@@ -123,6 +125,35 @@ public class MinioHandler {
     }
 
     return successCount;
+  }
+
+  /**
+   * Write a byte array directly to MinIO as a single object.
+   *
+   * <p>Intended for small payloads like JSON status files. For large data,
+   * use {@link #uploadFile(File, String)} or the streaming
+   * {@link org.joshsim.lang.io.MinioOutputStreamStrategy} instead.</p>
+   *
+   * @param data The bytes to write
+   * @param relativePath The path within the base directory where the object should be stored
+   * @param contentType The MIME type for the object (e.g., "application/json")
+   * @throws Exception If the upload fails
+   */
+  public void putBytes(byte[] data, String relativePath, String contentType) throws Exception {
+    String objectName = constructObjectPath(relativePath);
+    try (ByteArrayInputStream bais = new ByteArrayInputStream(data)) {
+      minioClient.putObject(
+          PutObjectArgs.builder()
+              .bucket(bucketName)
+              .object(objectName)
+              .stream(bais, data.length, -1)
+              .contentType(contentType)
+              .build()
+      );
+    }
+    output.printInfo(
+        "Put " + data.length + " bytes to minio://" + bucketName + "/" + objectName
+    );
   }
 
   /**

--- a/src/test/java/org/joshsim/cloud/JoshSimBatchHandlerTest.java
+++ b/src/test/java/org/joshsim/cloud/JoshSimBatchHandlerTest.java
@@ -18,9 +18,13 @@ import io.undertow.server.handlers.form.FormData;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HttpString;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -240,6 +244,30 @@ class JoshSimBatchHandlerTest {
     handler.handleRequest(exchange);
 
     verify(apiDataLayer).log(anyString(), anyString(), any(long.class));
+  }
+
+  @TempDir
+  File tempDir;
+
+  @Test
+  void whenValidWorkDir_shouldReturn202() throws IOException {
+    setupValidApiKey();
+
+    // Create a real workDir with a dummy .josh file
+    File joshScript = new File(tempDir, "test.josh");
+    Files.writeString(joshScript.toPath(), "start simulation Test end simulation");
+
+    setupRequiredFields("job-async-1", "Test", tempDir.getAbsolutePath());
+    when(formData.contains("stageFromMinio")).thenReturn(false);
+
+    handler.processFormData(exchange, formData);
+
+    verify(exchange).setStatusCode(202);
+    String body = responseBody.toString();
+    assertTrue(body.contains("\"status\":\"accepted\""), "Should return accepted status");
+    assertTrue(body.contains("\"jobId\":\"job-async-1\""), "Should include jobId");
+    assertTrue(body.contains("\"statusPath\":\"batch-status/job-async-1/status.json\""),
+        "Should include statusPath");
   }
 
   // --- Helpers ---

--- a/src/test/java/org/joshsim/util/MinioHandlerTest.java
+++ b/src/test/java/org/joshsim/util/MinioHandlerTest.java
@@ -16,6 +16,7 @@ import io.minio.GetObjectResponse;
 import io.minio.ListObjectsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
 import io.minio.RemoveObjectArgs;
 import io.minio.Result;
 import io.minio.messages.Item;
@@ -251,6 +252,64 @@ public class MinioHandlerTest {
     // Verify
     assertTrue(keys.isEmpty());
   }
+
+  // --- putBytes tests ---
+
+  @Test
+  void putBytes_shouldUploadDataWithCorrectPath() throws Exception {
+    // Setup
+    MinioHandler handler = createHandler();
+    byte[] data = "{\"status\":\"running\"}".getBytes(StandardCharsets.UTF_8);
+
+    // Execute
+    handler.putBytes(data, "batch-status/job-1/status.json", "application/json");
+
+    // Verify
+    ArgumentCaptor<PutObjectArgs> captor = ArgumentCaptor.forClass(PutObjectArgs.class);
+    verify(minioClient).putObject(captor.capture());
+    assertEquals(testBucket, captor.getValue().bucket());
+    assertEquals("batch-status/job-1/status.json", captor.getValue().object());
+    assertEquals("application/json", captor.getValue().contentType());
+    verify(output).printInfo(contains("Put " + data.length + " bytes"));
+  }
+
+  @Test
+  void putBytes_shouldPrependBasePath() throws Exception {
+    // Setup - handler with a base path
+    when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+    when(options.isEnsureBucketExists()).thenReturn(false);
+    when(options.getObjectPath()).thenReturn("base/path");
+    MinioHandler handler = new MinioHandler(options, output);
+
+    byte[] data = "test".getBytes(StandardCharsets.UTF_8);
+
+    // Execute
+    handler.putBytes(data, "status.json", "application/json");
+
+    // Verify
+    ArgumentCaptor<PutObjectArgs> captor = ArgumentCaptor.forClass(PutObjectArgs.class);
+    verify(minioClient).putObject(captor.capture());
+    assertEquals("base/path/status.json", captor.getValue().object());
+  }
+
+  @Test
+  void putBytes_shouldPropagateException() throws Exception {
+    // Setup
+    MinioHandler handler = createHandler();
+    when(minioClient.putObject(any(PutObjectArgs.class)))
+        .thenThrow(new RuntimeException("upload failed"));
+
+    byte[] data = "test".getBytes(StandardCharsets.UTF_8);
+
+    // Execute & Verify
+    Exception exception = assertThrows(
+        RuntimeException.class,
+        () -> handler.putBytes(data, "path.json", "application/json")
+    );
+    assertTrue(exception.getMessage().contains("upload failed"));
+  }
+
+  // --- deleteObjects tests ---
 
   @Test
   void deleteObjects_shouldDeleteAllListedObjects() throws Exception {


### PR DESCRIPTION
(Claude Summary)

## Summary

- `/runBatch` now returns **202 Accepted** immediately instead of blocking until simulation completes
- Writes `status.json` to MinIO at `batch-status/<jobId>/status.json` with three lifecycle states: `running`, `complete`, `error`
- Enables clients to fan out concurrent batch jobs to serverless workers and poll for completion
- Status writes are best-effort — if MinIO creds are missing, the simulation still runs without status tracking

## Changes

- **`MinioHandler.java`**: Added `putBytes()` for writing small payloads (JSON status) directly to MinIO
- **`JoshSimBatchHandler.java`**: Async dispatch via `CompletableFuture.runAsync()` on a dedicated thread pool; validation/staging errors still return synchronously (400/500)
- **Tests**: 3 new `putBytes` tests, 1 new async 202 response test; all existing tests pass unchanged
- **`llms-full.txt`**: Updated endpoint docs with new response format and polling workflow

## Test plan

- [x] `./gradlew test` passes (all existing + 4 new tests)
- [x] `./gradlew checkstyleMain checkstyleTest` passes
- [x] Local integration test: 202 returned immediately, `status.json` shows `"running"` on poll, transitions to `"complete"` with results CSV in MinIO
- [x] Local integration test: wrong simulation name → 202 accepted, `status.json` shows `"error"` with message
- [x] Local integration test: validation errors (missing fields, bad workDir, missing minioPrefix) still return synchronous 400
- [ ] Deploy to dev Cloud Run and re-run integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)