### PR TITLE
Fix MinIO streaming silent failure for large uploads

### DIFF
--- a/.github/workflows/test-minio.yaml
+++ b/.github/workflows/test-minio.yaml
@@ -200,6 +200,36 @@ jobs:
 
           echo "✓ Queue backpressure test passed"
 
+      - name: Test large payload upload (multipart)
+        run: |
+          echo "Testing large payload upload to exercise multipart upload path..."
+
+          # Run simulation that generates >10MB of entity-level CSV data
+          # 1500 organisms * 100 steps * 3 fields = ~15MB CSV
+          java -Xmx2g -jar build/libs/joshsim-fat.jar run \
+            --replicates=1 \
+            examples/test/minio/large_payload.josh \
+            LargePayloadTest \
+            --minio-endpoint=http://localhost:9000 \
+            --minio-access-key=minioadmin \
+            --minio-secret-key=minioadmin \
+            --export-queue-size=10000 \
+            --output-steps=100
+
+          # Verify file was uploaded
+          ./mc stat testminio/josh-test-bucket/results/large_payload_0.csv
+
+          # Verify file size exceeds 10MB multipart threshold
+          SIZE_BYTES=$(./mc stat testminio/josh-test-bucket/results/large_payload_0.csv --json | grep -o '"size":[0-9]*' | cut -d':' -f2)
+          echo "  Large payload size: $SIZE_BYTES bytes"
+
+          if [ "$SIZE_BYTES" -gt 10485760 ]; then
+            echo "✓ Large payload test passed (${SIZE_BYTES} bytes > 10MB multipart threshold)"
+          else
+            echo "✗ Large payload test failed: expected >10MB but got ${SIZE_BYTES} bytes"
+            exit 7
+          fi
+
       - name: Test error handling - missing credentials
         run: |
           echo "Testing error handling with missing credentials..."
@@ -341,6 +371,7 @@ jobs:
           echo "✓ File upload verification"
           echo "✓ Large CSV export (>10MB multipart upload)"
           echo "✓ Queue backpressure handling"
+          echo "✓ Large payload multipart upload"
           echo "✓ Error handling validation"
           echo "✓ MinioPollingStrategy integration"
           echo "✓ batchRemote end-to-end (server + MinIO)"

--- a/.github/workflows/test-minio.yaml
+++ b/.github/workflows/test-minio.yaml
@@ -160,6 +160,26 @@ jobs:
             exit 5
           fi
 
+      - name: Test large CSV export to MinIO (multipart upload)
+        run: |
+          echo "Testing large export forcing multipart upload (>10MB)..."
+          java -Xmx2g -jar build/libs/joshsim-fat.jar run \
+            --replicates=1 \
+            examples/test/minio/large_export.josh \
+            MinioLargeTest \
+            --minio-endpoint=http://localhost:9000 \
+            --minio-access-key=minioadmin \
+            --minio-secret-key=minioadmin
+
+          echo "Verifying large file exists and exceeds 10MB..."
+          SIZE=$(./mc stat testminio/josh-test-bucket/results/large_test.csv --json | grep -o '"size":[0-9]*' | cut -d':' -f2)
+          if [ "$SIZE" -gt 10485760 ]; then
+            echo "✓ Large export test passed: $SIZE bytes (multipart path exercised)"
+          else
+            echo "✗ Large export too small: $SIZE bytes (expected >10MB)"
+            exit 8
+          fi
+
       - name: Test queue backpressure with small queue
         run: |
           echo "Testing queue backpressure with small queue size..."
@@ -319,6 +339,7 @@ jobs:
           echo "✓ NetCDF export to MinIO"
           echo "✓ Mixed MinIO and local exports"
           echo "✓ File upload verification"
+          echo "✓ Large CSV export (>10MB multipart upload)"
           echo "✓ Queue backpressure handling"
           echo "✓ Error handling validation"
           echo "✓ MinioPollingStrategy integration"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,25 @@
       "-Djavax.media.jai.disableMediaLib=true"
     ]
   },
