### PR TITLE
cloud run: enable instance-based billing for /runBatch async work

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -573,5 +573,6 @@ jobs:
             --allow-unauthenticated \
             --set-secrets="JOSH_API_KEYS=${{ secrets.SECRET_NAME }}" \
             --use-http2 \
+            --no-cpu-throttling \
             --concurrency=1 \
             --timeout=3600s

--- a/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
@@ -67,6 +67,12 @@ import org.joshsim.util.OutputOptions;
  */
 public class JoshSimBatchHandler implements HttpHandler {
 
+  // On Cloud Run, this async pattern requires instance-based billing
+  // (--no-cpu-throttling on gcloud run deploy; see .github/workflows/build.yaml).
+  // Without it, CPU is throttled after the 202 response flushes and the daemon
+  // threads below freeze mid-simulation — status.json never updates. See #418.
+  // Durable fix tracked in #421 (dispatch to Cloud Run Jobs instead of running
+  // in-process).
   private static final ExecutorService BATCH_EXECUTOR =
       Executors.newCachedThreadPool(runnable -> {
         Thread thread = new Thread(runnable);
@@ -187,6 +193,8 @@ public class JoshSimBatchHandler implements HttpHandler {
     sendJsonAccepted(exchange, jobId, statusPath);
 
     String capturedApiKey = apiKey;
+    // This background dispatch only survives on Cloud Run when the service is
+    // deployed with --no-cpu-throttling. See BATCH_EXECUTOR above, #418, #421.
     CompletableFuture.runAsync(() -> {
       runBatchWithStatus(
           statusMinio, jobId, simulation, workDir, replicates, statusPath, capturedApiKey


### PR DESCRIPTION
(Claude summary)
## Summary

Fixes #418 — `batchRemote` jobs dispatched to `josh-executor-dev` (Cloud Run) accept the request, write `status.json` with `"running"`, and then silently stall. The same script against the GKE/K8s target completes normally.

Root cause: `JoshSimBatchHandler` returns HTTP 202 immediately and runs the simulation on a daemon thread via `CompletableFuture.runAsync(..., BATCH_EXECUTOR)`. Cloud Run's default request-scoped billing throttles CPU to near-zero the moment the response flushes, freezing that daemon thread mid-simulation. The JVM stays alive but makes no progress, which is why no error gets logged — it's a platform-level throttle, not a Java-level event.

## Changes

- **`.github/workflows/build.yaml`** — add `--no-cpu-throttling` to the single `gcloud run deploy` step. One deploy step drives both `josh-executor-dev` and `josh-executor-prod` based on branch (env set conditionally upstream), so this one-line change covers both services.
- **`src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java`** — add two short regression-guard comments (above `BATCH_EXECUTOR` and above the `CompletableFuture.runAsync(...)` dispatch) noting that the async pattern depends on the deploy flag. This way a future infra refactor stripping the flag doesn't silently reintroduce #418 without anyone noticing.

Zero functional Java code changes. Zero new dependencies. No client-side changes (`HttpBatchTarget`, `BatchRemoteCommand`, joshpy, status-polling wire contract all unchanged).

## Why this fix and not a bigger one

This is the minimal hotfix to unblock joshpy integration tests against the Cloud Run target. The "background thread on a web service" pattern is still fragile and capped at Cloud Run's 3600s request timeout, but for the dev target's short test sims that's fine, and Kubernetes remains the production path for large simulations.

The durable architectural move — refactoring `/runBatch` to submit a Cloud Run Job via pure HTTP REST instead of running the simulation in-process — is tracked in **#421**. That change would delete `BATCH_EXECUTOR`/daemon-thread risk entirely, unlock >1h sims on Cloud Run, and quarantine the GCP-specific code behind a pluggable `BatchDispatcher` interface. Not worth doing right now; filed as a nice-to-have for when it matters.

## Test plan

- [ ] CI builds green and redeploys `josh-executor-dev` with `--no-cpu-throttling` active.
- [ ] After deploy, re-run the reporter's reproducer from #418:
      `batchRemote /tmp/e2e_batch/sim.josh Main --target=cloudrun-dev --replicates=1 --no-wait` then `pollBatch <jobId> --target=cloudrun-dev`.
- [ ] Confirm `status.json` transitions `running` → `complete` within ~30–60s (parity with the GKE path).
- [ ] Confirm `output_0.csv` appears under `gs://josh-batch-storage/e2e-test/`.
- [ ] On merge to `main`, same flag rides through to `josh-executor-prod`.

## Notes

- Slight cost increase: instance-based billing bills CPU while an instance is warm. With `--min-instances=0` still in place, there's no 24/7 cost — you only pay while instances are actively serving or running background work.
- Does **not** raise the Cloud Run Service 3600s request-timeout cap. Long-running simulations should continue to use the Kubernetes path. The Cloud Run Jobs refactor (#421) is the path to lifting that cap on this route.

Closes #418. Refs #421.