### PR TITLE
bug / csv precision performance

### DIFF
--- a/src/main/java/org/joshsim/command/RunCommand.java
+++ b/src/main/java/org/joshsim/command/RunCommand.java
@@ -163,8 +163,8 @@ public class RunCommand implements Callable<Integer> {
   @Option(
       names = "--csv-precision",
       description = "Maximum decimal places for numeric values in CSV output. "
-                  + "Use -1 for unlimited precision (default: 6).",
-      defaultValue = "6"
+                  + "Use -1 for unlimited precision (default: 10).",
+      defaultValue = "10"
   )
   private int csvPrecision = MapSerializeStrategy.DEFAULT_MAX_DECIMAL_PLACES;
 

--- a/src/main/java/org/joshsim/lang/io/MapSerializeStrategy.java
+++ b/src/main/java/org/joshsim/lang/io/MapSerializeStrategy.java
@@ -25,7 +25,7 @@ public class MapSerializeStrategy implements MapExportSerializeStrategy {
   public static final int UNLIMITED_PRECISION = -1;
 
   /** Default maximum number of decimal places for numeric values in CSV output. */
-  public static final int DEFAULT_MAX_DECIMAL_PLACES = 6;
+  public static final int DEFAULT_MAX_DECIMAL_PLACES = 10;
 
   private final int maxDecimalPlaces;
 
@@ -97,21 +97,31 @@ public class MapSerializeStrategy implements MapExportSerializeStrategy {
   }
 
   /**
-   * Format a string value, rounding if it represents a decimal number with excess precision.
+   * Format a string value, truncating if it represents a decimal number with excess precision.
+   *
+   * <p>Uses pure string operations to avoid expensive BigDecimal parsing. Values with fewer
+   * decimal places than the limit are returned as-is. Values with excess precision are truncated
+   * (not rounded) to the configured maximum decimal places.</p>
    *
    * @param valueStr The string to potentially format.
-   * @return The original string if non-numeric or within precision, otherwise a rounded version.
+   * @return The original string if non-numeric or within precision, otherwise a truncated version.
    */
   String formatNumeric(String valueStr) {
     if (maxDecimalPlaces == UNLIMITED_PRECISION || valueStr.isEmpty()) {
       return valueStr;
     }
-    try {
-      BigDecimal bd = new BigDecimal(valueStr);
-      return formatDecimal(bd);
-    } catch (NumberFormatException e) {
+
+    int dotIndex = valueStr.indexOf('.');
+    if (dotIndex < 0) {
       return valueStr;
     }
+
+    int decimalDigits = valueStr.length() - dotIndex - 1;
+    if (decimalDigits <= maxDecimalPlaces) {
+      return valueStr;
+    }
+
+    return valueStr.substring(0, dotIndex + 1 + maxDecimalPlaces);
   }
 
 }

--- a/src/test/java/org/joshsim/lang/io/MapSerializeStrategyTest.java
+++ b/src/test/java/org/joshsim/lang/io/MapSerializeStrategyTest.java
@@ -139,7 +139,7 @@ class MapSerializeStrategyTest {
       when(entity.getGeometry()).thenReturn(Optional.empty());
 
       Map<String, String> result = strategy.getRecord(entity);
-      assertEquals("3.141593", result.get("pi"));
+      assertEquals("3.141592", result.get("pi"));
     }
 
     @Test
@@ -236,7 +236,7 @@ class MapSerializeStrategyTest {
     }
 
     @Test
-    void testTrailingZerosStripped() {
+    void testTrailingZerosKept() {
       MapSerializeStrategy strategy = new MapSerializeStrategy(6);
 
       Entity entity = Mockito.mock(Entity.class);
@@ -247,11 +247,11 @@ class MapSerializeStrategyTest {
       when(entity.getGeometry()).thenReturn(Optional.empty());
 
       Map<String, String> result = strategy.getRecord(entity);
-      assertEquals("1.1", result.get("val"));
+      assertEquals("1.100000", result.get("val"));
     }
 
     @Test
-    void testRoundingHalfUp() {
+    void testTruncationNotRounding() {
       MapSerializeStrategy strategy = new MapSerializeStrategy(2);
 
       Entity entity = Mockito.mock(Entity.class);
@@ -262,7 +262,7 @@ class MapSerializeStrategyTest {
       when(entity.getGeometry()).thenReturn(Optional.empty());
 
       Map<String, String> result = strategy.getRecord(entity);
-      assertEquals("1.01", result.get("val"));
+      assertEquals("1.00", result.get("val"));
     }
   }
 }

--- a/src/test/java/org/joshsim/lang/io/MapSerializeStrategyTest.java
+++ b/src/test/java/org/joshsim/lang/io/MapSerializeStrategyTest.java
@@ -139,7 +139,7 @@ class MapSerializeStrategyTest {
       when(entity.getGeometry()).thenReturn(Optional.empty());
 
       Map<String, String> result = strategy.getRecord(entity);
-      assertEquals("3.141592", result.get("pi"));
+      assertEquals("3.1415926535", result.get("pi"));
     }
 
     @Test


### PR DESCRIPTION
Before running models over the weekened, I (somewhat hastily) merged a seemingly innocuous change to reduce the enormous filesize of our output csvs from josh (due to BigDecimal exporting 100x the precision than we need for actual analysis). Claude's solution took existing output strings, coerced back to BigDecimal and then applied `setScale()` to round it properly, but this was enormously expensive and I didn't notice this until we were running big models. 

So - now, we just truncate string output to 10 digits, with again an optional override. Perhaps down the line we can consider a smarter approach (since this hard truncation will cause rounding error), but at 10 digits I don't think this will matter for most aggregation operations. 