### PR TITLE
Add Dockerfile.batch, pod_minio_endpoint, and Kind CI workflow

### DIFF
--- a/.github/workflows/test-k8s.yaml
+++ b/.github/workflows/test-k8s.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - feat/k8s-target
   pull_request:
 
 jobs:

--- a/.github/workflows/test-k8s.yaml
+++ b/.github/workflows/test-k8s.yaml
@@ -37,10 +37,11 @@ jobs:
       - name: Create Kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          cluster_name: kind
           wait: 300s
 
       - name: Load batch image into Kind
-        run: kind load docker-image joshsim-batch:ci
+        run: kind load docker-image joshsim-batch:ci --name kind
 
       - name: Deploy MinIO inside Kind
         run: |

--- a/.github/workflows/test-k8s.yaml
+++ b/.github/workflows/test-k8s.yaml
@@ -1,0 +1,278 @@
+name: Kubernetes Integration Tests
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+
+jobs:
+  test-k8s-batch:
+    runs-on: ubuntu-latest
+    name: Test K8s Batch Execution
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup netCDF
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libnetcdf-dev
+
+      - name: Build fat jar
+        run: ./gradlew fatJar
+
+      - name: Build batch worker image
+        run: docker build -f cloud-img/Dockerfile.batch -t joshsim-batch:ci .
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          wait: 300s
+
+      - name: Load batch image into Kind
+        run: kind load docker-image joshsim-batch:ci
+
+      - name: Deploy MinIO inside Kind
+        run: |
+          kubectl apply -f - <<'EOF'
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: minio
+            labels:
+              app: minio
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: minio
+            template:
+              metadata:
+                labels:
+                  app: minio
+              spec:
+                containers:
+                - name: minio
+                  image: minio/minio:latest
+                  args: ["server", "/data"]
+                  env:
+                  - name: MINIO_ROOT_USER
+                    value: minioadmin
+                  - name: MINIO_ROOT_PASSWORD
+                    value: minioadmin
+                  ports:
+                  - containerPort: 9000
+                  readinessProbe:
+                    httpGet:
+                      path: /minio/health/ready
+                      port: 9000
+                    initialDelaySeconds: 5
+                    periodSeconds: 5
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: minio
+          spec:
+            selector:
+              app: minio
+            ports:
+            - port: 9000
+              targetPort: 9000
+          EOF
+
+          echo "Waiting for MinIO pod to be ready..."
+          kubectl wait --for=condition=ready pod -l app=minio --timeout=120s
+
+      - name: Create MinIO test bucket
+        run: |
+          MINIO_POD=$(kubectl get pod -l app=minio -o jsonpath='{.items[0].metadata.name}')
+
+          # Install mc inside the MinIO pod and create bucket
+          kubectl exec $MINIO_POD -- sh -c '
+            curl -sL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc &&
+            chmod +x /tmp/mc &&
+            /tmp/mc alias set local http://localhost:9000 minioadmin minioadmin &&
+            /tmp/mc mb local/josh-test-bucket
+          '
+
+      - name: Port-forward MinIO to host
+        run: |
+          kubectl port-forward svc/minio 9000:9000 &
+          sleep 2
+          # Verify port-forward works
+          curl -sf http://localhost:9000/minio/health/ready || {
+            echo "Port-forward failed"
+            exit 1
+          }
+          echo "MinIO accessible at localhost:9000"
+
+      - name: Create test simulation
+        run: |
+          mkdir -p /tmp/k8s-e2e-test
+          cat > /tmp/k8s-e2e-test/k8s_test.josh << 'JOSH'
+          start simulation K8sTest
+            grid.size = 100 m
+            grid.low = 0 degrees latitude, 0 degrees longitude
+            grid.high = 0.01 degrees latitude, 0.01 degrees longitude
+            grid.patch = "Default"
+            steps.low = 0 count
+            steps.high = 2 count
+            exportFiles.patch = "minio://josh-test-bucket/k8s-e2e-results/results.csv"
+          end simulation
+
+          start patch Default
+            Tree.init = create 3 count of Tree
+            export.treeCount.step = count(Tree)
+          end patch
+
+          start organism Tree
+            age.init = 0 count
+            age.step = prior.age + 1 count
+          end organism
+          JOSH
+
+      - name: Create K8s target profile
+        run: |
+          mkdir -p ~/.josh/targets
+          cat > ~/.josh/targets/ci-k8s.json << 'PROFILE'
+          {
+            "type": "kubernetes",
+            "kubernetes": {
+              "context": "kind-kind",
+              "namespace": "default",
+              "image": "joshsim-batch:ci",
+              "parallelism": 2,
+              "timeoutSeconds": 300,
+              "pod_minio_endpoint": "http://minio.default.svc:9000"
+            },
+            "minio_endpoint": "http://localhost:9000",
+            "minio_access_key": "minioadmin",
+            "minio_secret_key": "minioadmin",
+            "minio_bucket": "josh-test-bucket"
+          }
+          PROFILE
+
+      - name: Run batchRemote end-to-end
+        run: |
+          echo "Running batchRemote with K8s target..."
+          java -jar build/libs/joshsim-fat.jar batchRemote \
+            /tmp/k8s-e2e-test/ K8sTest \
+            --target=ci-k8s \
+            --replicates=2 \
+            --poll-interval=5 \
+            --timeout=300
+
+          echo "batchRemote completed successfully"
+
+      - name: Verify K8s Job completed
+        run: |
+          echo "Checking K8s Jobs..."
+          kubectl get jobs
+          echo "---"
+          kubectl get pods
+          echo "---"
+
+          # Verify at least one job exists with completions
+          SUCCEEDED=$(kubectl get jobs -o jsonpath='{.items[0].status.succeeded}')
+          if [ "$SUCCEEDED" -ge 1 ]; then
+            echo "K8s Job completed with $SUCCEEDED succeeded pods"
+          else
+            echo "K8s Job did not complete as expected"
+            kubectl describe jobs
+            exit 1
+          fi
+
+      - name: Verify results in MinIO
+        run: |
+          MINIO_POD=$(kubectl get pod -l app=minio -o jsonpath='{.items[0].metadata.name}')
+
+          echo "Checking results in MinIO..."
+          kubectl exec $MINIO_POD -- /tmp/mc ls local/josh-test-bucket/k8s-e2e-results/
+
+          # Verify results CSV exists and is non-empty
+          SIZE=$(kubectl exec $MINIO_POD -- /tmp/mc stat local/josh-test-bucket/k8s-e2e-results/results.csv --json 2>/dev/null | grep -o '"size":[0-9]*' | cut -d':' -f2)
+          if [ "$SIZE" -gt 0 ]; then
+            echo "Results CSV found in MinIO ($SIZE bytes)"
+          else
+            echo "Results CSV empty or missing"
+            exit 1
+          fi
+
+      - name: Test failure detection - bad image
+        run: |
+          echo "Testing ImagePullBackOff detection..."
+          cat > ~/.josh/targets/ci-k8s-bad-image.json << 'PROFILE'
+          {
+            "type": "kubernetes",
+            "kubernetes": {
+              "context": "kind-kind",
+              "namespace": "default",
+              "image": "nonexistent-registry.example.com/no-such-image:v999",
+              "parallelism": 1,
+              "timeoutSeconds": 60,
+              "pod_minio_endpoint": "http://minio.default.svc:9000"
+            },
+            "minio_endpoint": "http://localhost:9000",
+            "minio_access_key": "minioadmin",
+            "minio_secret_key": "minioadmin",
+            "minio_bucket": "josh-test-bucket"
+          }
+          PROFILE
+
+          # This should fail with an image pull error
+          if java -jar build/libs/joshsim-fat.jar batchRemote \
+            /tmp/k8s-e2e-test/ K8sTest \
+            --target=ci-k8s-bad-image \
+            --replicates=1 \
+            --poll-interval=5 \
+            --timeout=90 2>&1 | tee /tmp/bad-image-output.txt; then
+            echo "ERROR: batchRemote should have failed for bad image"
+            exit 1
+          fi
+
+          # Verify the error mentions image pull
+          if grep -qi "ImagePull\|ErrImage\|image" /tmp/bad-image-output.txt; then
+            echo "Image pull failure detected correctly"
+          else
+            echo "Warning: error detected but message may not mention image pull"
+            cat /tmp/bad-image-output.txt
+          fi
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== K8s Jobs ==="
+          kubectl get jobs -o wide
+          echo "=== K8s Pods ==="
+          kubectl get pods -o wide
+          echo "=== Pod Logs ==="
+          kubectl logs -l app=joshsim --all-containers=true --tail=50 2>/dev/null || true
+          echo "=== Job Descriptions ==="
+          kubectl describe jobs 2>/dev/null || true
+          echo "=== MinIO Pod Logs ==="
+          kubectl logs -l app=minio --tail=20 2>/dev/null || true
+
+      - name: Test summary
+        if: always()
+        run: |
+          echo "================================================"
+          echo "Kubernetes Integration Test Summary"
+          echo "================================================"
+          echo "  Kind cluster creation"
+          echo "  Batch worker image build + load"
+          echo "  MinIO deployment inside Kind"
+          echo "  batchRemote e2e (K8s target, 2 replicates)"
+          echo "  Job completion verification"
+          echo "  Results verification in MinIO"
+          echo "  Failure detection (bad image)"
+          echo "================================================"

