### PR TITLE
Add debugBottle Gradle task and bottle debugging docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ jotr
 
 # Joshpy bottles (compressed archives and extracted debug sessions)
 joshpy-bottles/
+!joshpy-bottles/README.md

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -110,7 +110,8 @@
       "name": "Attach to Bottle",
       "request": "attach",
       "hostName": "localhost",
-      "port": 5005
+      "port": 5005,
+      "projectName": "josh"
     }
   ],
   "inputs": [

--- a/build.gradle
+++ b/build.gradle
@@ -328,6 +328,117 @@ task generateTestData {
     dependsOn preprocessTestData
 }
 
+// Task to extract and debug a joshpy bottle with JDWP on port 5005.
+// Usage: ./gradlew debugBottle -Pbottle=<path-or-name.tar.gz>
+task debugBottle {
+  description = 'Extracts a joshpy bottle and launches the simulation with JDWP debugger on port 5005'
+  group = 'debugging'
+  dependsOn fatJar
+
+  doLast {
+    if (!project.hasProperty('bottle')) {
+      throw new GradleException('Usage: ./gradlew debugBottle -Pbottle=<bottle.tar.gz>')
+    }
+
+    def bottlePath = project.property('bottle') as String
+    def compressedDir = file("${rootDir}/joshpy-bottles/compressed")
+    def extractedDir = file("${rootDir}/joshpy-bottles/extracted")
+    def envFile = file("${rootDir}/.devcontainer/.env")
+
+    // Resolve bottle: as given, then compressed/ directory
+    def resolved = [
+      file(bottlePath),
+      new File(compressedDir, bottlePath),
+      new File(compressedDir, new File(bottlePath).name),
+    ].find { it.exists() }
+
+    if (resolved == null) {
+      throw new GradleException("Bottle not found: ${bottlePath} (also checked ${compressedDir})")
+    }
+    if (!resolved.name.endsWith('.tar.gz')) {
+      throw new GradleException("Expected a .tar.gz file, got: ${resolved.name}")
+    }
+
+    // Extract
+    extractedDir.mkdirs()
+    def dirName = ['tar', '-tzf', resolved.absolutePath].execute().text
+        .split('/')[0]
+    def extractDir = new File(extractedDir, dirName)
+    if (!extractDir.exists()) {
+      exec { commandLine 'tar', '-xzf', resolved.absolutePath, '-C', extractedDir.absolutePath }
+      println "Extracted: ${extractDir}"
+    } else {
+      println "Already extracted: ${extractDir}"
+    }
+
+    // Parse manifest
+    def manifest = new File(extractDir, 'manifest.json')
+    if (!manifest.exists()) {
+      throw new GradleException("No manifest.json in bottle")
+    }
+    def mf = new groovy.json.JsonSlurper().parse(manifest)
+
+    // Parse run.sh for --data and --custom-tag args
+    def runSh = new File(extractDir, 'run.sh')
+    if (!runSh.exists()) {
+      throw new GradleException("No run.sh in bottle")
+    }
+    def jvmArgs = []
+    def appArgs = ['run', 'simulation.josh', mf.simulation]
+    runSh.eachLine { line ->
+      def dataMatcher = (line =~ /--data\s+(\S+)/)
+      if (dataMatcher.find()) {
+        appArgs.addAll(['--data', dataMatcher.group(1).replaceAll(/\s*\\$/, '')])
+      }
+      def tagMatcher = (line =~ /--custom-tag\s+(\S+)/)
+      if (tagMatcher.find()) {
+        appArgs.addAll(['--custom-tag', tagMatcher.group(1).replaceAll(/\s*\\$/, '')])
+      }
+    }
+
+    // Load .devcontainer/.env
+    def extraEnv = [:]
+    if (envFile.exists()) {
+      envFile.eachLine { line ->
+        line = line.trim()
+        if (line && !line.startsWith('#')) {
+          def eqIdx = line.indexOf('=')
+          if (eqIdx > 0) {
+            extraEnv[line.substring(0, eqIdx)] = line.substring(eqIdx + 1)
+          }
+        }
+      }
+      println "Loaded ${extraEnv.size()} env vars from ${envFile}"
+    } else {
+      println "Warning: ${envFile} not found -- MinIO credentials may be missing"
+    }
+
+    println ""
+    println "=== Bottle Debug Session ==="
+    println "Simulation:  ${mf.simulation}"
+    println "Run hash:    ${mf.run_hash}"
+    println "Bottled at:  ${mf.bottled_at}"
+    println "Data files:  ${mf.original_data_paths?.size() ?: 0}"
+    println "Parameters:  ${mf.parameters?.size() ?: 0}"
+    println "Debug port:  5005 (suspend=y)"
+    println ""
+    println "Waiting for debugger on port 5005..."
+    println "-> Attach VSCode debugger \"Attach to Bottle\" to continue"
+    println ""
+
+    // Launch with JDWP
+    exec {
+      commandLine(['java',
+        '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005',
+        '-ea', '-Xmx4g',
+        '-jar', fatJar.archiveFile.get().asFile.absolutePath,
+      ] + appArgs)
+      workingDir = extractDir
+      environment System.getenv() + extraEnv
+    }
+  }
+}
+
 // Task to run conformance tests
 task conformanceTest(type: Test) {
     description = 'Runs conformance tests'

--- a/joshpy-bottles/README.md
+++ b/joshpy-bottles/README.md
@@ -1,0 +1,66 @@
+# joshpy-bottles
+
+Reproducible snapshots of joshpy sweep runs, used for debugging simulation failures locally.
+
+A "bottle" is a self-contained `.tar.gz` archive produced by joshpy's `SweepManager` that captures everything needed to re-run a single simulation job: the `.josh` script, `.jshc` config, `.jshd` data files, and a `manifest.json` with parameters and provenance.
+
+## Directory structure
+
+```
+joshpy-bottles/
+  compressed/    # .tar.gz bottle archives (gitignored)
+  extracted/     # unpacked bottles, created automatically (gitignored)
+```
+
+Both directories are gitignored. Bottles contain large binary data files and should be shared out-of-band (e.g. MinIO, shared drives).
+
+## Bottle contents
+
+Each archive extracts to a directory named `bottle_<label>_<run_hash>/`:
+
+```
+bottle_test-minio-fail_a412e32bbcb9/
+  manifest.json       # provenance: simulation name, parameters, jar SHA, git hash, timestamps
+  simulation.josh     # the Josh script
+  sweep_config.jshc   # parameter configuration
+  run.sh              # the exact command joshpy used to launch this job
+  data/               # .jshd preprocessed data files
+```
+
+## Debugging a bottle
+
+### With Gradle (recommended)
+
+```bash
+./gradlew debugBottle -Pbottle=<bottle.tar.gz>
+```
+
+This will:
+1. Build the fat JAR if needed
+2. Resolve the bottle from `joshpy-bottles/compressed/` (accepts a filename or full path)
+3. Extract it if not already extracted
+4. Load MinIO credentials from `.devcontainer/.env`
+5. Launch the JVM with JDWP suspended on port 5005
+
+Then attach the VSCode debugger using the **"Attach to Bottle"** launch configuration.
+
+### With the shell script
+
+```bash
+source .devcontainer/.env  # load MinIO credentials if needed
+bash scripts/unbottle_and_debug.sh <bottle.tar.gz>
+```
+
+The shell script does not source `.env` automatically -- you must do it yourself if the simulation targets a MinIO export.
+
+## Naming convention
+
+Bottles are named by joshpy as:
+
+```
+bottle_<label>_<run_hash>_<timestamp>.tar.gz
+```
+
+- **label**: user-provided sweep label (e.g. `test-minio-fail`)
+- **run_hash**: 12-char hex hash identifying the sweep run
+- **timestamp**: `YYYYMMDD_HHMMSS` in UTC


### PR DESCRIPTION
## Summary
- Adds `./gradlew debugBottle -Pbottle=<file>` Gradle task that extracts a joshpy bottle, auto-loads MinIO credentials from `.devcontainer/.env`, and launches the JVM with JDWP on port 5005
- Fixes "Attach to Bottle" VSCode launch config (adds `projectName` so debug console expression evaluation works)
- Adds `joshpy-bottles/README.md` documenting bottle structure and debugging workflow

## Test plan
- [x] `./gradlew tasks --group=debugging` lists the task
- [x] `./gradlew debugBottle` without `-Pbottle` gives usage error
- [x] `./gradlew debugBottle -Pbottle=<bottle>.tar.gz` extracts, loads env, launches with JDWP

🤖 Generated with [Claude Code](https://claude.com/claude-code)