### PR TITLE
Add sample binomial distribution primitive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
   // Apache Commons CSV for CSV handling
   implementation("org.apache.commons:commons-csv:1.10.0")
 
+  // Apache Commons Math for statistical distributions (binomial, etc.)
+  implementation("org.apache.commons:commons-math3:3.6.1")
+
   // UCAR NetCDF for NetCDF support
   implementation "edu.ucar:cdm-core:5.7.0"
   implementation "edu.ucar:netcdf4:5.7.0"

--- a/examples/features/binomial.josh
+++ b/examples/features/binomial.josh
@@ -1,0 +1,45 @@
+start simulation CohortSurvival
+
+  grid.size = 1 km
+  grid.low.x = 0 m
+  grid.low.y = 0 m
+  grid.high.x = 1 km
+  grid.high.y = 1 km
+  grid.patch = "Default"
+
+  steps.low = 0 count
+  steps.high = 3 count
+
+end simulation
+
+start patch Default
+
+  Cohort.init = create 1 count of Cohort
+
+end patch
+
+start organism Cohort
+
+  survivors.init = 1000 count
+
+  # Each step, surviving individuals face independent mortality with 80% survival rate.
+  # Instead of instantiating all survivors and rolling each one, draw a single
+  # binomial to get the number that survive to the next stage.
+  survivors.step = sample binomial with n of prior.survivors p of 0.8 count
+
+end organism
+
+start unit m
+  alias meter
+  alias meters
+  km = current / 1000
+end unit
+
+start unit km
+  alias kilometer
+  alias kilometers
+  m = current * 1000
+end unit
+
+start unit count
+end unit

--- a/josh-tests/conformance/stochastic/distributions/test_stochastic_binomial.josh
+++ b/josh-tests/conformance/stochastic/distributions/test_stochastic_binomial.josh
@@ -1,0 +1,65 @@
+# @category: stochastic
+# @subcategory: distributions
+# @priority: critical
+# @issue: #407
+# @description: Test binomial distribution sampling - verifies mean approximates n*p and all values within range
+
+start simulation StochasticBinomial
+
+  grid.size = 1 km
+  grid.low.x = 0 m
+  grid.low.y = 0 m
+  grid.high.x = 1 km
+  grid.high.y = 1 km
+  grid.patch = "Default"
+
+  steps.low = 0 count
+  steps.high = 1 count
+
+end simulation
+
+start patch Default
+
+  TestOrg.init = create 1000 count of TestOrg
+
+  avgValue.step = mean(TestOrg.value)
+  minValue.step = min(TestOrg.value)
+  maxValue.step = max(TestOrg.value)
+
+  # For Binomial(20, 0.5), expected mean = 10
+  # With 1000 samples, expect mean within +/- 1.5 of 10
+  expectedMean.step = 10 count
+  meanTolerance.step = 1.5 count
+  meanLowerBound.step = expectedMean - meanTolerance
+  meanUpperBound.step = expectedMean + meanTolerance
+  assert.meanApprox.step = (avgValue >= meanLowerBound) and (avgValue <= meanUpperBound)
+
+  # All values should be in [0, 20]
+  assert.allInRange.step = (minValue >= 0 count) and (maxValue <= 20 count)
+
+end patch
+
+start organism TestOrg
+
+  value.init = sample binomial with n of 20 count p of 0.5 count
+  value.step = prior.value
+
+end organism
+
+start unit degrees
+end unit
+
+start unit m
+  alias meter
+  alias meters
+  km = current / 1000
+end unit
+
+start unit km
+  alias kilometer
+  alias kilometers
+  m = current * 1000
+end unit
+
+start unit count
+end unit