--- a/.github/workflows/test-k8s.yaml
+++ b/.github/workflows/test-k8s.yaml
@@ -118,57 +118,17 @@ jobs:
           }
           echo "MinIO accessible at localhost:9000"
 
-      - name: Create test simulation
-        run: |
-          mkdir -p /tmp/k8s-e2e-test
-          cat > /tmp/k8s-e2e-test/k8s_test.josh << 'JOSH'
-          start simulation K8sTest
-            grid.size = 100 m
-            grid.low = 0 degrees latitude, 0 degrees longitude
-            grid.high = 0.01 degrees latitude, 0.01 degrees longitude
-            grid.patch = "Default"
-            steps.low = 0 count
-            steps.high = 2 count
-            exportFiles.patch = "minio://josh-test-bucket/k8s-e2e-results/results.csv"
-          end simulation
-
-          start patch Default
-            Tree.init = create 3 count of Tree
-            export.treeCount.step = count(Tree)
-          end patch
-
-          start organism Tree
-            age.init = 0 count
-            age.step = prior.age + 1 count
-          end organism
-          JOSH
-
-      - name: Create K8s target profile
+      - name: Install target profiles
         run: |
           mkdir -p ~/.josh/targets
-          cat > ~/.josh/targets/ci-k8s.json << 'PROFILE'
-          {
-            "type": "kubernetes",
-            "kubernetes": {
-              "context": "kind-kind",
-              "namespace": "default",
-              "image": "joshsim-batch:ci",
-              "parallelism": 2,
-              "timeoutSeconds": 300,
-              "pod_minio_endpoint": "http://minio.default.svc:9000"
-            },
-            "minio_endpoint": "http://localhost:9000",
-            "minio_access_key": "minioadmin",
-            "minio_secret_key": "minioadmin",
-            "minio_bucket": "josh-test-bucket"
-          }
-          PROFILE
+          cp examples/test/k8s/ci-k8s-profile.json ~/.josh/targets/ci-k8s.json
+          cp examples/test/k8s/ci-k8s-bad-image-profile.json ~/.josh/targets/ci-k8s-bad-image.json
 
       - name: Run batchRemote end-to-end
         run: |
           echo "Running batchRemote with K8s target..."
           java -jar build/libs/joshsim-fat.jar batchRemote \
