### PR TITLE
Add pollBatch CLI command + structured --no-wait output

### DIFF
--- a/src/main/java/org/joshsim/JoshSimCommander.java
+++ b/src/main/java/org/joshsim/JoshSimCommander.java
@@ -18,6 +18,7 @@ import org.joshsim.command.BatchRemoteCommand;
 import org.joshsim.command.DiscoverConfigCommand;
 import org.joshsim.command.InspectExportsCommand;
 import org.joshsim.command.InspectJshdCommand;
+import org.joshsim.command.PollBatchCommand;
 import org.joshsim.command.PreprocessBatchCommand;
 import org.joshsim.command.PreprocessCommand;
 import org.joshsim.command.RunCommand;
@@ -68,6 +69,7 @@ import picocli.CommandLine;
         StageToMinioCommand.class,
         StageFromMinioCommand.class,
         BatchRemoteCommand.class,
+        PollBatchCommand.class,
         PreprocessBatchCommand.class
     }
 )

--- a/src/main/java/org/joshsim/command/BatchRemoteCommand.java
+++ b/src/main/java/org/joshsim/command/BatchRemoteCommand.java
@@ -124,9 +124,16 @@ public class BatchRemoteCommand implements Callable<Integer> {
       File inputDir = resolveInputDir();
 
       if (noWait) {
-        String jobId = strategy.executeNoWait(inputDir, simulation, replicates);
-        output.printInfo("Job dispatched: " + jobId);
-        output.printInfo("Poll manually: batch-status/" + jobId + "/status.json");
+        String jobId = strategy.executeNoWait(
+            inputDir, simulation, replicates
+        );
+        String statusPath = "batch-status/" + jobId
+            + "/status.json";
+        System.out.println(
+            "{\"jobId\":\"" + jobId
+            + "\",\"target\":\"" + targetName
+            + "\",\"statusPath\":\"" + statusPath + "\"}"
+        );
         return 0;
       }
 

--- a/src/main/java/org/joshsim/command/BatchRemoteCommand.java
+++ b/src/main/java/org/joshsim/command/BatchRemoteCommand.java
@@ -6,6 +6,8 @@
 
 package org.joshsim.command;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.util.concurrent.Callable;
 import org.joshsim.pipeline.target.BatchJobStrategy;
@@ -42,6 +44,7 @@ public class BatchRemoteCommand implements Callable<Integer> {
 
   private static final int TARGET_ERROR_CODE = 100;
   private static final int DISPATCH_ERROR_CODE = 101;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   @Parameters(index = "0", description = "Path to Josh simulation file or input directory")
   private File input;
@@ -127,13 +130,14 @@ public class BatchRemoteCommand implements Callable<Integer> {
         String jobId = strategy.executeNoWait(
             inputDir, simulation, replicates
         );
-        String statusPath = "batch-status/" + jobId
-            + "/status.json";
-        System.out.println(
-            "{\"jobId\":\"" + jobId
-            + "\",\"target\":\"" + targetName
-            + "\",\"statusPath\":\"" + statusPath + "\"}"
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("jobId", jobId);
+        node.put("target", targetName);
+        node.put(
+            "statusPath",
+            "batch-status/" + jobId + "/status.json"
         );
+        System.out.println(node.toString());
         return 0;
       }
 

--- a/src/main/java/org/joshsim/command/PollBatchCommand.java
+++ b/src/main/java/org/joshsim/command/PollBatchCommand.java
@@ -1,0 +1,115 @@
+/**
+ * Command for polling the status of a dispatched batch job.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.command;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.concurrent.Callable;
+import org.joshsim.pipeline.target.BatchPollingStrategy;
+import org.joshsim.pipeline.target.JobStatus;
+import org.joshsim.pipeline.target.TargetProfile;
+import org.joshsim.pipeline.target.TargetProfileLoader;
+import org.joshsim.util.OutputOptions;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+
+/**
+ * Polls the status of a previously dispatched batch job.
+ *
+ * <p>Single-shot status check — loads the target profile, queries the
+ * appropriate status source (MinIO status file for HTTP targets, K8s
+ * Job API for Kubernetes targets), and outputs JSON to stdout. The
+ * caller (joshpy) handles polling intervals and retry logic.</p>
+ *
+ * <p>Exit codes: 0 = complete, 1 = error, 2 = running/pending.</p>
+ */
+@Command(
+    name = "pollBatch",
+    description = "Check the status of a dispatched batch job"
+)
+public class PollBatchCommand implements Callable<Integer> {
+
+  static final int EXIT_COMPLETE = 0;
+  static final int EXIT_ERROR = 1;
+  static final int EXIT_RUNNING = 2;
+  private static final int EXIT_POLL_FAILURE = 100;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Parameters(
+      index = "0",
+      description = "Job ID returned by batchRemote --no-wait"
+  )
+  private String jobId;
+
+  @Option(
+      names = "--target",
+      description = "Target profile name "
+          + "(loads ~/.josh/targets/<name>.json)",
+      required = true
+  )
+  private String targetName;
+
+  @Mixin
+  private OutputOptions output = new OutputOptions();
+
+  @Override
+  public Integer call() {
+    try {
+      TargetProfileLoader loader = new TargetProfileLoader();
+      TargetProfile profile = loader.load(targetName);
+      BatchPollingStrategy poller =
+          profile.buildPollingStrategy(output);
+
+      JobStatus status = poller.poll(jobId);
+
+      System.out.println(formatJson(status));
+      return exitCodeFor(status.getState());
+
+    } catch (Exception e) {
+      output.printError(
+          "pollBatch failed: " + e.getMessage()
+      );
+      return EXIT_POLL_FAILURE;
+    }
+  }
+
+  String formatJson(JobStatus status) {
+    ObjectNode node = MAPPER.createObjectNode();
+    node.put("status", status.getState().name().toLowerCase());
+    node.put("jobId", jobId);
+
+    status.getMessage().ifPresent(
+        msg -> node.put("message", msg)
+    );
+
+    status.getTimestamp().ifPresent(ts -> {
+      String key = timestampKeyFor(status.getState());
+      node.put(key, ts);
+    });
+
+    return node.toString();
+  }
+
+  static int exitCodeFor(JobStatus.State state) {
+    return switch (state) {
+      case COMPLETE -> EXIT_COMPLETE;
+      case ERROR -> EXIT_ERROR;
+      case RUNNING, PENDING -> EXIT_RUNNING;
+    };
+  }
+
+  private static String timestampKeyFor(JobStatus.State state) {
+    return switch (state) {
+      case RUNNING, PENDING -> "startedAt";
+      case COMPLETE -> "completedAt";
+      case ERROR -> "failedAt";
+    };
+  }
+}

--- a/src/main/java/org/joshsim/pipeline/target/TargetProfile.java
+++ b/src/main/java/org/joshsim/pipeline/target/TargetProfile.java
@@ -8,6 +8,9 @@ package org.joshsim.pipeline.target;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.joshsim.util.MinioHandler;
 import org.joshsim.util.MinioOptions;
 import org.joshsim.util.OutputOptions;
@@ -132,5 +135,40 @@ public class TargetProfile {
   public MinioHandler buildMinioHandler(OutputOptions output)
       throws Exception {
     return new MinioHandler(buildMinioOptions(), output);
+  }
+
+  /**
+   * Creates the appropriate {@link BatchPollingStrategy} for this target.
+   *
+   * <p>HTTP targets use {@link MinioPollingStrategy} (reads status.json
+   * from MinIO). Kubernetes targets use {@link KubernetesPollingStrategy}
+   * (queries the K8s Job API via Fabric8).</p>
+   *
+   * @param output For logging during MinIO handler construction.
+   * @return A polling strategy configured for this target's type.
+   * @throws Exception If strategy construction fails.
+   */
+  public BatchPollingStrategy buildPollingStrategy(
+      OutputOptions output
+  ) throws Exception {
+    if ("http".equals(type)) {
+      return new MinioPollingStrategy(buildMinioHandler(output));
+    } else if ("kubernetes".equals(type)) {
+      KubernetesTargetConfig k8sConfig = getKubernetesConfig();
+      String context = k8sConfig.getContext();
+      Config kubeConfig = (context != null && !context.isEmpty())
+          ? Config.autoConfigure(context)
+          : Config.autoConfigure(null);
+      KubernetesClient client = new KubernetesClientBuilder()
+          .withConfig(kubeConfig)
+          .build();
+      return new KubernetesPollingStrategy(
+          client, k8sConfig.getNamespace()
+      );
+    }
+    throw new IllegalArgumentException(
+        "Unsupported target type for polling: " + type
+        + ". Supported types: http, kubernetes"
+    );
   }
 }

--- a/src/test/java/org/joshsim/command/PollBatchCommandTest.java
+++ b/src/test/java/org/joshsim/command/PollBatchCommandTest.java
@@ -1,0 +1,144 @@
+/**
+ * Tests for PollBatchCommand.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.joshsim.pipeline.target.JobStatus;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Unit tests for {@link PollBatchCommand}.
+ */
+class PollBatchCommandTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void exitCodeForComplete() {
+    assertEquals(
+        PollBatchCommand.EXIT_COMPLETE,
+        PollBatchCommand.exitCodeFor(JobStatus.State.COMPLETE)
+    );
+  }
+
+  @Test
+  void exitCodeForError() {
+    assertEquals(
+        PollBatchCommand.EXIT_ERROR,
+        PollBatchCommand.exitCodeFor(JobStatus.State.ERROR)
+    );
+  }
+
+  @Test
+  void exitCodeForRunning() {
+    assertEquals(
+        PollBatchCommand.EXIT_RUNNING,
+        PollBatchCommand.exitCodeFor(JobStatus.State.RUNNING)
+    );
+  }
+
+  @Test
+  void exitCodeForPending() {
+    assertEquals(
+        PollBatchCommand.EXIT_RUNNING,
+        PollBatchCommand.exitCodeFor(JobStatus.State.PENDING)
+    );
+  }
+
+  @Test
+  void formatJsonComplete() throws Exception {
+    PollBatchCommand cmd = buildCommand("job-42");
+    JobStatus status = new JobStatus(
+        JobStatus.State.COMPLETE,
+        null,
+        "2026-04-15T10:00:00Z"
+    );
+
+    JsonNode node = MAPPER.readTree(cmd.formatJson(status));
+
+    assertEquals("complete", node.get("status").asText());
+    assertEquals("job-42", node.get("jobId").asText());
+    assertEquals(
+        "2026-04-15T10:00:00Z",
+        node.get("completedAt").asText()
+    );
+    assertTrue(node.path("message").isMissingNode());
+  }
+
+  @Test
+  void formatJsonError() throws Exception {
+    PollBatchCommand cmd = buildCommand("job-99");
+    JobStatus status = new JobStatus(
+        JobStatus.State.ERROR,
+        "OOMKilled",
+        "2026-04-15T11:00:00Z"
+    );
+
+    JsonNode node = MAPPER.readTree(cmd.formatJson(status));
+
+    assertEquals("error", node.get("status").asText());
+    assertEquals("job-99", node.get("jobId").asText());
+    assertEquals("OOMKilled", node.get("message").asText());
+    assertEquals(
+        "2026-04-15T11:00:00Z",
+        node.get("failedAt").asText()
+    );
+  }
+
+  @Test
+  void formatJsonRunning() throws Exception {
+    PollBatchCommand cmd = buildCommand("job-7");
+    JobStatus status = new JobStatus(
+        JobStatus.State.RUNNING,
+        null,
+        "2026-04-15T09:00:00Z"
+    );
+
+    JsonNode node = MAPPER.readTree(cmd.formatJson(status));
+
+    assertEquals("running", node.get("status").asText());
+    assertEquals("job-7", node.get("jobId").asText());
+    assertEquals(
+        "2026-04-15T09:00:00Z",
+        node.get("startedAt").asText()
+    );
+  }
+
+  @Test
+  void formatJsonPendingNoTimestamp() throws Exception {
+    PollBatchCommand cmd = buildCommand("job-new");
+    JobStatus status = new JobStatus(JobStatus.State.PENDING);
+
+    JsonNode node = MAPPER.readTree(cmd.formatJson(status));
+
+    assertEquals("pending", node.get("status").asText());
+    assertEquals("job-new", node.get("jobId").asText());
+    assertTrue(node.path("startedAt").isMissingNode());
+    assertTrue(node.path("message").isMissingNode());
+  }
+
+  /**
+   * Creates a PollBatchCommand with the jobId field set via reflection.
+   */
+  private PollBatchCommand buildCommand(String jobId) {
+    try {
+      PollBatchCommand cmd = new PollBatchCommand();
+      java.lang.reflect.Field field =
+          PollBatchCommand.class.getDeclaredField("jobId");
+      field.setAccessible(true);
+      field.set(cmd, jobId);
+      return cmd;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/org/joshsim/pipeline/target/TargetProfileBuildPollerTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/TargetProfileBuildPollerTest.java
@@ -1,0 +1,94 @@
+/**
+ * Tests for TargetProfile.buildPollingStrategy.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.pipeline.target;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.joshsim.util.MinioHandler;
+import org.joshsim.util.OutputOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+
+/**
+ * Unit tests for {@link TargetProfile#buildPollingStrategy}.
+ */
+class TargetProfileBuildPollerTest {
+
+  @TempDir
+  File tempDir;
+
+  @Test
+  void httpTargetReturnsMinioPollingStrategy() throws Exception {
+    TargetProfile profile = spy(loadProfile("http-target", """
+        {
+          "type": "http",
+          "http": {
+            "endpoint": "https://example.com",
+            "apiKey": "key"
+          },
+          "minio_endpoint": "https://storage.example.com",
+          "minio_access_key": "a",
+          "minio_secret_key": "s",
+          "minio_bucket": "b"
+        }
+        """));
+
+    MinioHandler mockHandler = mock(MinioHandler.class);
+    doReturn(mockHandler).when(profile).buildMinioHandler(
+        any(OutputOptions.class)
+    );
+
+    BatchPollingStrategy strategy = profile.buildPollingStrategy(
+        new OutputOptions()
+    );
+
+    assertTrue(strategy instanceof MinioPollingStrategy);
+  }
+
+  @Test
+  void unsupportedTypeThrowsException() throws Exception {
+    TargetProfile profile = loadProfile("bad-target", """
+        {
+          "type": "ssh",
+          "minio_endpoint": "https://storage.example.com",
+          "minio_access_key": "a",
+          "minio_secret_key": "s",
+          "minio_bucket": "b"
+        }
+        """);
+
+    IllegalArgumentException ex = assertThrows(
+        IllegalArgumentException.class,
+        () -> profile.buildPollingStrategy(new OutputOptions())
+    );
+    assertTrue(ex.getMessage().contains("ssh"));
+    assertTrue(
+        ex.getMessage().contains("Unsupported target type")
+    );
+  }
+
+  private TargetProfile loadProfile(
+      String name,
+      String json
+  ) throws IOException {
+    Files.writeString(
+        new File(tempDir, name + ".json").toPath(), json
+    );
+    TargetProfileLoader loader =
+        new TargetProfileLoader(tempDir);
+    return loader.load(name);
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `pollBatch` CLI command from #406 so joshpy can query job status out-of-band after a `batchRemote --no-wait` dispatch. Also makes the `--no-wait` output structured JSON so joshpy can reliably parse the job ID and target.

## What

- **New `pollBatch <jobId> --target=<name>` command** — single-shot status check. Loads the target profile, delegates to the existing `BatchPollingStrategy` (MinIO status file for HTTP targets, K8s Job API for Kubernetes targets), emits JSON to stdout. Exit codes: `0`=complete, `1`=error, `2`=running/pending, `100`=poll failure.
- **`TargetProfile.buildPollingStrategy(OutputOptions)`** — DRY factory so poller construction lives in one place and can be reused by both `BatchRemoteCommand` and `PollBatchCommand`.
- **Structured `batchRemote --no-wait` output** — was plain text (`"Job dispatched: <id>"`), now a single JSON line (`{"jobId":..., "target":..., "statusPath":...}`) so joshpy can parse it robustly.

## Why

joshpy is the stateful orchestrator — it dispatches N batch jobs via `--no-wait`, stores `(job_id, target)` in its RunRegistry, and needs to poll them later (for parallel dispatch, crash recovery, and fire-and-forget workflows). Previously the polling logic was only reachable inside the blocking `batchRemote` flow. The `--target` flag tells josh which polling strategy to use, so joshpy just needs to remember the target name alongside the job ID.

This completes the boundary: josh owns execution and status, joshpy owns orchestration and state.

## Test plan

- [x] New unit tests: exit codes + JSON formatting for all 4 `JobStatus.State` values (`PollBatchCommandTest`)
- [x] New unit tests: HTTP → `MinioPollingStrategy` routing, unsupported-type error (`TargetProfileBuildPollerTest`)
- [ ] `./gradlew test` / `checkstyleMain` / `fatJar` — couldn't run locally (GeoTools repos 403'd in this env); CI will validate
- [ ] Manual: `joshsim pollBatch <jobId> --target=<name>` against a live dispatch

## Example usage

```bash
# joshpy dispatches
$ joshsim batchRemote sim.josh Main --target=cloudrun-prod --no-wait
{"jobId":"abc-123","target":"cloudrun-prod","statusPath":"batch-status/abc-123/status.json"}

# joshpy polls later
$ joshsim pollBatch abc-123 --target=cloudrun-prod
{"status":"complete","jobId":"abc-123","completedAt":"2026-04-15T..."}
$ echo $?
0
```

Closes #406.

https://claude.ai/code/session_01CwQ5RDzhnnJehXL6KRii1w