--- a/josh-tests/conformance/stochastic/distributions/test_stochastic_binomial_parameters.josh
+++ b/josh-tests/conformance/stochastic/distributions/test_stochastic_binomial_parameters.josh
@@ -1,0 +1,89 @@
+# @category: stochastic
+# @subcategory: distributions
+# @priority: high
+# @issue: #407
+# @description: Test binomial distribution with different parameters - verifies n and p affect results correctly
+
+start simulation StochasticBinomialParameters
+
+  grid.size = 1 km
+  grid.low.x = 0 m
+  grid.low.y = 0 m
+  grid.high.x = 1 km
+  grid.high.y = 1 km
+  grid.patch = "Default"
+
+  steps.low = 0 count
+  steps.high = 1 count
+
+end simulation
+
+start patch Default
+
+  TestOrg1.init = create 800 count of TestOrg1
+  TestOrg2.init = create 800 count of TestOrg2
+
+  # Calculate statistics for distribution 1: Binomial(10, 0.3), expected mean = 3
+  avgValue1.step = mean(TestOrg1.value)
+  minValue1.step = min(TestOrg1.value)
+  maxValue1.step = max(TestOrg1.value)
+
+  # Calculate statistics for distribution 2: Binomial(50, 0.7), expected mean = 35
+  avgValue2.step = mean(TestOrg2.value)
+  minValue2.step = min(TestOrg2.value)
+  maxValue2.step = max(TestOrg2.value)
+
+  # Test 1: Distribution 1 mean should approximate 3 with tolerance
+  expectedMean1.step = 3 count
+  tolerance1.step = 1.5 count
+  lowerBound1.step = expectedMean1 - tolerance1
+  upperBound1.step = expectedMean1 + tolerance1
+  assert.mean1.step = (avgValue1 >= lowerBound1) and (avgValue1 <= upperBound1)
+
+  # Test 2: Distribution 2 mean should approximate 35 with tolerance
+  expectedMean2.step = 35 count
+  tolerance2.step = 4 count
+  lowerBound2.step = expectedMean2 - tolerance2
+  upperBound2.step = expectedMean2 + tolerance2
+  assert.mean2.step = (avgValue2 >= lowerBound2) and (avgValue2 <= upperBound2)
+
+  # Test 3: Distribution 2 should have higher mean than Distribution 1
+  assert.differentMeans.step = avgValue2 > avgValue1
+
+  # Test 4: Range boundaries
+  assert.range1.step = (minValue1 >= 0 count) and (maxValue1 <= 10 count)
+  assert.range2.step = (minValue2 >= 0 count) and (maxValue2 <= 50 count)
+
+end patch
+
+start organism TestOrg1
+
+  value.init = sample binomial with n of 10 count p of 0.3 count
+  value.step = prior.value
+
+end organism
+
+start organism TestOrg2
+
+  value.init = sample binomial with n of 50 count p of 0.7 count
+  value.step = prior.value
+
+end organism
+
+start unit degrees
+end unit
+
+start unit m
+  alias meter
+  alias meters
+  km = current / 1000
+end unit
+
+start unit km
+  alias kilometer
+  alias kilometers
+  m = current * 1000
+end unit
+
+start unit count
+end unit

--- a/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
+++ b/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
@@ -46,6 +46,7 @@ ALL_: 'all';
 AND_: 'and';
 AS_: 'as';
 ASSERT_: 'assert';
+BINOMIAL_: 'binomial';
 AT_: 'at';
 CONFIG_: 'config';
 CONST_: 'const';
@@ -70,10 +71,12 @@ LONGITUDE_: 'longitude';
 MANAGEMENT_: 'management';
 MAP_: 'map';
 MEAN_: 'mean';
+N_: 'n';
 NORMAL_: 'normal';
 OF_: 'of';
 OR_: 'or';
 ORGANISM_: 'organism';
+P_: 'p';
 PATCH_: 'patch';
 PRIOR_: 'prior';
 RADIAL_: 'radial';
@@ -101,7 +104,7 @@ IDENTIFIER_: [A-Za-z][A-Za-z0-9_]*;
 WHITE_SPACE: [ \u000B\t\r\n] -> channel(HIDDEN);
 
 // Identifiers
-nakedIdentifier: (IDENTIFIER_|DEBUG_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_|ORGANISM_);
+nakedIdentifier: (IDENTIFIER_|DEBUG_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_|ORGANISM_|N_|P_);
 identifier: nakedIdentifier (DOT_ (nakedIdentifier))*;
 
 // Values
@@ -174,6 +177,7 @@ bool: (TRUE_ | FALSE_);
 
 distributionDescription: UNIFORM_ FROM_ low=expression TO_ high=expression # uniformSample
   | NORMAL_ WITH_ MEAN_ OF_ mean=expression STD_ OF_ stdev=expression # normalSample
+  | BINOMIAL_ WITH_ N_ OF_ n=expression P_ OF_ p=expression # binomialSample
   ;
 
 // Callables

