### PR TITLE
fix: lower profiler ON_THRESHOLD_MS to 0.0 to fix flaky CI test

### DIFF
--- a/.github/scripts/check_profiler.py
+++ b/.github/scripts/check_profiler.py
@@ -2,12 +2,11 @@
 
 Usage: python3 check_profiler.py <on|off>
 
-  on  -- asserts that at least one row has avgHeightEvalDuration > 0.1 ms,
+  on  -- asserts that at least one row has avgHeightEvalDuration > 0.0 ms,
          confirming the profiler was active and capturing real timing data.
          When the profiler is disabled, all values are exactly 0.0; when
-         enabled, values are consistently above 0.1 ms because the simulation
-         uses 50 TimedTree agents per patch, giving each mean() call enough
-         evaluations to produce a meaningful timing even on fast hardware.
+         enabled, values are non-zero. Using > 0.0 avoids false failures on
+         fast CI runners where durations can be very small but still non-zero.
 
   off -- asserts that every row has avgHeightEvalDuration < 1.0 ms,
          confirming the profiler was not enabled during the simulation run.
@@ -16,7 +15,7 @@ Usage: python3 check_profiler.py <on|off>
 import csv
 import sys
 
-ON_THRESHOLD_MS = 0.1
+ON_THRESHOLD_MS = 0.0
 OFF_THRESHOLD_MS = 1.0
 
 if len(sys.argv) < 2 or sys.argv[1] not in ('on', 'off'):
@@ -44,13 +43,13 @@ if mode == 'on':
 
     if not found:
         print(
-            f'FAIL: no row has avgHeightEvalDuration > {ON_THRESHOLD_MS} ms '
-            f'({row_count} rows checked)'
+            f'FAIL: no row has avgHeightEvalDuration > {ON_THRESHOLD_MS} '
+            f'(profiler appears inactive; {row_count} rows checked)'
         )
         sys.exit(1)
 
     print(
-        f'PASS: at least one row has avgHeightEvalDuration > {ON_THRESHOLD_MS} ms '
+        f'PASS: at least one row has avgHeightEvalDuration > {ON_THRESHOLD_MS} '
         f'({row_count} rows checked)'
     )
     sys.exit(0)


### PR DESCRIPTION
## Summary

Fixes #401 — intermittent CI failure in `run_profiler_remote.sh`.

- Lowers `ON_THRESHOLD_MS` from `0.1` to `0.0` in `.github/scripts/check_profiler.py`
- The `on` mode now checks `avgHeightEvalDuration > 0.0` instead of `> 0.1`

## Rationale

The 0.1 ms threshold was failing on fast CI runners where the profiler is active but produces very small (sub-0.1 ms) timings. Since the profiler outputs exactly `0.0` for all rows when disabled, checking `> 0.0` is the correct semantic test: any non-zero value confirms the profiler was active and recording real data, regardless of hardware speed.

## Test plan

- [ ] CI passes on `run_profiler_remote.sh on` — at least one row has `avgHeightEvalDuration > 0.0`
- [ ] CI passes on `run_profiler_remote.sh off` — all rows remain `< 1.0 ms` (unchanged)

https://claude.ai/code/session_01RD5xQKtbNWg3oe4hcCoCWd