-            /tmp/k8s-e2e-test/ K8sTest \
+            examples/test/k8s/ K8sTest \
             --target=ci-k8s \
             --replicates=2 \
             --poll-interval=5 \
@@ -214,28 +174,11 @@ jobs:
         run: |
           set -o pipefail
           echo "Testing ImagePullBackOff detection..."
-          cat > ~/.josh/targets/ci-k8s-bad-image.json << 'PROFILE'
-          {
-            "type": "kubernetes",
-            "kubernetes": {
-              "context": "kind-kind",
-              "namespace": "default",
-              "image": "nonexistent-registry.example.com/no-such-image:v999",
-              "parallelism": 1,
-              "timeoutSeconds": 180,
-              "pod_minio_endpoint": "http://minio.default.svc:9000"
-            },
-            "minio_endpoint": "http://localhost:9000",
-            "minio_access_key": "minioadmin",
-            "minio_secret_key": "minioadmin",
-            "minio_bucket": "josh-test-bucket"
-          }
-          PROFILE
 
           # batchRemote should fail — capture exit code through tee
           EXIT_CODE=0
           java -jar build/libs/joshsim-fat.jar batchRemote \
-            /tmp/k8s-e2e-test/ K8sTest \
+            examples/test/k8s/ K8sTest \
             --target=ci-k8s-bad-image \
             --replicates=1 \
             --poll-interval=10 \

--- a/.github/workflows/test-k8s.yaml
+++ b/.github/workflows/test-k8s.yaml
@@ -182,7 +182,7 @@ jobs:
             --target=ci-k8s-bad-image \
             --replicates=1 \
             --poll-interval=10 \
-            --timeout=180 2>&1 | tee /tmp/bad-image-output.txt || EXIT_CODE=$?
+            --timeout=120 2>&1 | tee /tmp/bad-image-output.txt || EXIT_CODE=$?
 
           if [ "$EXIT_CODE" -eq 0 ]; then
             echo "ERROR: batchRemote should have failed for bad image"

--- a/.github/workflows/test-k8s.yaml
+++ b/.github/workflows/test-k8s.yaml
@@ -212,6 +212,7 @@ jobs:
 
       - name: Test failure detection - bad image
         run: |
+          set -o pipefail
           echo "Testing ImagePullBackOff detection..."
           cat > ~/.josh/targets/ci-k8s-bad-image.json << 'PROFILE'
           {
@@ -221,7 +222,7 @@ jobs:
               "namespace": "default",
               "image": "nonexistent-registry.example.com/no-such-image:v999",
               "parallelism": 1,
-              "timeoutSeconds": 60,
+              "timeoutSeconds": 180,
               "pod_minio_endpoint": "http://minio.default.svc:9000"
             },
             "minio_endpoint": "http://localhost:9000",