--- a/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
@@ -349,6 +349,17 @@ public interface EventHandlerMachine {
   EventHandlerMachine randNorm();
 
   /**
+   * Draw a single integer from a binomial distribution.
+   *
+   * <p>Draw a single integer randomly from a binomial distribution Binomial(n, p), pushing the
+   * value drawn to the top of the stack. Prior to pushing the result, first the probability p
+   * will be popped followed by the number of trials n.</p>
+   *
+   * @return Reference to this machine for chaining.
+   */
+  EventHandlerMachine randBinomial();
+
+  /**
    * Calculate the absolute value of a number.
    *
    * <p>Pop a value from the top of the stack, calculate its absolute value, and push the result

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -699,6 +699,24 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
   }
 
   @Override
+  public EventHandlerMachine randBinomial() {
+    startConversionGroup();
+    EngineValue pValue = pop();
+    EngineValue nValue = pop();
+    endConversionGroup();
+
+    int nInt = (int) nValue.getAsInt();
+    double pDouble = pValue.getAsDouble();
+    int binomialResult = SharedRandom.nextBinomial(nInt, pDouble);
+
+    EngineValue decoratedResult = valueFactory.buildForNumber(
+        (double) binomialResult, nValue.getUnits());
+    memory.push(decoratedResult);
+
+    return this;
+  }
+
+  @Override
   public EventHandlerMachine abs() {
     return applyUnaryMathFunction(v -> {
       if (favorBigDecimal) {

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -701,16 +701,16 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
   @Override
   public EventHandlerMachine randBinomial() {
     startConversionGroup();
-    EngineValue pValue = pop();
-    EngineValue nValue = pop();
+    EngineValue prob = pop();
+    EngineValue trials = pop();
     endConversionGroup();
 
-    int nInt = (int) nValue.getAsInt();
-    double pDouble = pValue.getAsDouble();
-    int binomialResult = SharedRandom.nextBinomial(nInt, pDouble);
+    int trialsInt = (int) trials.getAsInt();
+    double probDouble = prob.getAsDouble();
+    int binomialResult = SharedRandom.nextBinomial(trialsInt, probDouble);
 
     EngineValue decoratedResult = valueFactory.buildForNumber(
-        (double) binomialResult, nValue.getUnits());
+        (double) binomialResult, trials.getUnits());
     memory.push(decoratedResult);
 
     return this;

--- a/src/main/java/org/joshsim/lang/interpret/visitor/JoshParserToMachineVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/JoshParserToMachineVisitor.java
@@ -211,6 +211,10 @@ public class JoshParserToMachineVisitor extends JoshLangBaseVisitor<JoshFragment
     return distributionVisitor.visitNormalSample(ctx);
   }
 
+  public JoshFragment visitBinomialSample(JoshLangParser.BinomialSampleContext ctx) {
+    return distributionVisitor.visitBinomialSample(ctx);
+  }
+
   public JoshFragment visitCast(JoshLangParser.CastContext ctx) {
     return typesUnitsVisitor.visitCast(ctx);
   }

--- a/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitor.java
@@ -196,12 +196,12 @@ public class JoshDistributionVisitor implements JoshVisitorDelegate {
    * @return JoshFragment containing the binomial sampling expression parsed.
    */
   public JoshFragment visitBinomialSample(JoshLangParser.BinomialSampleContext ctx) {
-    EventHandlerAction nAction = ctx.n.accept(parent).getCurrentAction();
-    EventHandlerAction pAction = ctx.p.accept(parent).getCurrentAction();
+    EventHandlerAction trialsAction = ctx.n.accept(parent).getCurrentAction();
+    EventHandlerAction probAction = ctx.p.accept(parent).getCurrentAction();
 
     EventHandlerAction action = (machine) -> {
-      nAction.apply(machine);
-      pAction.apply(machine);
+      trialsAction.apply(machine);
+      probAction.apply(machine);
       machine.randBinomial();
       return machine;
     };

--- a/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitor.java
@@ -186,4 +186,27 @@ public class JoshDistributionVisitor implements JoshVisitorDelegate {
     return new ActionFragment(action);
   }
 
+  /**
+   * Parse a binomial distribution sampling expression.
+   *
+   * <p>Parse an expression that draws a single integer from a binomial distribution Binomial(n, p)
+   * where n is the number of trials and p is the probability of success.</p>
+   *
+   * @param ctx The ANTLR context from which to parse the binomial sampling expression.
+   * @return JoshFragment containing the binomial sampling expression parsed.
+   */
+  public JoshFragment visitBinomialSample(JoshLangParser.BinomialSampleContext ctx) {
+    EventHandlerAction nAction = ctx.n.accept(parent).getCurrentAction();
+    EventHandlerAction pAction = ctx.p.accept(parent).getCurrentAction();
+
+    EventHandlerAction action = (machine) -> {
+      nAction.apply(machine);
+      pAction.apply(machine);
+      machine.randBinomial();
+      return machine;
+    };
+
+    return new ActionFragment(action);
+  }
+
 }

--- a/src/main/java/org/joshsim/util/SharedRandom.java
+++ b/src/main/java/org/joshsim/util/SharedRandom.java
@@ -13,6 +13,9 @@ package org.joshsim.util;
 import java.util.Optional;
 import java.util.Random;
 
+import org.apache.commons.math3.distribution.BinomialDistribution;
+import org.apache.commons.math3.random.RandomGeneratorFactory;
+
 
 /**
  * Utility class for managing a shared Random instance across simulation components.
@@ -172,6 +175,29 @@ public final class SharedRandom {
    */
   public static double nextGaussian(double mean, double stddev) {
     return get().nextGaussian(mean, stddev);
+  }
+
+  /**
+   * Generate a binomial-distributed random integer.
+   *
+   * <p>Draws a single sample from a Binomial(n, p) distribution using Apache Commons Math,
+   * returning the number of successes in n independent Bernoulli(p) trials.</p>
+   *
+   * @param n The number of trials (must be non-negative).
+   * @param p The probability of success on each trial (must be in [0, 1]).
+   * @return The number of successes, an integer in [0, n].
+   * @throws IllegalArgumentException if n is negative or p is not in [0, 1].
+   */
+  public static int nextBinomial(int n, double p) {
+    if (n < 0) {
+      throw new IllegalArgumentException("n must be non-negative, got: " + n);
+    }
+    if (p < 0.0 || p > 1.0) {
+      throw new IllegalArgumentException("p must be in [0, 1], got: " + p);
+    }
+    BinomialDistribution dist = new BinomialDistribution(
+        RandomGeneratorFactory.createRandomGenerator(get()), n, p);
+    return dist.sample();
   }
 
 }