-  "java.compile.nullAnalysis.mode": "disabled"
+  "java.compile.nullAnalysis.mode": "disabled",
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#65c89b",
+    "activityBar.background": "#65c89b",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#945bc4",
+    "activityBarBadge.foreground": "#e7e7e7",
+    "commandCenter.border": "#15202b99",
+    "sash.hoverBorder": "#65c89b",
+    "statusBar.background": "#42b883",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#359268",
+    "statusBarItem.remoteBackground": "#42b883",
+    "statusBarItem.remoteForeground": "#15202b",
+    "titleBar.activeBackground": "#42b883",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#42b88399",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.remoteColor": "#42b883"
 }

--- a/examples/test/minio/large_export.josh
+++ b/examples/test/minio/large_export.josh
@@ -1,9 +1,9 @@
 start simulation MinioLargeTest
   # Test large CSV export to MinIO, forcing multipart upload (>10MB).
-  # ~1000 patches x 100 steps x ~100 bytes/row > 10MB.
+  # ~1300 patches x 100 steps x ~80 bytes/row > 10MB.
   grid.size = 100 m
   grid.low = 0 degrees latitude, 0 degrees longitude
-  grid.high = 0.03 degrees latitude, 0.03 degrees longitude
+  grid.high = 0.035 degrees latitude, 0.035 degrees longitude
   steps.low = 0 count
   steps.high = 100 count
   exportFiles.patch = "minio://josh-test-bucket/results/large_test.csv"

--- a/examples/test/minio/large_export.josh
+++ b/examples/test/minio/large_export.josh
@@ -1,0 +1,32 @@
+start simulation MinioLargeTest
+  # Test large CSV export to MinIO, forcing multipart upload (>10MB).
+  # ~1000 patches x 100 steps x ~100 bytes/row > 10MB.
+  grid.size = 100 m
+  grid.low = 0 degrees latitude, 0 degrees longitude
+  grid.high = 0.03 degrees latitude, 0.03 degrees longitude
+  steps.low = 0 count
+  steps.high = 100 count
+  exportFiles.patch = "minio://josh-test-bucket/results/large_test.csv"
+end simulation
+
+start patch Default
+  TestIndividual.init = create 10 count of TestIndividual
+
+  export.avgAge.step = mean(TestIndividual.age)
+  export.maxAge.step = max(TestIndividual.age)
+  export.minAge.step = min(TestIndividual.age)
+  export.avgHeight.step = mean(TestIndividual.height)
+  export.maxHeight.step = max(TestIndividual.height)
+end patch
+
+start organism TestIndividual
+  age.init = 0 year
+  age.step = prior.age + 1 year
+
+  height.init = 1.0 m
+  height.step = prior.height + 0.1 m
+end organism
+
+start unit year
+  alias years
+end unit

--- a/examples/test/minio/large_payload.josh
+++ b/examples/test/minio/large_payload.josh
@@ -1,0 +1,38 @@
+start simulation LargePayloadTest
+  # Test large payload upload to exercise MinIO multipart upload path (>10MB)
+  grid.size = 100 m
+  grid.low = 0 degrees latitude, 0 degrees longitude
+  grid.high = 0.001 degrees latitude, 0.001 degrees longitude
+  steps.low = 0 count
+  steps.high = 100 count
+  exportFiles.entity = "minio://josh-test-bucket/results/large_payload_{replicate}.csv"
+end simulation
+
+start patch Default
+  TestIndividual.init = create 1500 count of TestIndividual
+
+  export.avgAge.step = mean(TestIndividual.age)
+end patch
+
+start organism TestIndividual
+  age.init = 0 year
+  age.step = prior.age + 1 year
+
+  height.init = 1.0 m
+  height.step = prior.height + 0.1 m
+
+  weight.init = 50.0 kg
+  weight.step = prior.weight + 0.5 kg
+
+  export.age.step = current.age
+  export.height.step = current.height
+  export.weight.step = current.weight
+end organism
+
+start unit year
+  alias years
+end unit
+
+start unit kg
+  alias kilograms
+end unit