@@ -231,22 +232,27 @@ jobs:
           }
           PROFILE
 
-          # This should fail with an image pull error
-          if java -jar build/libs/joshsim-fat.jar batchRemote \
+          # batchRemote should fail — capture exit code through tee
+          EXIT_CODE=0
+          java -jar build/libs/joshsim-fat.jar batchRemote \
             /tmp/k8s-e2e-test/ K8sTest \
             --target=ci-k8s-bad-image \
             --replicates=1 \
-            --poll-interval=5 \
-            --timeout=90 2>&1 | tee /tmp/bad-image-output.txt; then
+            --poll-interval=10 \
+            --timeout=180 2>&1 | tee /tmp/bad-image-output.txt || EXIT_CODE=$?
+
+          if [ "$EXIT_CODE" -eq 0 ]; then
             echo "ERROR: batchRemote should have failed for bad image"
             exit 1
           fi
 
-          # Verify the error mentions image pull
-          if grep -qi "ImagePull\|ErrImage\|image" /tmp/bad-image-output.txt; then
-            echo "Image pull failure detected correctly"
+          echo "batchRemote failed as expected (exit code $EXIT_CODE)"
+
+          # Check that the error is related to image or backoff
+          if grep -qi "ImagePull\|ErrImage\|BackoffLimit\|image" /tmp/bad-image-output.txt; then
+            echo "Failure reason detected correctly"
           else
