### PR TITLE
Add --replicate-index flag to RunCommand

### DIFF
--- a/src/main/java/org/joshsim/command/RunCommand.java
+++ b/src/main/java/org/joshsim/command/RunCommand.java
@@ -368,65 +368,47 @@ public class RunCommand implements Callable<Integer> {
     boolean sizeMetersFull = sizeStr.equals("meter") || sizeStr.equals("meters");
     boolean sizeMeters = sizeMetersFull || sizeMeterAbbreviated;
 
-    // Single replicate mode: run one replicate at the specified index and return.
-    if (replicateIndex != null) {
-      JoshJob currentJob = jobs.get(0);
-      if (!currentJob.getFilePaths().isEmpty()) {
-        inputStrategy = new JvmMappedInputGetter(currentJob.getFilePaths());
-      }
-      runReplicate(currentJob, replicateIndex, false, valueFactory, geometryFactory,
-          inputStrategy, hasDegrees, sizeMeters, sizeValueRaw, extractor, program,
-          simulation, progressCalculator, parsedOutputSteps);
-      output.printInfo("");
-      output.printInfo("✓ Replicate " + replicateIndex + " completed successfully!");
-      SharedRandom.clear();
-      return 0;
-    }
-
-    // Execute simulation for each job combination and replicate
+    // Execute simulation for each job combination and replicate.
+    // When --replicate-index is set, run exactly one replicate at that index.
     int totalReplicateCount = 0;
 
     for (int jobIndex = 0; jobIndex < jobs.size(); jobIndex++) {
       JoshJob currentJob = jobs.get(jobIndex);
       output.printInfo("Executing job combination " + (jobIndex + 1) + "/" + jobs.size());
 
-      // Update InputGetterStrategy for this job's file mappings
       if (!currentJob.getFilePaths().isEmpty()) {
         inputStrategy = new JvmMappedInputGetter(currentJob.getFilePaths());
       }
 
       for (int currentReplicate = 0; currentReplicate < currentJob.getReplicates();
            currentReplicate++) {
+        int effectiveReplicate = replicateIndex != null ? replicateIndex : currentReplicate;
         totalReplicateCount++;
 
-        // Reset progress tracking for each new simulation (except first)
         if (totalReplicateCount > 1) {
           progressCalculator.resetForNextReplicate(totalReplicateCount);
         }
 
-        runReplicate(currentJob, currentReplicate, totalReplicateCount > 1,
+        runReplicate(currentJob, effectiveReplicate, totalReplicateCount > 1,
             valueFactory, geometryFactory, inputStrategy, hasDegrees, sizeMeters,
             sizeValueRaw, extractor, program, simulation, progressCalculator,
             parsedOutputSteps);
 
-        // Report replicate completion
         ProgressUpdate completion = progressCalculator.updateReplicateCompleted(
             totalReplicateCount);
         output.printInfo(completion.getMessage());
       }
 
-      // Report job combination completion
       if (jobIndex < jobs.size() - 1) {
         output.printInfo("Completed job combination " + (jobIndex + 1) + "/" + jobs.size());
       }
     }
 
-    // Report overall success
     output.printInfo("");
     output.printInfo("✓ All simulations completed successfully!");
     output.printInfo("  Total replicates run: " + totalReplicateCount);
     output.printInfo("  Job combinations: " + jobs.size());
-    output.printInfo("  Replicates per job: " + replicates);
+    output.printInfo("  Replicates per job: " + effectiveReplicates);
 
     // Clean up shared random
     SharedRandom.clear();

--- a/src/main/java/org/joshsim/command/RunCommand.java
+++ b/src/main/java/org/joshsim/command/RunCommand.java
@@ -99,6 +99,13 @@ public class RunCommand implements Callable<Integer> {
   private int replicates = 1;
 
   @Option(
+      names = "--replicate-index",
+      description = "Run a single replicate at this index (mutually exclusive with --replicates)."
+          + " Used by K8s indexed Jobs where each pod runs one replicate."
+  )
+  private Integer replicateIndex;
+
+  @Option(
       names = "--use-float-64",
       description = "Use double instead of BigDecimal, offering speed but lower precision.",
       defaultValue = "false"
@@ -210,6 +217,14 @@ public class RunCommand implements Callable<Integer> {
   @Override
   public Integer call() {
     // Validate replicates parameter
+    if (replicateIndex != null && replicates > 1) {
+      output.printError("--replicate-index and --replicates are mutually exclusive");
+      return 1;
+    }
+    if (replicateIndex != null && replicateIndex < 0) {
+      output.printError("--replicate-index must be >= 0");
+      return 1;
+    }
     if (replicates < 1) {
       output.printError("Number of replicates must be at least 1");
       return 1;
@@ -238,9 +253,12 @@ public class RunCommand implements Callable<Integer> {
     // Parse custom parameters from command line
     Map<String, String> customParameters = parseCustomParameters();
 
+    // When --replicate-index is set, run exactly one replicate at that index.
+    int effectiveReplicates = replicateIndex != null ? 1 : replicates;
+
     // Create job configurations using JobVariationParser for grid search
     JoshJobBuilder templateJobBuilder = new JoshJobBuilder()
-        .setReplicates(replicates)
+        .setReplicates(effectiveReplicates)
         .setCustomParameters(customParameters);
     JobVariationParser parser = new JobVariationParser();
     List<JoshJobBuilder> jobBuilders = parser.parseDataFiles(templateJobBuilder, dataFiles);
@@ -251,9 +269,14 @@ public class RunCommand implements Callable<Integer> {
         .toList();
 
     // Report grid search information
-    output.printInfo("Grid search will execute " + jobs.size() + " job combination(s) "
-        + "with " + replicates + " replicate(s) each");
-    output.printInfo("Total simulations to run: " + (jobs.size() * replicates));
+    if (replicateIndex != null) {
+      output.printInfo("Running replicate index " + replicateIndex
+          + " across " + jobs.size() + " job combination(s)");
+    } else {
+      output.printInfo("Grid search will execute " + jobs.size() + " job combination(s) "
+          + "with " + replicates + " replicate(s) each");
+    }
+    output.printInfo("Total simulations to run: " + (jobs.size() * effectiveReplicates));
 
     // Use first job for initialization (all jobs should have compatible structure)
     JoshJob firstJob = jobs.get(0);
@@ -357,7 +380,11 @@ public class RunCommand implements Callable<Integer> {
         inputStrategy = new JvmMappedInputGetter(currentJob.getFilePaths());
       }
 
-      for (int currentReplicate = 0; currentReplicate < currentJob.getReplicates();
+      int startReplicate = replicateIndex != null ? replicateIndex : 0;
+      int endReplicate = replicateIndex != null
+          ? replicateIndex + 1 : currentJob.getReplicates();
+
+      for (int currentReplicate = startReplicate; currentReplicate < endReplicate;
            currentReplicate++) {
         totalReplicateCount++;
 

--- a/src/main/java/org/joshsim/command/RunCommand.java
+++ b/src/main/java/org/joshsim/command/RunCommand.java
@@ -368,6 +368,21 @@ public class RunCommand implements Callable<Integer> {
     boolean sizeMetersFull = sizeStr.equals("meter") || sizeStr.equals("meters");
     boolean sizeMeters = sizeMetersFull || sizeMeterAbbreviated;
 
+    // Single replicate mode: run one replicate at the specified index and return.
+    if (replicateIndex != null) {
+      JoshJob currentJob = jobs.get(0);
+      if (!currentJob.getFilePaths().isEmpty()) {
+        inputStrategy = new JvmMappedInputGetter(currentJob.getFilePaths());
+      }
+      runReplicate(currentJob, replicateIndex, false, valueFactory, geometryFactory,
+          inputStrategy, hasDegrees, sizeMeters, sizeValueRaw, extractor, program,
+          simulation, progressCalculator, parsedOutputSteps);
+      output.printInfo("");
+      output.printInfo("✓ Replicate " + replicateIndex + " completed successfully!");
+      SharedRandom.clear();
+      return 0;
+    }
+
     // Execute simulation for each job combination and replicate
     int totalReplicateCount = 0;
 
@@ -380,11 +395,7 @@ public class RunCommand implements Callable<Integer> {
         inputStrategy = new JvmMappedInputGetter(currentJob.getFilePaths());
       }
 
-      int startReplicate = replicateIndex != null ? replicateIndex : 0;
-      int endReplicate = replicateIndex != null
-          ? replicateIndex + 1 : currentJob.getReplicates();
-
-      for (int currentReplicate = startReplicate; currentReplicate < endReplicate;
+      for (int currentReplicate = 0; currentReplicate < currentJob.getReplicates();
            currentReplicate++) {
         totalReplicateCount++;
 
@@ -393,52 +404,10 @@ public class RunCommand implements Callable<Integer> {
           progressCalculator.resetForNextReplicate(totalReplicateCount);
         }
 
-        // Create TemplateStringRenderer for this job and replicate
-        TemplateStringRenderer templateRenderer = new TemplateStringRenderer(currentJob,
-            currentReplicate);
-
-        // Create InputOutputLayer with template renderer (similar to JoshSimFacade logic)
-        InputOutputLayer inputOutputLayer;
-        if (hasDegrees && sizeMeters) {
-          PatchBuilderExtentsBuilder extentsBuilder = new PatchBuilderExtentsBuilder();
-          ExtentsUtil.addExtents(extentsBuilder, extractor.getStartStr(), true, valueFactory);
-          ExtentsUtil.addExtents(extentsBuilder, extractor.getEndStr(), false, valueFactory);
-          BigDecimal sizeValuePrimitive = sizeValueRaw.getAsDecimal();
-          inputOutputLayer = new JvmInputOutputLayerBuilder()
-              .withReplicate(currentReplicate)
-              .withEarthSpace(extentsBuilder.build(), sizeValuePrimitive)
-              .withInputStrategy(inputStrategy)
-              .withTemplateRenderer(templateRenderer)
-              .withMinioOptions(minioOptions)
-              .withAppendMode(totalReplicateCount > 1)
-              .withMaxDecimalPlaces(csvPrecision)
-              .build();
-        } else {
-          inputOutputLayer = new JvmInputOutputLayerBuilder()
-              .withReplicate(currentReplicate)
-              .withInputStrategy(inputStrategy)
-              .withTemplateRenderer(templateRenderer)
-              .withMinioOptions(minioOptions)
-              .withAppendMode(totalReplicateCount > 1)
-              .withMaxDecimalPlaces(csvPrecision)
-              .build();
-        }
-
-        JoshSimFacadeUtil.runSimulation(
-            valueFactory,
-            geometryFactory,
-            inputOutputLayer,
-            program,
-            simulation,
-            (step) -> {
-              ProgressUpdate update = progressCalculator.updateStep(step);
-              if (update.shouldReport()) {
-                output.printInfo(update.getMessage());
-              }
-            },
-            serialPatches,
-            parsedOutputSteps
-        );
+        runReplicate(currentJob, currentReplicate, totalReplicateCount > 1,
+            valueFactory, geometryFactory, inputStrategy, hasDegrees, sizeMeters,
+            sizeValueRaw, extractor, program, simulation, progressCalculator,
+            parsedOutputSteps);
 
         // Report replicate completion
         ProgressUpdate completion = progressCalculator.updateReplicateCompleted(
@@ -463,6 +432,58 @@ public class RunCommand implements Callable<Integer> {
     SharedRandom.clear();
 
     return 0;
+  }
+
+  private void runReplicate(JoshJob currentJob, int currentReplicate, boolean appendMode,
+      ValueSupportFactory valueFactory, EngineGeometryFactory geometryFactory,
+      InputGetterStrategy inputStrategy, boolean hasDegrees, boolean sizeMeters,
+      EngineValue sizeValueRaw, GridInfoExtractor extractor, JoshProgram program,
+      String simulation, ProgressCalculator progressCalculator,
+      Optional<Set<Integer>> parsedOutputSteps) {
+    TemplateStringRenderer templateRenderer = new TemplateStringRenderer(currentJob,
+        currentReplicate);
+
+    InputOutputLayer inputOutputLayer;
+    if (hasDegrees && sizeMeters) {
+      PatchBuilderExtentsBuilder extentsBuilder = new PatchBuilderExtentsBuilder();
+      ExtentsUtil.addExtents(extentsBuilder, extractor.getStartStr(), true, valueFactory);
+      ExtentsUtil.addExtents(extentsBuilder, extractor.getEndStr(), false, valueFactory);
+      BigDecimal sizeValuePrimitive = sizeValueRaw.getAsDecimal();
+      inputOutputLayer = new JvmInputOutputLayerBuilder()
+          .withReplicate(currentReplicate)
+          .withEarthSpace(extentsBuilder.build(), sizeValuePrimitive)
+          .withInputStrategy(inputStrategy)
+          .withTemplateRenderer(templateRenderer)
+          .withMinioOptions(minioOptions)
+          .withAppendMode(appendMode)
+          .withMaxDecimalPlaces(csvPrecision)
+          .build();
+    } else {
+      inputOutputLayer = new JvmInputOutputLayerBuilder()
+          .withReplicate(currentReplicate)
+          .withInputStrategy(inputStrategy)
+          .withTemplateRenderer(templateRenderer)
+          .withMinioOptions(minioOptions)
+          .withAppendMode(appendMode)
+          .withMaxDecimalPlaces(csvPrecision)
+          .build();
+    }
+
+    JoshSimFacadeUtil.runSimulation(
+        valueFactory,
+        geometryFactory,
+        inputOutputLayer,
+        program,
+        simulation,
+        (step) -> {
+          ProgressUpdate update = progressCalculator.updateStep(step);
+          if (update.shouldReport()) {
+            output.printInfo(update.getMessage());
+          }
+        },
+        serialPatches,
+        parsedOutputSteps
+    );
   }
 
 }


### PR DESCRIPTION
## Summary
Add `--replicate-index` flag to `RunCommand`, mutually exclusive with `--replicates`. Runs a single replicate at the specified index so `{replicate}` template paths resolve correctly.

Used by K8s indexed Jobs where each pod runs one replicate — pod 3 uses `--replicate-index=3`, producing `smoke_3.csv` instead of `smoke_0.csv`.

```bash
# Old (all pods write replicate 0):
java -jar joshsim.jar run sim.josh Main --replicates=1

# New (pod writes at its assigned index):
java -jar joshsim.jar run sim.josh Main --replicate-index=$JOB_COMPLETION_INDEX
```

## Test plan
- [x] `./gradlew test checkstyleMain` — all pass
- [x] Mutually exclusive validation: `--replicate-index=3 --replicates=5` → error
- [x] Negative index validation: `--replicate-index=-1` → error
- [x] Existing `--replicates` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)