### PR TITLE
Add Spot pod support and Job TTL cleanup for K8s targets

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -352,12 +352,18 @@ Target profiles are JSON files at `~/.josh/targets/<name>.json` that define a co
       "limits": { "memory": "256Gi" }
     },
     "parallelism": 10,
-    "timeoutSeconds": 3600
+    "timeoutSeconds": 3600,
+    "spot": true,
+    "ttlSecondsAfterFinished": 3600
   },
   "minio_endpoint": "https://storage.googleapis.com",
   "minio_bucket": "josh-batch-storage"
 }
 ```
+
+**Spot pods:** Set `"spot": true` in the kubernetes config block to schedule pods on Spot (preemptible) VMs for 60-90% cost savings. The Job spec gets a `cloud.google.com/gke-spot` node selector and toleration. Preempted pods are retried via `backoffLimit`. GKE Autopilot only.
+
+**Job TTL cleanup:** Set `"ttlSecondsAfterFinished": <seconds>` to automatically delete completed/failed Jobs after the specified duration. Prevents accumulation of finished Jobs in the namespace. Omit or set to null to disable.
 
 **Credential resolution:** MinIO credentials (`minio_endpoint`, `minio_access_key`, `minio_secret_key`, `minio_bucket`) are resolved via `HierarchyConfig` in priority order: CLI flags > profile JSON > environment variables (`MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`). Secrets do not need to live in the profile JSON — they can come entirely from the environment.
 

--- a/src/main/java/org/joshsim/pipeline/target/KubernetesPreprocessTarget.java
+++ b/src/main/java/org/joshsim/pipeline/target/KubernetesPreprocessTarget.java
@@ -13,6 +13,8 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.Toleration;
+import io.fabric8.kubernetes.api.model.TolerationBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.client.Config;
@@ -86,7 +88,7 @@ public class KubernetesPreprocessTarget implements RemotePreprocessTarget {
 
     createSecret(secretName);
 
-    Job job = new JobBuilder()
+    JobBuilder jobBuilder = new JobBuilder()
         .withNewMetadata()
             .withName(JOB_NAME_PREFIX + jobId)
             .withNamespace(config.getNamespace())
@@ -100,6 +102,9 @@ public class KubernetesPreprocessTarget implements RemotePreprocessTarget {
             .withBackoffLimit(BACKOFF_LIMIT)
             .withActiveDeadlineSeconds(
                 (long) config.getTimeoutSeconds()
+            )
+            .withTtlSecondsAfterFinished(
+                config.getTtlSecondsAfterFinished()
             )
             .withNewTemplate()
                 .withNewSpec()
@@ -121,8 +126,13 @@ public class KubernetesPreprocessTarget implements RemotePreprocessTarget {
                     .endContainer()
                 .endSpec()
             .endTemplate()
-        .endSpec()
-        .build();
+        .endSpec();
+
+    if (config.isSpot()) {
+      applySpotConfig(jobBuilder);
+    }
+
+    Job job = jobBuilder.build();
 
     client.batch().v1().jobs()
         .inNamespace(config.getNamespace())
@@ -284,6 +294,25 @@ public class KubernetesPreprocessTarget implements RemotePreprocessTarget {
       reqs.setLimits(limits);
     }
     return reqs;
+  }
+
+  private void applySpotConfig(JobBuilder jobBuilder) {
+    Toleration spotToleration = new TolerationBuilder()
+        .withKey("cloud.google.com/gke-spot")
+        .withOperator("Equal")
+        .withValue("true")
+        .withEffect("NoSchedule")
+        .build();
+    jobBuilder.editSpec()
+        .editTemplate()
+            .editSpec()
+                .addToNodeSelector(
+                    "cloud.google.com/gke-spot", "true"
+                )
+                .addToTolerations(spotToleration)
+            .endSpec()
+        .endTemplate()
+        .endSpec();
   }
 
   private static KubernetesClient buildClient(String context) {

--- a/src/main/java/org/joshsim/pipeline/target/KubernetesTarget.java
+++ b/src/main/java/org/joshsim/pipeline/target/KubernetesTarget.java
@@ -13,6 +13,8 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.Toleration;
+import io.fabric8.kubernetes.api.model.TolerationBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.client.Config;
@@ -95,7 +97,7 @@ public class KubernetesTarget implements RemoteBatchTarget {
 
     createSecret(secretName);
 
-    Job job = new JobBuilder()
+    JobBuilder jobBuilder = new JobBuilder()
         .withNewMetadata()
             .withName(JOB_NAME_PREFIX + jobId)
             .withNamespace(config.getNamespace())
@@ -111,6 +113,9 @@ public class KubernetesTarget implements RemoteBatchTarget {
             .withBackoffLimit(BACKOFF_LIMIT)
             .withActiveDeadlineSeconds(
                 (long) config.getTimeoutSeconds()
+            )
+            .withTtlSecondsAfterFinished(
+                config.getTtlSecondsAfterFinished()
             )
             .withNewTemplate()
                 .withNewSpec()
@@ -132,8 +137,13 @@ public class KubernetesTarget implements RemoteBatchTarget {
                     .endContainer()
                 .endSpec()
             .endTemplate()
-        .endSpec()
-        .build();
+        .endSpec();
+
+    if (config.isSpot()) {
+      applySpotConfig(jobBuilder);
+    }
+
+    Job job = jobBuilder.build();
 
     client.batch().v1().jobs()
         .inNamespace(config.getNamespace())
@@ -275,6 +285,25 @@ public class KubernetesTarget implements RemoteBatchTarget {
       reqs.setLimits(limits);
     }
     return reqs;
+  }
+
+  private void applySpotConfig(JobBuilder jobBuilder) {
+    Toleration spotToleration = new TolerationBuilder()
+        .withKey("cloud.google.com/gke-spot")
+        .withOperator("Equal")
+        .withValue("true")
+        .withEffect("NoSchedule")
+        .build();
+    jobBuilder.editSpec()
+        .editTemplate()
+            .editSpec()
+                .addToNodeSelector(
+                    "cloud.google.com/gke-spot", "true"
+                )
+                .addToTolerations(spotToleration)
+            .endSpec()
+        .endTemplate()
+        .endSpec();
   }
 
   private static KubernetesClient buildClient(String context) {

--- a/src/main/java/org/joshsim/pipeline/target/KubernetesTargetConfig.java
+++ b/src/main/java/org/joshsim/pipeline/target/KubernetesTargetConfig.java
@@ -46,6 +46,12 @@ public class KubernetesTargetConfig {
   @JsonProperty("pod_minio_endpoint")
   private String podMinioEndpoint;
 
+  @JsonProperty("spot")
+  private boolean spot;
+
+  @JsonProperty("ttlSecondsAfterFinished")
+  private Integer ttlSecondsAfterFinished;
+
   /**
    * Default constructor for Jackson deserialization.
    */
@@ -137,5 +143,31 @@ public class KubernetesTargetConfig {
    */
   public String getPodMinioEndpoint() {
     return podMinioEndpoint;
+  }
+
+  /**
+   * Returns whether pods should run on Spot (preemptible) VMs.
+   *
+   * <p>When true, the Job spec includes a {@code gke-spot} node selector
+   * and toleration, enabling 60-90% cost savings for batch workloads.
+   * Preempted pods are retried via {@code backoffLimit}.</p>
+   *
+   * @return True if pods should use Spot VMs.
+   */
+  public boolean isSpot() {
+    return spot;
+  }
+
+  /**
+   * Returns the TTL in seconds for automatic Job cleanup after completion.
+   *
+   * <p>When set, K8s automatically deletes the Job and its pods this many
+   * seconds after the Job finishes (succeeded or failed). Prevents
+   * accumulation of completed Jobs in the namespace.</p>
+   *
+   * @return The TTL in seconds, or null to disable automatic cleanup.
+   */
+  public Integer getTtlSecondsAfterFinished() {
+    return ttlSecondsAfterFinished;
   }
 }

--- a/src/test/java/org/joshsim/pipeline/target/KubernetesPreprocessTargetTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/KubernetesPreprocessTargetTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.BatchAPIGroupDSL;
@@ -219,6 +220,53 @@ class KubernetesPreprocessTargetTest {
 
     Job job = jobCaptor.getValue();
     assertNull(getContainer(job).getResources());
+  }
+
+  @Test
+  void dispatchSetsSpotNodeSelectorAndToleration() throws Exception {
+    config = buildConfig(10, 3600, null);
+    setField(config, "spot", true);
+
+    KubernetesPreprocessTarget target = buildTarget(config);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, buildParams());
+
+    Job job = jobCaptor.getValue();
+    Map<String, String> nodeSelector =
+        job.getSpec().getTemplate().getSpec().getNodeSelector();
+    assertNotNull(nodeSelector);
+    assertEquals("true", nodeSelector.get("cloud.google.com/gke-spot"));
+
+    List<Toleration> tolerations = job.getSpec()
+        .getTemplate().getSpec().getTolerations();
+    assertNotNull(tolerations);
+    assertTrue(tolerations.stream().anyMatch(
+        t -> "cloud.google.com/gke-spot".equals(t.getKey())
+    ));
+  }
+
+  @Test
+  void dispatchOmitsSpotWhenFalse() throws Exception {
+    config = buildConfig(10, 3600, null);
+
+    KubernetesPreprocessTarget target = buildTarget(config);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, buildParams());
+
+    Job job = jobCaptor.getValue();
+    Map<String, String> nodeSelector =
+        job.getSpec().getTemplate().getSpec().getNodeSelector();
+    assertTrue(nodeSelector == null || nodeSelector.isEmpty());
+  }
+
+  @Test
+  void dispatchSetsTtlSecondsAfterFinished() throws Exception {
+    config = buildConfig(10, 3600, null);
+    setField(config, "ttlSecondsAfterFinished", 600);
+
+    KubernetesPreprocessTarget target = buildTarget(config);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, buildParams());
+
+    Job job = jobCaptor.getValue();
+    assertEquals(600, job.getSpec().getTtlSecondsAfterFinished());
   }
 
   // --- Helpers ---

--- a/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.BatchAPIGroupDSL;
@@ -267,6 +268,65 @@ class KubernetesTargetTest {
     assertEquals(
         "joshsim",
         job.getMetadata().getLabels().get("app")
+    );
+  }
+
+  @Test
+  void dispatchSetsSpotNodeSelectorAndToleration()
+      throws Exception {
+    config = buildConfig(10, 3600, null);
+    setField(config, "spot", true);
+
+    KubernetesTarget target = buildTarget(config);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+
+    Job job = jobCaptor.getValue();
+    Map<String, String> nodeSelector =
+        job.getSpec().getTemplate().getSpec()
+            .getNodeSelector();
+    assertNotNull(nodeSelector);
+    assertEquals(
+        "true",
+        nodeSelector.get("cloud.google.com/gke-spot")
+    );
+
+    List<Toleration> tolerations = job.getSpec()
+        .getTemplate().getSpec().getTolerations();
+    assertNotNull(tolerations);
+    assertTrue(tolerations.stream().anyMatch(
+        t -> "cloud.google.com/gke-spot".equals(t.getKey())
+    ));
+  }
+
+  @Test
+  void dispatchOmitsSpotWhenFalse() throws Exception {
+    config = buildConfig(10, 3600, null);
+
+    KubernetesTarget target = buildTarget(config);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+
+    Job job = jobCaptor.getValue();
+    Map<String, String> nodeSelector =
+        job.getSpec().getTemplate().getSpec()
+            .getNodeSelector();
+    assertTrue(
+        nodeSelector == null || nodeSelector.isEmpty()
+    );
+  }
+
+  @Test
+  void dispatchSetsTtlSecondsAfterFinished()
+      throws Exception {
+    config = buildConfig(10, 3600, null);
+    setField(config, "ttlSecondsAfterFinished", 600);
+
+    KubernetesTarget target = buildTarget(config);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+
+    Job job = jobCaptor.getValue();
+    assertEquals(
+        600,
+        job.getSpec().getTtlSecondsAfterFinished()
     );
   }
 


### PR DESCRIPTION
## Summary
- Add `spot` (boolean) field to K8s target profiles — schedules pods on GKE Spot VMs via `cloud.google.com/gke-spot` node selector + toleration for 60-90% cost savings on batch workloads
- Add `ttlSecondsAfterFinished` (integer) field — auto-deletes completed/failed Jobs after the specified duration to prevent namespace accumulation
- Applied to both `KubernetesTarget` (run) and `KubernetesPreprocessTarget` (preprocess)

## Target profile example
```json
{
  "type": "kubernetes",
  "kubernetes": {
    "spot": true,
    "ttlSecondsAfterFinished": 3600,
    ...
  }
}
```

Both fields are optional with safe defaults (spot=false, TTL=null/disabled).

## Test plan
- [x] `KubernetesTargetTest`: spot node selector + toleration set when true, omitted when false, TTL propagated
- [x] `KubernetesPreprocessTargetTest`: same three tests
- [x] `./gradlew test checkstyleMain checkstyleTest` — all pass
- [x] Existing tests unchanged

Ref: SchmidtDSE/fire-recovery-iac#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)