### PR TITLE
Fix flaky randBinomial test: BigDecimal scale check

### DIFF
--- a/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
@@ -796,7 +796,7 @@ public class SingleThreadEventHandlerMachineTest {
 
     assertTrue(value.compareTo(BigDecimal.ZERO) >= 0);
     assertTrue(value.compareTo(new BigDecimal("100")) <= 0);
-    assertEquals(0, value.stripTrailingZeros().scale());
+    assertTrue(value.stripTrailingZeros().scale() <= 0);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Fixes flaky `randBinomial_shouldGenerateIntegerWithinRange` JUnit test that failed whenever the binomial draw was a multiple of 10
- Root cause: `BigDecimal(50.0).stripTrailingZeros()` yields `5E+1` with scale `-1`, not `0` — Java's `stripTrailingZeros` operates on significant digits, not just decimal places
- Change `assertEquals(0, scale)` to `assertTrue(scale <= 0)` since a whole number's stripped scale is always non-positive

## Test plan

- [ ] `./gradlew test` passes consistently (the old assertion had ~25% chance of failure per run)

https://claude.ai/code/session_01XtqiCZNmCkWc3FiafigaiT