-            echo "Warning: error detected but message may not mention image pull"
+            echo "Warning: failed but reason may not mention image pull"
             cat /tmp/bad-image-output.txt
           fi
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,27 @@ $ java -jar joshsim.jar server --worker-url your-server-url.com/runReplicate
 
 See also our [example Dockerfile](https://github.com/SchmidtDSE/josh/blob/main/cloud-img/Dockerfile.prod).
 
+### Batch execution on your own infrastructure
+For large-scale runs on your own Kubernetes cluster or server, Josh provides the `batchRemote` command. This stages simulation files to S3-compatible storage (MinIO, GCS, AWS S3), dispatches execution to a configured target, and polls for completion. Results are written back to storage via `minio://` export paths.
+
+```
+$ java -jar joshsim.jar batchRemote simulation.josh Main --target=nautilus --replicates=50
+```
+
+Targets are defined as JSON profiles at `~/.josh/targets/<name>.json`. Two target types are supported:
+
+- **HTTP targets** — dispatch to any joshsim server (Cloud Run, self-hosted). The server runs all replicates in-process.
+- **Kubernetes targets** — create an indexed K8s Job where each pod runs one replicate. Supports GKE, [Nautilus/NRP](https://nrp.ai), EKS, and self-hosted clusters.
+
+MinIO credentials are resolved from environment variables, the profile JSON, or CLI flags — secrets do not need to live in the profile file. See `llms-full.txt` for the full target profile specification and credential resolution details.
+
+The batch worker container image is built from `cloud-img/Dockerfile.batch`. Staging commands (`stageToMinio`, `stageFromMinio`) are also available for manual workflows:
+
+```
+$ java -jar joshsim.jar stageToMinio --input-dir=./sim/ --prefix=batch-jobs/abc/inputs/ \
+  --minio-endpoint=https://s3.amazonaws.com --minio-bucket=my-bucket
+```
+
 ## Security
 When running in server mode, some additional security mechanisms are in place.
 

--- a/cloud-img/Dockerfile.batch
+++ b/cloud-img/Dockerfile.batch
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+COPY build/libs/joshsim-fat.jar /app/joshsim-fat.jar
+COPY cloud-img/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/examples/test/k8s/ci-k8s-bad-image-profile.json
+++ b/examples/test/k8s/ci-k8s-bad-image-profile.json
@@ -1,0 +1,15 @@
+{
+  "type": "kubernetes",
+  "kubernetes": {
+    "context": "kind-kind",
+    "namespace": "default",
+    "image": "nonexistent-registry.example.com/no-such-image:v999",
+    "parallelism": 1,
+    "timeoutSeconds": 180,
+    "pod_minio_endpoint": "http://minio.default.svc:9000"
+  },
+  "minio_endpoint": "http://localhost:9000",
+  "minio_access_key": "minioadmin",
+  "minio_secret_key": "minioadmin",
+  "minio_bucket": "josh-test-bucket"
+}

--- a/examples/test/k8s/ci-k8s-bad-image-profile.json
+++ b/examples/test/k8s/ci-k8s-bad-image-profile.json
@@ -5,7 +5,7 @@
     "namespace": "default",
     "image": "nonexistent-registry.example.com/no-such-image:v999",
     "parallelism": 1,
-    "timeoutSeconds": 180,
+    "timeoutSeconds": 120,
     "pod_minio_endpoint": "http://minio.default.svc:9000"
   },
   "minio_endpoint": "http://localhost:9000",

--- a/examples/test/k8s/ci-k8s-profile.json
+++ b/examples/test/k8s/ci-k8s-profile.json
@@ -1,0 +1,15 @@
+{
+  "type": "kubernetes",
+  "kubernetes": {
+    "context": "kind-kind",
+    "namespace": "default",
+    "image": "joshsim-batch:ci",
+    "parallelism": 2,
+    "timeoutSeconds": 300,
+    "pod_minio_endpoint": "http://minio.default.svc:9000"
+  },
+  "minio_endpoint": "http://localhost:9000",
+  "minio_access_key": "minioadmin",
+  "minio_secret_key": "minioadmin",
+  "minio_bucket": "josh-test-bucket"
+}

--- a/examples/test/k8s/k8s_test.josh
+++ b/examples/test/k8s/k8s_test.josh
@@ -1,0 +1,19 @@
+start simulation K8sTest
+  grid.size = 100 m
+  grid.low = 0 degrees latitude, 0 degrees longitude
+  grid.high = 0.01 degrees latitude, 0.01 degrees longitude
+  grid.patch = "Default"
+  steps.low = 0 count
+  steps.high = 2 count
+  exportFiles.patch = "minio://josh-test-bucket/k8s-e2e-results/results.csv"
+end simulation
+
+start patch Default
+  Tree.init = create 3 count of Tree
+  export.treeCount.step = count(Tree)
+end patch
+
+start organism Tree
+  age.init = 0 count
+  age.step = prior.age + 1 count
+end organism

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -253,6 +253,107 @@ java -jar joshsim-fat.jar runRemote <script.josh> <SimulationName> [OPTIONS]
 - `--replicates <N>`: Number of replicates
 - `--endpoint <url>`: Custom Josh Cloud endpoint
 
+#### `batchRemote` - Batch Execution on Remote Targets
+Dispatches a simulation to a remote compute target (Cloud Run, Kubernetes, etc.) via MinIO staging. The target profile defines how the job runs — an HTTP target POSTs to a joshsim server, a Kubernetes target creates an indexed Job with one pod per replicate.
+
+```bash
+java -jar joshsim-fat.jar batchRemote <script.josh | inputDir> <SimulationName> [OPTIONS]
+```
+
+**Parameters:**
+- `<script.josh>` or `<inputDir>`: Path to Josh simulation file or directory containing simulation files
+- `<SimulationName>`: Name of simulation to execute
+
+**Options:**
+- `--target <name>` (required): Target profile name (loads `~/.josh/targets/<name>.json`)
+- `--replicates <N>`: Number of replicates (default: 1). Passed to the target — HTTP targets run N in-process, K8s targets create N pods.
+- `--no-wait`: Dispatch and exit without polling for completion
+- `--poll-interval <seconds>`: Seconds between status polls (default: 5)
+- `--timeout <seconds>`: Maximum seconds to wait for completion (default: 3600)
+
+**Examples:**
+```bash
+# Run on Cloud Run via HTTP target, wait for completion
+java -jar joshsim-fat.jar batchRemote simulation.josh Main --target=cloudrun-prod
+
+# Run 50 replicates on Kubernetes (one pod each), fire and forget
+java -jar joshsim-fat.jar batchRemote simulation.josh Main --target=nautilus --replicates=50 --no-wait
+```
+
+**Workflow:**
+1. Stages local simulation files to MinIO (`batch-jobs/<jobId>/inputs/`)
+2. Dispatches to the configured target (HTTP POST or K8s Job creation)
+3. Polls for completion (MinIO status file for HTTP, K8s Job API for Kubernetes)
+4. Results land in MinIO via `minio://` export paths in the Josh script
+
+##### Target Profiles
+
+Target profiles are JSON files at `~/.josh/targets/<name>.json` that define a compute target and its MinIO storage configuration.
+
+**HTTP target** (Cloud Run, any joshsim server):
+```json
+{
+  "type": "http",
+  "http": {
+    "endpoint": "https://josh-executor.run.app",
+    "apiKey": "your-api-key"
+  },
+  "minio_endpoint": "https://storage.googleapis.com",
+  "minio_bucket": "josh-batch-storage"
+}
+```
+
+**Kubernetes target** (GKE, Nautilus/NRP, EKS, any K8s cluster):
+```json
+{
+  "type": "kubernetes",
+  "kubernetes": {
+    "context": "nautilus",
+    "namespace": "joshsim-lab",
+    "image": "ghcr.io/schmidtdse/joshsim-job:latest",
+    "pod_minio_endpoint": "https://storage.googleapis.com",
+    "resources": {
+      "requests": { "cpu": "2", "memory": "4Gi" },
+      "limits": { "memory": "256Gi" }
+    },
+    "parallelism": 10,
+    "timeoutSeconds": 3600
+  },
+  "minio_endpoint": "https://storage.googleapis.com",
+  "minio_bucket": "josh-batch-storage"
+}
+```
+
+**Credential resolution:** MinIO credentials (`minio_endpoint`, `minio_access_key`, `minio_secret_key`, `minio_bucket`) are resolved via `HierarchyConfig` in priority order: CLI flags > profile JSON > environment variables (`MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`). Secrets do not need to live in the profile JSON — they can come entirely from the environment.
+
+**Pod MinIO endpoint:** Kubernetes targets require `pod_minio_endpoint` in the kubernetes config block — the MinIO endpoint that pods use inside the cluster. This may differ from the outer `minio_endpoint` used by the host for staging (e.g., `http://minio.namespace.svc:9000` vs `https://storage.googleapis.com`).
+
+**Kubernetes Job details:** `batchRemote` with a K8s target creates an indexed Job (`completionMode: Indexed`) where each pod runs one replicate. MinIO credentials are stored in a per-job K8s Secret (`josh-creds-<jobId>`) and referenced via `secretKeyRef`. Pods run `entrypoint.sh` which calls `stageFromMinio` to download inputs, then `run` to execute the simulation. Infrastructure failures (OOMKill, ImagePullBackOff, scheduling failures) are detected by polling the K8s Job API.
+
+#### `stageToMinio` - Upload Files to MinIO
+Uploads local files to MinIO for batch job staging.
+
+```bash
+java -jar joshsim-fat.jar stageToMinio --input-dir=<dir> --prefix=<prefix> [MinioOptions]
+```
+
+**Options:**
+- `--input-dir <dir>`: Local directory containing files to upload
+- `--prefix <prefix>`: MinIO object prefix (e.g., `batch-jobs/abc/inputs/`)
+- MinIO options: `--minio-endpoint`, `--minio-access-key`, `--minio-secret-key`, `--minio-bucket`, or environment variables
+
+#### `stageFromMinio` - Download Files from MinIO
+Downloads all objects under a MinIO prefix to a local directory.
+
+```bash
+java -jar joshsim-fat.jar stageFromMinio --prefix=<prefix> --output-dir=<dir> [MinioOptions]
+```
+
+**Options:**
+- `--prefix <prefix>`: MinIO object prefix to download from
+- `--output-dir <dir>`: Local directory to download files into
+- MinIO options: same as `stageToMinio`
+
 ### Global Options
 
 All commands support these global options:

--- a/src/main/java/org/joshsim/pipeline/target/KubernetesPollingStrategy.java
+++ b/src/main/java/org/joshsim/pipeline/target/KubernetesPollingStrategy.java
@@ -230,7 +230,9 @@ public class KubernetesPollingStrategy implements BatchPollingStrategy {
     }
 
     ContainerStateTerminated terminated = state.getTerminated();
-    if (terminated != null && terminated.getReason() != null) {
+    if (terminated != null && terminated.getReason() != null
+        && terminated.getExitCode() != null
+        && terminated.getExitCode() != 0) {
       return terminated.getReason();
     }
 

--- a/src/main/java/org/joshsim/pipeline/target/KubernetesPollingStrategy.java
+++ b/src/main/java/org/joshsim/pipeline/target/KubernetesPollingStrategy.java
@@ -27,9 +27,11 @@ import java.util.List;
  * errors) that never reach the MinIO status file because the
  * container process is killed or never starts.</p>
  *
- * <p>Pod-level inspection is performed only when the Job has a
- * {@code Failed} condition, minimizing K8s API calls during normal
- * execution.</p>
+ * <p>Pod-level inspection is performed when the Job has a
+ * {@code Failed} condition, and also when the Job is active —
+ * if all active pods are stuck (ImagePullBackOff, CrashLoopBackOff,
+ * Unschedulable), reports an error immediately rather than waiting
+ * for the deadline to expire.</p>
  */
 public class KubernetesPollingStrategy implements BatchPollingStrategy {
 
@@ -91,6 +93,12 @@ public class KubernetesPollingStrategy implements BatchPollingStrategy {
 
     Integer active = job.getStatus().getActive();
     if (active != null && active > 0) {
+      String stuckReason = checkAllPodsStuck(job);
+      if (stuckReason != null) {
+        return new JobStatus(
+            JobStatus.State.ERROR, stuckReason, null
+        );
+      }
       return new JobStatus(JobStatus.State.RUNNING);
     }
 
@@ -128,6 +136,32 @@ public class KubernetesPollingStrategy implements BatchPollingStrategy {
     }
 
     return "Job failed";
+  }
+
+  private String checkAllPodsStuck(Job job) {
+    String jobName = job.getMetadata().getName();
+
+    List<Pod> pods = client.pods()
+        .inNamespace(namespace)
+        .withLabel("job-name", jobName)
+        .list()
+        .getItems();
+
+    if (pods.isEmpty()) {
+      return null;
+    }
+
+    String firstReason = null;
+    for (Pod pod : pods) {
+      String reason = inspectPod(pod);
+      if (reason == null) {
+        return null;
+      }
+      if (firstReason == null) {
+        firstReason = reason;
+      }
+    }
+    return firstReason;
   }
 
   private String getPodFailureDetail(Job job) {

--- a/src/main/java/org/joshsim/pipeline/target/KubernetesTarget.java
+++ b/src/main/java/org/joshsim/pipeline/target/KubernetesTarget.java
@@ -165,6 +165,10 @@ public class KubernetesTarget implements RemoteBatchTarget {
   private void createSecret(String secretName) {
     Map<String, String> resolved =
         minioOptions.getResolvedCredentials();
+    // Pods use the explicit pod endpoint, not the host-resolved one
+    resolved.put(
+        "MINIO_ENDPOINT", config.getPodMinioEndpoint()
+    );
     Map<String, String> data = new HashMap<>();
     resolved.forEach(
         (k, v) -> data.put(k, encode(v))

--- a/src/main/java/org/joshsim/pipeline/target/KubernetesTargetConfig.java
+++ b/src/main/java/org/joshsim/pipeline/target/KubernetesTargetConfig.java
@@ -43,6 +43,9 @@ public class KubernetesTargetConfig {
   @JsonProperty("jarPath")
   private String jarPath;
 
+  @JsonProperty("pod_minio_endpoint")
+  private String podMinioEndpoint;
+
   /**
    * Default constructor for Jackson deserialization.
    */
@@ -119,5 +122,20 @@ public class KubernetesTargetConfig {
       return "/app/joshsim-fat.jar";
     }
     return jarPath;
+  }
+
+  /**
+   * Returns the MinIO endpoint that pods use inside the cluster.
+   *
+   * <p>Required for K8s targets. Pods often have a different
+   * network path to MinIO than the host running {@code batchRemote}
+   * (e.g., cluster DNS {@code http://minio.ns.svc:9000} vs public
+   * URL {@code https://storage.googleapis.com}). This value goes
+   * into the K8s Secret that pods read.</p>
+   *
+   * @return The pod-facing MinIO endpoint, or null if not set.
+   */
+  public String getPodMinioEndpoint() {
+    return podMinioEndpoint;
   }
 }

--- a/src/main/java/org/joshsim/pipeline/target/TargetProfileLoader.java
+++ b/src/main/java/org/joshsim/pipeline/target/TargetProfileLoader.java
@@ -88,5 +88,19 @@ public class TargetProfileLoader {
               + "but is missing 'kubernetes' config block"
       );
     }
+
+    if ("kubernetes".equals(type) && profile.getKubernetesConfig() != null) {
+      String podEndpoint =
+          profile.getKubernetesConfig().getPodMinioEndpoint();
+      if (podEndpoint == null || podEndpoint.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Target profile '" + name + "' has type 'kubernetes'"
+                + " but is missing required 'pod_minio_endpoint'"
+                + " in the 'kubernetes' config block. Pods need"
+                + " an explicit MinIO endpoint (may differ from"
+                + " the host endpoint)."
+        );
+      }
+    }
   }
 }

--- a/src/test/java/org/joshsim/pipeline/target/KubernetesPollingStrategyTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/KubernetesPollingStrategyTest.java
@@ -119,6 +119,50 @@ class KubernetesPollingStrategyTest {
   }
 
   @Test
+  void pollReportsErrorWhenAllPodsStuck() throws Exception {
+    when(mockJobResource.get()).thenReturn(
+        new JobBuilder()
+            .withNewMetadata().withName(JOB_NAME).endMetadata()
+            .withNewSpec().endSpec()
+            .withStatus(new JobStatusBuilder()
+                .withActive(1)
+                .build())
+            .build()
+    );
+
+    when(mockLabeledPods.list()).thenReturn(
+        new PodListBuilder()
+            .withItems(new PodBuilder()
+                .withNewMetadata()
+                    .withName("josh-pod-0")
+                .endMetadata()
+                .withNewStatus()
+                    .withContainerStatuses(
+                        new ContainerStatusBuilder()
+                            .withName("joshsim")
+                            .withState(new ContainerStateBuilder()
+                                .withNewWaiting()
+                                    .withReason("ImagePullBackOff")
+                                    .withMessage(
+                                        "image not found"
+                                    )
+                                .endWaiting()
+                                .build())
+                            .build())
+                .endStatus()
+                .build())
+            .build()
+    );
+
+    JobStatus status = strategy.poll(JOB_ID);
+
+    assertEquals(JobStatus.State.ERROR, status.getState());
+    assertTrue(
+        status.getMessage().get().contains("ImagePullBackOff")
+    );
+  }
+
+  @Test
   void pollReturnsCompleteOnCompleteCondition() throws Exception {
     when(mockJobResource.get()).thenReturn(
         new JobBuilder()

--- a/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
@@ -52,6 +52,8 @@ class KubernetesTargetTest {
   private static final String PREFIX =
       "batch-jobs/abc-123-def/inputs/";
   private static final String SIMULATION = "Main";
+  private static final String POD_ENDPOINT =
+      "http://minio.default.svc:9000";
 
   private KubernetesClient mockClient;
   private ScalableResource mockJobResource;
@@ -144,7 +146,13 @@ class KubernetesTargetTest {
         secret.getMetadata().getName()
     );
     Map<String, String> data = secret.getData();
-    assertNotNull(data.get("MINIO_ENDPOINT"));
+    // Secret should use pod endpoint, not host endpoint
+    String decodedEndpoint = new String(
+        java.util.Base64.getDecoder().decode(
+            data.get("MINIO_ENDPOINT")
+        )
+    );
+    assertEquals(POD_ENDPOINT, decodedEndpoint);
     assertNotNull(data.get("MINIO_ACCESS_KEY"));
     assertNotNull(data.get("MINIO_SECRET_KEY"));
     assertNotNull(data.get("MINIO_BUCKET"));
@@ -311,6 +319,7 @@ class KubernetesTargetTest {
       setField(cfg, "resources", resources);
       setField(cfg, "parallelism", parallelism);
       setField(cfg, "timeoutSeconds", timeout);
+      setField(cfg, "podMinioEndpoint", POD_ENDPOINT);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/org/joshsim/pipeline/target/TargetProfileLoaderTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/TargetProfileLoaderTest.java
@@ -70,7 +70,8 @@ class TargetProfileLoaderTest {
               "limits": { "memory": "256Gi" }
             },
             "parallelism": 10,
-            "timeoutSeconds": 3600
+            "timeoutSeconds": 3600,
+            "pod_minio_endpoint": "http://minio.joshsim-lab.svc:9000"
           },
           "minio_endpoint": "https://minio.example.com",
           "minio_access_key": "k8s-access",
@@ -153,6 +154,29 @@ class TargetProfileLoaderTest {
         IllegalArgumentException.class, () -> loader.load("bad-k8s")
     );
     assertTrue(exception.getMessage().contains("missing 'kubernetes' config block"));
+  }
+
+  @Test
+  void throwsOnK8sWithoutPodMinioEndpoint() throws Exception {
+    writeProfile("k8s-no-pod-ep", """
+        {
+          "type": "kubernetes",
+          "kubernetes": {
+            "context": "test",
+            "namespace": "default",
+            "image": "test:latest",
+            "parallelism": 1,
+            "timeoutSeconds": 60
+          },
+          "minio_endpoint": "https://example.com"
+        }
+        """);
+    TargetProfileLoader loader = new TargetProfileLoader(tempDir);
+    IllegalArgumentException ex = assertThrows(
+        IllegalArgumentException.class,
+        () -> loader.load("k8s-no-pod-ep")
+    );
+    assertTrue(ex.getMessage().contains("pod_minio_endpoint"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Adds `cloud-img/Dockerfile.batch` — minimal JRE-only batch worker image with `entrypoint.sh`
- Adds required `pod_minio_endpoint` field to `KubernetesTargetConfig` — pods often have a different network path to MinIO than the host (cluster DNS vs public URL). Validated by `TargetProfileLoader`.
- Adds `.github/workflows/test-k8s.yaml` — end-to-end Kind cluster + MinIO integration test: builds batch image, creates Kind cluster, deploys MinIO, runs `batchRemote` with K8s target, verifies Job completion + results in MinIO, tests ImagePullBackOff failure detection.

## Context

PR 8 in the batch remote execution sequence ([#374](https://github.com/SchmidtDSE/josh/issues/374)). Targets `feat/k8s-batch`. Builds on PR 7's `KubernetesTarget`, `KubernetesPollingStrategy`, and HierarchyConfig credential routing.

The `pod_minio_endpoint` solves a real networking issue: the host running `batchRemote` and K8s pods often have different paths to MinIO. For example, GCS at `https://storage.googleapis.com` works from everywhere, but a cluster-internal MinIO is only reachable at `http://minio.namespace.svc:9000`. Making this field required forces users to explicitly confirm the pod-facing endpoint.

## Test plan

- [x] `./gradlew test` — all tests pass (including new pod_minio_endpoint + validation tests)
- [x] `./gradlew checkstyleMain checkstyleTest` — zero errors
- [x] `./gradlew fatJar` — builds
- [x] `test-k8s.yaml` CI — Kind cluster e2e (first run with this PR)
- [ ] Failure detection: bad image → ImagePullBackOff

🤖 Generated with [Claude Code](https://claude.com/claude-code)