--- a/src/main/java/org/joshsim/util/SharedRandom.java
+++ b/src/main/java/org/joshsim/util/SharedRandom.java
@@ -12,7 +12,6 @@ package org.joshsim.util;
 
 import java.util.Optional;
 import java.util.Random;
-
 import org.apache.commons.math3.distribution.BinomialDistribution;
 import org.apache.commons.math3.random.RandomGeneratorFactory;
 

--- a/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
@@ -779,6 +779,27 @@ public class SingleThreadEventHandlerMachineTest {
   }
 
   @Test
+  void randBinomial_shouldGenerateIntegerWithinRange() {
+    // Given
+    EngineValue n = makeIntScalar(100L);
+    EngineValue p = makeDecimalScalar(new BigDecimal("0.5"));
+
+    // When
+    machine.push(n);
+    machine.push(p);
+    machine.randBinomial();
+
+    // Then
+    machine.end();
+    DecimalScalar result = (DecimalScalar) machine.getResult();
+    BigDecimal value = result.getAsDecimal();
+
+    assertTrue(value.compareTo(BigDecimal.ZERO) >= 0);
+    assertTrue(value.compareTo(new BigDecimal("100")) <= 0);
+    assertEquals(0, value.stripTrailingZeros().scale());
+  }
+
+  @Test
   void condition_shouldExecuteActionWhenConditionIsTrue() {
     // Given
     EngineValue condition = makeBoolScalar(true);

--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitorTest.java
@@ -288,15 +288,15 @@ class JoshDistributionVisitorTest {
     context.n = mock(ExpressionContext.class);
     context.p = mock(ExpressionContext.class);
 
-    JoshFragment nFragment = mock(JoshFragment.class);
-    JoshFragment pFragment = mock(JoshFragment.class);
-    EventHandlerAction nAction = mock(EventHandlerAction.class);
-    EventHandlerAction pAction = mock(EventHandlerAction.class);
+    JoshFragment trialsFragment = mock(JoshFragment.class);
+    JoshFragment probFragment = mock(JoshFragment.class);
+    EventHandlerAction trialsAction = mock(EventHandlerAction.class);
+    EventHandlerAction probAction = mock(EventHandlerAction.class);
 
-    when(context.n.accept(parent)).thenReturn(nFragment);
-    when(context.p.accept(parent)).thenReturn(pFragment);
-    when(nFragment.getCurrentAction()).thenReturn(nAction);
-    when(pFragment.getCurrentAction()).thenReturn(pAction);
+    when(context.n.accept(parent)).thenReturn(trialsFragment);
+    when(context.p.accept(parent)).thenReturn(probFragment);
+    when(trialsFragment.getCurrentAction()).thenReturn(trialsAction);
+    when(probFragment.getCurrentAction()).thenReturn(probAction);
 
     // Test
     JoshFragment result = visitor.visitBinomialSample(context);
@@ -312,8 +312,8 @@ class JoshDistributionVisitorTest {
 
     action.apply(mockMachine);
 
-    verify(nAction).apply(mockMachine);
-    verify(pAction).apply(mockMachine);
+    verify(trialsAction).apply(mockMachine);
+    verify(probAction).apply(mockMachine);
     verify(mockMachine).randBinomial();
   }
 }

--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitorTest.java
@@ -13,6 +13,7 @@ import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.ValueSupportFactory;
 import org.joshsim.engine.value.type.EngineValue;
 import org.joshsim.engine.value.type.LanguageType;
+import org.joshsim.lang.antlr.JoshLangParser.BinomialSampleContext;
 import org.joshsim.lang.antlr.JoshLangParser.ExpressionContext;
 import org.joshsim.lang.antlr.JoshLangParser.NormalSampleContext;
 import org.joshsim.lang.antlr.JoshLangParser.SampleParamContext;
@@ -278,5 +279,41 @@ class JoshDistributionVisitorTest {
     verify(meanAction).apply(mockMachine);
     verify(stdevAction).apply(mockMachine);
     verify(mockMachine).randNorm();
+  }
+
+  @Test
+  void testVisitBinomialSample() {
+    // Mock
+    BinomialSampleContext context = mock(BinomialSampleContext.class);
+    context.n = mock(ExpressionContext.class);
+    context.p = mock(ExpressionContext.class);
+
+    JoshFragment nFragment = mock(JoshFragment.class);
+    JoshFragment pFragment = mock(JoshFragment.class);
+    EventHandlerAction nAction = mock(EventHandlerAction.class);
+    EventHandlerAction pAction = mock(EventHandlerAction.class);
+
+    when(context.n.accept(parent)).thenReturn(nFragment);
+    when(context.p.accept(parent)).thenReturn(pFragment);
+    when(nFragment.getCurrentAction()).thenReturn(nAction);
+    when(pFragment.getCurrentAction()).thenReturn(pAction);
+
+    // Test
+    JoshFragment result = visitor.visitBinomialSample(context);
+
+    // Validate
+    assertNotNull(result);
+    assertTrue(result instanceof ActionFragment);
+
+    EventHandlerAction action = result.getCurrentAction();
+    assertNotNull(action);
+
+    EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
+
+    action.apply(mockMachine);
+
+    verify(nAction).apply(mockMachine);
+    verify(pAction).apply(mockMachine);
+    verify(mockMachine).randBinomial();
   }
 }


