### PR TITLE
Add CI workflow to build and push batch worker image to GHCR

### DIFF
--- a/.github/workflows/build-batch-image.yaml
+++ b/.github/workflows/build-batch-image.yaml
@@ -1,0 +1,91 @@
+name: Build Batch Worker Image
+
+on:
+  push:
+    branches: [main, dev, feat/k8s-batch]
+    paths:
+      - 'cloud-img/**'
+      - 'src/main/**'
+      - 'build.gradle'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: schmidtdse/josh/joshsim-batch
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    name: Build and push batch worker image
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup netCDF
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libnetcdf-dev
+
+      - name: Build fat jar
+        run: ./gradlew fatJar
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine image tags
+        id: tags
+        run: |
+          SHA_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+          echo "sha_tag=${SHA_TAG}" >> $GITHUB_OUTPUT
+
+          BRANCH=${GITHUB_REF#refs/heads/}
+          BRANCH_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${BRANCH//\//-}"
+          echo "branch_tag=${BRANCH_TAG}" >> $GITHUB_OUTPUT
+
+          if [[ "$BRANCH" == "main" || "$BRANCH" == "dev" ]]; then
+            echo "latest_tag=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
+          else
+            echo "latest_tag=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build Docker image
+        run: |
+          docker build -f cloud-img/Dockerfile.batch \
+            -t ${{ steps.tags.outputs.sha_tag }} \
+            -t ${{ steps.tags.outputs.branch_tag }} \
+            ${{ steps.tags.outputs.latest_tag && format('-t {0}', steps.tags.outputs.latest_tag) }} \
+            .
+
+      - name: Push Docker image
+        run: |
+          docker push ${{ steps.tags.outputs.sha_tag }}
+          docker push ${{ steps.tags.outputs.branch_tag }}
+          if [ -n "${{ steps.tags.outputs.latest_tag }}" ]; then
+            docker push ${{ steps.tags.outputs.latest_tag }}
+          fi
+
+      - name: Image summary
+        run: |
+          echo "### Batch Worker Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- SHA: \`${{ steps.tags.outputs.sha_tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Branch: \`${{ steps.tags.outputs.branch_tag }}\`" >> $GITHUB_STEP_SUMMARY
+          if [ -n "${{ steps.tags.outputs.latest_tag }}" ]; then
+            echo "- Latest: \`${{ steps.tags.outputs.latest_tag }}\`" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Contains both \`run-entrypoint.sh\` and \`preprocess-entrypoint.sh\`." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/build-batch-image.yaml` that builds the `joshsim-batch` Docker image and pushes to `ghcr.io/schmidtdse/josh/joshsim-batch`
- Single image supports both run and preprocess — `Dockerfile.batch` includes both `run-entrypoint.sh` and `preprocess-entrypoint.sh`
- Triggers on push to `main`, `dev`, `feat/k8s-batch` when cloud-img/, src/main/, or build.gradle change
- Supports `workflow_dispatch` for manual trigger (needed for first push)
- Tags: `<sha>` (immutable), `<branch>` (mutable), `latest` (main/dev only)
- Uses `GITHUB_TOKEN` for GHCR auth — no additional secrets needed

## Test plan
- [ ] Merge and trigger manually via `workflow_dispatch`
- [ ] Image appears at `ghcr.io/schmidtdse/josh/joshsim-batch`
- [ ] Make package public (Settings → Packages → Change visibility)
- [ ] GKE pods can pull the image (resolves ErrImagePull from integration testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)