--- a/src/main/java/org/joshsim/compat/JvmQueueService.java
+++ b/src/main/java/org/joshsim/compat/JvmQueueService.java
@@ -8,8 +8,10 @@ package org.joshsim.compat;
 
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -25,6 +27,7 @@ public class JvmQueueService implements QueueService {
   private final ExecutorService executorService = Executors.newSingleThreadExecutor();
   private final AtomicBoolean active = new AtomicBoolean(false);
   private final QueueServiceCallback callback;
+  private volatile Future<?> workerFuture;
 
   /**
    * Creates a new JvmQueueService with the specified callback handler and capacity.
@@ -49,7 +52,7 @@ public class JvmQueueService implements QueueService {
   @Override
   public void start() {
     if (active.compareAndSet(false, true)) {
-      executorService.submit(() -> {
+      workerFuture = executorService.submit(() -> {
         callback.onStart();
 
         while (active.get() || !taskQueue.isEmpty()) {
@@ -73,6 +76,18 @@ public class JvmQueueService implements QueueService {
     executorService.shutdown();
     while (!executorService.isTerminated()) {
       trySleep();
+    }
+
+    // Propagate any exception from the worker thread
+    if (workerFuture != null) {
+      try {
+        workerFuture.get();
+      } catch (ExecutionException e) {
+        throw new RuntimeException("Worker thread failed", e.getCause());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("Interrupted while waiting for worker thread", e);
+      }
     }
   }
 

--- a/src/main/java/org/joshsim/lang/io/MinioOutputStreamStrategy.java
+++ b/src/main/java/org/joshsim/lang/io/MinioOutputStreamStrategy.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executors;
  *
  * <p>The BlockingQueue approach provides proper async coordination: the writer thread enqueues
  * data chunks as they're written, and the upload thread consumes them. This eliminates timing
- * issues and supports retry logic since the queue can be read multiple times if needed.
+ * issues present in the previous PipedInputStream/PipedOutputStream implementation.
  * </p>
  *
  * <p>The upload happens asynchronously in a dedicated thread pool to prevent thread exhaustion
@@ -37,7 +37,6 @@ import java.util.concurrent.Executors;
  */
 public class MinioOutputStreamStrategy implements OutputStreamStrategy {
 
-  private static final int[] RETRY_DELAYS_MS = {1000, 2000, 4000, 8000, 16000};
   private static final int CHUNK_SIZE = 256 * 1024; // 256KB chunks
   private static final int QUEUE_CAPACITY = 8; // 8 chunks = 2MB buffer
 
@@ -88,7 +87,7 @@ public class MinioOutputStreamStrategy implements OutputStreamStrategy {
     // This prevents thread starvation when MinIO's internal async operations
     // compete for ForkJoinPool.commonPool threads
     CompletableFuture<Void> uploadFuture = CompletableFuture.runAsync(() -> {
-      uploadWithRetry(inputStream);
+      upload(inputStream);
     }, UPLOAD_EXECUTOR);
 
     // Return a wrapper that blocks on close() to ensure upload completes
@@ -121,56 +120,32 @@ public class MinioOutputStreamStrategy implements OutputStreamStrategy {
   }
 
   /**
-   * Uploads data from the BlockingQueue input stream with exponential backoff retry logic.
+   * Uploads data from the BlockingQueue input stream to MinIO.
    *
-   * <p>The BlockingQueue approach supports proper retry logic since the stream can be
-   * consumed multiple times if needed. The writer thread enqueues data chunks, and the
-   * upload thread reads them asynchronously without timing dependencies.</p>
+   * <p>Streaming uploads backed by a BlockingQueue cannot be retried at this level because
+   * the queue is destructive: data consumed during a failed attempt is gone. Retry logic
+   * for streaming uploads belongs at a higher level (e.g., re-running the simulation).</p>
    *
    * <p>NOTE: The input stream is NOT closed in this method. The BlockingQueueOutputStream
    * manages stream lifecycle by signaling EOF when closed, which allows the upload to
    * complete naturally.</p>
    *
    * @param inputStream The BlockingQueue input stream containing data to upload
-   * @throws RuntimeException if all retry attempts fail
+   * @throws RuntimeException if the upload fails
    */
-  private void uploadWithRetry(BlockingQueueInputStream inputStream) {
-    Exception lastException = null;
-    for (int attempt = 0; attempt < RETRY_DELAYS_MS.length; attempt++) {
-      try {
-        // Attempt upload
-        minioClient.putObject(
-            PutObjectArgs.builder()
-                .bucket(bucketName)
-                .object(objectPath)
-                .stream(inputStream, -1, 10485760) // -1 = unknown size, 10MB part size
-                .build()
-        );
-
-        // Success - upload completed
-        return;
-
-      } catch (Exception e) {
-        lastException = e;
-
-        // If not the last attempt, wait before retrying
-        if (attempt < RETRY_DELAYS_MS.length - 1) {
-          try {
-            Thread.sleep(RETRY_DELAYS_MS[attempt]);
-          } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Upload interrupted during retry backoff", ie);
-          }
-        }
-      }
+  private void upload(BlockingQueueInputStream inputStream) {
+    try {
+      minioClient.putObject(
+          PutObjectArgs.builder()
+              .bucket(bucketName)
+              .object(objectPath)
+              .stream(inputStream, -1, 10485760) // -1 = unknown size, 10MB part size
+              .build()
+      );
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to upload to MinIO: " + bucketName + "/" + objectPath, e);
     }
-
-    // All retries exhausted - propagate error
-    throw new RuntimeException(
-        "Failed to upload to MinIO after " + RETRY_DELAYS_MS.length + " attempts: "
-            + bucketName + "/" + objectPath,
-        lastException
-    );
   }
 
   /**

--- a/src/test/java/org/joshsim/compat/JvmQueueServiceTest.java
+++ b/src/test/java/org/joshsim/compat/JvmQueueServiceTest.java
@@ -146,6 +146,49 @@ class JvmQueueServiceTest {
     });
   }
 
+  @Test
+  void testJoinPropagatesOnEndException() {
+    ThrowingCallback callback = new ThrowingCallback(ThrowingCallback.Phase.ON_END);
+    JvmQueueService jvmQueueService = new JvmQueueService(callback);
+
+    jvmQueueService.start();
+
+    RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+      jvmQueueService.join();
+    });
+    assertTrue(thrown.getMessage().contains("Worker thread failed"));
+    assertTrue(thrown.getCause().getMessage().contains("onEnd exploded"));
+  }
+
+  @Test
+  void testJoinPropagatesOnStartException() {
+    ThrowingCallback callback = new ThrowingCallback(ThrowingCallback.Phase.ON_START);
+    JvmQueueService jvmQueueService = new JvmQueueService(callback);
+
+    jvmQueueService.start();
+
+    RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+      jvmQueueService.join();
+    });
+    assertTrue(thrown.getMessage().contains("Worker thread failed"));
+    assertTrue(thrown.getCause().getMessage().contains("onStart exploded"));
+  }
+
+  @Test
+  void testJoinPropagatesOnTaskException() {
+    ThrowingCallback callback = new ThrowingCallback(ThrowingCallback.Phase.ON_TASK);
+    JvmQueueService jvmQueueService = new JvmQueueService(callback);
+
+    jvmQueueService.start();
+    jvmQueueService.add("Task1");
+
+    RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+      jvmQueueService.join();
+    });
+    assertTrue(thrown.getMessage().contains("Worker thread failed"));
+    assertTrue(thrown.getCause().getMessage().contains("onTask exploded"));
+  }
+
   private class TestCallback implements QueueServiceCallback {
 
     private int startCalls;
@@ -209,6 +252,38 @@ class JvmQueueServiceTest {
 
     public int getProcessedTaskCount() {
       return processedCount.get();
+    }
+  }
+
+  private class ThrowingCallback implements QueueServiceCallback {
+
+    enum Phase { ON_START, ON_TASK, ON_END }
+
+    private final Phase throwOn;
+
+    ThrowingCallback(Phase throwOn) {
+      this.throwOn = throwOn;
+    }
+
+    @Override
+    public void onStart() {
+      if (throwOn == Phase.ON_START) {
+        throw new RuntimeException("onStart exploded");
+      }
+    }
+
+    @Override
+    public void onTask(Optional<Object> task) {
+      if (throwOn == Phase.ON_TASK && task.isPresent()) {
+        throw new RuntimeException("onTask exploded");
+      }
+    }
+
+    @Override
+    public void onEnd() {
+      if (throwOn == Phase.ON_END) {
+        throw new RuntimeException("onEnd exploded");
+      }
     }
   }
 

--- a/src/test/java/org/joshsim/compat/JvmQueueServiceTest.java
+++ b/src/test/java/org/joshsim/compat/JvmQueueServiceTest.java
@@ -94,6 +94,48 @@ class JvmQueueServiceTest {
   }
 
   @Test
+  void testExceptionInOnEndPropagatesToJoin() {
+    QueueServiceCallback failingCallback = new QueueServiceCallback() {
+      @Override
+      public void onStart() {}
+
+      @Override
+      public void onTask(Optional<Object> task) {}
+
+      @Override
+      public void onEnd() {
+        throw new RuntimeException("Upload failed");
+      }
+    };
+    JvmQueueService service = new JvmQueueService(failingCallback);
+    service.start();
+    service.add("task");
+    assertThrows(RuntimeException.class, () -> service.join());
+  }
+
+  @Test
+  void testExceptionInOnTaskPropagatesToJoin() {
+    QueueServiceCallback failingCallback = new QueueServiceCallback() {
+      @Override
+      public void onStart() {}
+
+      @Override
+      public void onTask(Optional<Object> task) {
+        if (task.isPresent()) {
+          throw new RuntimeException("Task processing failed");
+        }
+      }
+
+      @Override
+      public void onEnd() {}
+    };
+    JvmQueueService service = new JvmQueueService(failingCallback);
+    service.start();
+    service.add("task");
+    assertThrows(RuntimeException.class, () -> service.join());
+  }
+
+  @Test
   void testCannotAddWhenNotActive() {
     TestCallback callback = new TestCallback();
     JvmQueueService jvmQueueService = new JvmQueueService(callback, 10);

--- a/src/test/java/org/joshsim/lang/io/MinioOutputStreamStrategyTest.java
+++ b/src/test/java/org/joshsim/lang/io/MinioOutputStreamStrategyTest.java
@@ -30,7 +30,7 @@ import org.mockito.MockitoAnnotations;
 
 /**
  * Unit tests for MinioOutputStreamStrategy, verifying streaming behavior,
- * retry logic, and bucket management.
+ * error propagation, and bucket management.
  */
 class MinioOutputStreamStrategyTest {
 
@@ -123,10 +123,11 @@ class MinioOutputStreamStrategyTest {
   }
 
   @Test
-  void testUploadFailure_propagatesAsIoException() throws Exception {
+  void testUploadFailure_propagatesException() throws Exception {
     // Arrange
     when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
 
+    // Upload fails
     when(minioClient.putObject(any(PutObjectArgs.class)))
         .thenThrow(new RuntimeException("Network error"));
 
@@ -138,10 +139,13 @@ class MinioOutputStreamStrategyTest {
     OutputStream out = strategy.open();
     out.write("test".getBytes(StandardCharsets.UTF_8));
 
-    // close() should propagate the upload failure
+    // close() should propagate the error immediately (no retry)
     IOException exception = assertThrows(IOException.class, () -> out.close());
     assertTrue(exception.getMessage().contains("Upload failed"));
     assertTrue(exception.getCause().getMessage().contains("Failed to upload to MinIO"));
+
+    // Verify putObject was called exactly once (no retry)
+    verify(minioClient, times(1)).putObject(any(PutObjectArgs.class));
   }
 
   @Test

--- a/src/test/java/org/joshsim/lang/io/MinioOutputStreamStrategyTest.java
+++ b/src/test/java/org/joshsim/lang/io/MinioOutputStreamStrategyTest.java
@@ -22,6 +22,7 @@ import io.minio.PutObjectArgs;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -122,39 +123,12 @@ class MinioOutputStreamStrategyTest {
   }
 
   @Test
-  void testRetryLogic_failsOnce_thenSucceeds() throws Exception {
+  void testUploadFailure_propagatesAsIoException() throws Exception {
     // Arrange
     when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
 
-    // First call fails, second succeeds
     when(minioClient.putObject(any(PutObjectArgs.class)))
-        .thenThrow(new RuntimeException("Temporary network error"))
-        .thenReturn(null);
-
-    MinioOutputStreamStrategy strategy = new MinioOutputStreamStrategy(
-        minioClient, TEST_BUCKET, TEST_OBJECT
-    );
-
-    // Act
-    try (OutputStream out = strategy.open()) {
-      out.write("test".getBytes(StandardCharsets.UTF_8));
-    }
-
-    // Give async upload time to retry
-    Thread.sleep(2000);
-
-    // Assert - verify putObject was called twice (1 fail + 1 retry success)
-    verify(minioClient, times(2)).putObject(any(PutObjectArgs.class));
-  }
-
-  @Test
-  void testRetryLogic_exhaustsAllRetries_throwsException() throws Exception {
-    // Arrange
-    when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
-
-    // All calls fail
-    when(minioClient.putObject(any(PutObjectArgs.class)))
-        .thenThrow(new RuntimeException("Persistent network error"));
+        .thenThrow(new RuntimeException("Network error"));
 
     MinioOutputStreamStrategy strategy = new MinioOutputStreamStrategy(
         minioClient, TEST_BUCKET, TEST_OBJECT
@@ -164,7 +138,7 @@ class MinioOutputStreamStrategyTest {
     OutputStream out = strategy.open();
     out.write("test".getBytes(StandardCharsets.UTF_8));
 
-    // close() should propagate the error after retries exhausted
+    // close() should propagate the upload failure
     IOException exception = assertThrows(IOException.class, () -> out.close());
     assertTrue(exception.getMessage().contains("Upload failed"));
     assertTrue(exception.getCause().getMessage().contains("Failed to upload to MinIO"));
@@ -229,6 +203,39 @@ class MinioOutputStreamStrategyTest {
 
     // Assert - upload should only happen once
     verify(minioClient, times(1)).putObject(any(PutObjectArgs.class));
+  }
+
+  @Test
+  void testUploadFailure_afterStreamConsumed_propagatesError() throws Exception {
+    // Simulates real MinIO SDK behavior: putObject reads the entire stream,
+    // then fails. With the broken retry logic, the retry would read from an
+    // already-consumed stream — either blocking forever or uploading empty data.
+    // The correct behavior is to propagate the failure cleanly.
+    when(minioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+
+    AtomicInteger attempt = new AtomicInteger(0);
+    when(minioClient.putObject(any(PutObjectArgs.class))).thenAnswer(invocation -> {
+      PutObjectArgs args = invocation.getArgument(0);
+      // Consume entire stream (simulates real MinIO SDK putObject behavior)
+      byte[] buf = new byte[8192];
+      while (args.stream().read(buf) >= 0) {
+        // drain
+      }
+      if (attempt.getAndIncrement() == 0) {
+        throw new RuntimeException("Network error after consuming stream");
+      }
+      return null;
+    });
+
+    MinioOutputStreamStrategy strategy = new MinioOutputStreamStrategy(
+        minioClient, TEST_BUCKET, TEST_OBJECT
+    );
+
+    OutputStream out = strategy.open();
+    out.write("test data that will be consumed then lost".getBytes(StandardCharsets.UTF_8));
+
+    // close() must propagate the upload failure, not silently succeed with empty retry
+    assertThrows(IOException.class, () -> out.close());
   }
 
   @Test


### PR DESCRIPTION
## Summary

~~Fixes #396. Large batch simulations complete with `"status": "complete"` but no CSV data appears in MinIO. Small runs work fine.~~

See comment below!

- **`JvmQueueService.join()` now propagates worker thread exceptions** instead of silently swallowing them. The `Future` from `submit()` is stored and `get()` is called in `join()` to surface errors from `onEnd()` (where MinIO upload completion happens).
- **Removed broken retry logic from `MinioOutputStreamStrategy`**. The retry loop re-read an already-consumed `BlockingQueueInputStream` — data taken from an `ArrayBlockingQueue` is gone, so retries would either block forever or upload empty/corrupt data. Streaming uploads cannot be retried at this level; a single-attempt upload with clean error propagation is correct.
- **Added CI integration test** with a >10MB simulation to exercise the MinIO SDK multipart upload path, which was the boundary where failures occurred.

## Test plan

- [x] New unit test: `JvmQueueServiceTest.testExceptionInOnEndPropagatesToJoin` — verified it fails before fix, passes after
- [x] New unit test: `JvmQueueServiceTest.testExceptionInOnTaskPropagatesToJoin` — same
- [x] New unit test: `MinioOutputStreamStrategyTest.testUploadFailure_afterStreamConsumed_propagatesError` — verified it fails before fix (retry silently "succeeds" with empty data), passes after
- [x] Updated `testUploadFailure_propagatesAsIoException` — replaces old retry-exhaustion test
- [x] All existing tests pass (`./gradlew test` — 0 failures)
- [x] CI: new `large_export.josh` test step in `test-minio.yaml` verifies >10MB multipart upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)