### PR DESCRIPTION
## Summary

Closes #407. Adds a `sample binomial with n of X p of Y` primitive that returns a single integer draw from `Binomial(n, p)`.

- Adds `binomial` keyword and `# binomialSample` grammar alternative in `JoshLang.g4`, with `n` and `p` as keywords that can still be used as identifiers (added to `nakedIdentifier`)
- Adds `commons-math3:3.6.1` dependency for exact, O(1)-amortized binomial sampling via inverse CDF (sets the pattern for future distributions like Poisson, Exponential, etc.)
- Implements `randBinomial()` through the full interpreter stack: `SharedRandom` → `EventHandlerMachine` → `SingleThreadEventHandlerMachine` → `JoshDistributionVisitor` → `JoshParserToMachineVisitor`

## Test plan

- [ ] Unit test: `JoshDistributionVisitorTest.testVisitBinomialSample` — verifies visitor creates correct `ActionFragment` calling `machine.randBinomial()`
- [ ] Unit test: `SingleThreadEventHandlerMachineTest.randBinomial_shouldGenerateIntegerWithinRange` — verifies result is an integer in `[0, n]`
- [ ] Conformance test: `test_stochastic_binomial.josh` (critical) — 1000 draws from `Binomial(20, 0.5)`, asserts mean ≈ 10 and all values in `[0, 20]`
- [ ] Conformance test: `test_stochastic_binomial_parameters.josh` (high) — compares `Binomial(10, 0.3)` vs `Binomial(50, 0.7)`, asserts means approximate `n*p` and ranges correct
- [ ] Example: `examples/features/binomial.josh` — cohort survival use case from the issue
- [ ] TeaVM smoke test: `./gradlew war` compiles cleanly with commons-math3 (verifies WASM compatibility)

https://claude.ai/code/session_01XtqiCZNmCkWc3FiafigaiT