### PR TITLE
batchRemote: flag-based UX with .josh-staged.json sentinel

### DIFF
--- a/.github/workflows/test-k8s.yaml
+++ b/.github/workflows/test-k8s.yaml
@@ -136,9 +136,10 @@ jobs:
       - name: Run batchRemote end-to-end
         run: |
           echo "Running batchRemote with K8s target..."
-          java -jar build/libs/joshsim-fat.jar batchRemote \
-            examples/test/k8s/ K8sTest \
+          java -jar build/libs/joshsim-fat.jar batchRemote K8sTest \
             --target=ci-k8s \
+            --minio-prefix=batch-jobs/k8s-e2e/inputs/ \
+            --stage-from-local-dir=examples/test/k8s/ \
             --replicates=2 \
             --poll-interval=5 \
             --timeout=300
@@ -186,9 +187,10 @@ jobs:
 
           # batchRemote should fail — capture exit code through tee
           EXIT_CODE=0
-          java -jar build/libs/joshsim-fat.jar batchRemote \
-            examples/test/k8s/ K8sTest \
+          java -jar build/libs/joshsim-fat.jar batchRemote K8sTest \
             --target=ci-k8s-bad-image \
+            --minio-prefix=batch-jobs/k8s-bad-image/inputs/ \
+            --stage-from-local-dir=examples/test/k8s/ \
             --replicates=1 \
             --poll-interval=10 \
             --timeout=120 2>&1 | tee /tmp/bad-image-output.txt || EXIT_CODE=$?

--- a/.github/workflows/test-minio.yaml
+++ b/.github/workflows/test-minio.yaml
@@ -327,9 +327,10 @@ jobs:
           JOSH
 
           # Run batchRemote with wait
-          java -jar build/libs/joshsim-fat.jar batchRemote \
-            /tmp/batch-e2e-test/e2e_test.josh E2ETest \
+          java -jar build/libs/joshsim-fat.jar batchRemote E2ETest \
             --target=ci-local \
+            --minio-prefix=batch-jobs/http-e2e/inputs/ \
+            --stage-from-local-dir=/tmp/batch-e2e-test \
             --replicates=1 \
             --poll-interval=2 \
             --timeout=120

--- a/README.md
+++ b/README.md
@@ -110,8 +110,12 @@ See also our [example Dockerfile](https://github.com/SchmidtDSE/josh/blob/main/c
 For large-scale runs on your own Kubernetes cluster or server, Josh provides the `batchRemote` command. This stages simulation files to S3-compatible storage (MinIO, GCS, AWS S3), dispatches execution to a configured target, and polls for completion. Results are written back to storage via `minio://` export paths.
 
 ```
-$ java -jar joshsim.jar batchRemote simulation.josh Main --target=nautilus --replicates=50
+$ java -jar joshsim.jar batchRemote Main --target=nautilus \
+    --minio-prefix=batch-jobs/my-run/inputs/ \
+    --stage-from-local-dir=./sim/ --replicates=50
 ```
+
+For workflows where inputs are staged once and dispatched many times (e.g. joshpy driving multiple simulations against the same data), stage separately with `stageToMinio` and then dispatch against the shared prefix — pass `--require-prestaged` to fail fast if the sentinel isn't present, or omit it to just warn on manual uploads.
 
 Targets are defined as JSON profiles at `~/.josh/targets/<name>.json`. Two target types are supported:
 

--- a/src/main/java/org/joshsim/command/BatchRemoteCommand.java
+++ b/src/main/java/org/joshsim/command/BatchRemoteCommand.java
@@ -9,6 +9,8 @@ package org.joshsim.command;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.joshsim.pipeline.target.BatchJobStrategy;
 import org.joshsim.pipeline.target.BatchPollingStrategy;
@@ -21,6 +23,8 @@ import org.joshsim.pipeline.target.RemoteBatchTarget;
 import org.joshsim.pipeline.target.TargetProfile;
 import org.joshsim.pipeline.target.TargetProfileLoader;
 import org.joshsim.util.MinioHandler;
+import org.joshsim.util.MinioHandler.StagedState;
+import org.joshsim.util.MinioHandler.StagedStatus;
 import org.joshsim.util.OutputOptions;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -29,27 +33,36 @@ import picocli.CommandLine.Parameters;
 
 
 /**
- * Dispatches a batch simulation to a remote compute target.
+ * Dispatches a batch simulation to a remote compute target against a MinIO prefix.
  *
- * <p>Stages local simulation files to MinIO, dispatches execution to the configured
- * target, and optionally polls for completion. The target profile determines how the
- * job runs — an HTTP target POSTs to a joshsim server, a Kubernetes target creates
- * an indexed Job, etc.</p>
+ * <p>Three modes:</p>
+ * <ol>
+ *   <li><b>Stage-and-dispatch</b> ({@code --stage-from-local-dir}): upload the local directory
+ *   to {@code --minio-prefix} (writing a {@code .josh-staged.json} sentinel), then dispatch.
+ *   </li>
+ *   <li><b>Trust-the-prefix</b> (no staging flag): read the sentinel; warn if absent (manual
+ *   upload case), fail if in-progress or errored, proceed if complete.</li>
+ *   <li><b>Strict</b> ({@code --require-prestaged}): fail fast unless the sentinel exists and
+ *   reports {@code complete}. Intended for shared/multi-dispatch workflows where staging is
+ *   a separate upstream step.</li>
+ * </ol>
+ *
+ * <p>Supports both HTTP and Kubernetes target types; the target profile determines
+ * how the dispatched job runs.</p>
  */
 @Command(
     name = "batchRemote",
-    description = "Run a simulation on a remote batch target via MinIO staging"
+    description = "Dispatch a simulation to a remote batch target against a MinIO prefix"
 )
 public class BatchRemoteCommand implements Callable<Integer> {
 
   private static final int TARGET_ERROR_CODE = 100;
   private static final int DISPATCH_ERROR_CODE = 101;
+  private static final int USAGE_ERROR_CODE = 102;
+  private static final int STAGING_ERROR_CODE = 103;
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  @Parameters(index = "0", description = "Path to Josh simulation file or input directory")
-  private File input;
-
-  @Parameters(index = "1", description = "Simulation name to execute")
+  @Parameters(index = "0", description = "Simulation name to execute")
   private String simulation;
 
   @Option(
@@ -58,6 +71,28 @@ public class BatchRemoteCommand implements Callable<Integer> {
       required = true
   )
   private String targetName;
+
+  @Option(
+      names = "--minio-prefix",
+      description = "MinIO object prefix where inputs live (e.g. batch-jobs/my-run/inputs/).",
+      required = true
+  )
+  private String minioPrefix;
+
+  @Option(
+      names = "--stage-from-local-dir",
+      description = "Upload this local directory to --minio-prefix before dispatching. "
+          + "Writes a .josh-staged.json sentinel. Mutually exclusive with --require-prestaged."
+  )
+  private File stageFromLocalDir;
+
+  @Option(
+      names = "--require-prestaged",
+      description = "Fail fast unless .josh-staged.json at --minio-prefix reports 'complete'. "
+          + "Mutually exclusive with --stage-from-local-dir.",
+      defaultValue = "false"
+  )
+  private boolean requirePrestaged = false;
 
   @Option(
       names = "--replicates",
@@ -92,6 +127,11 @@ public class BatchRemoteCommand implements Callable<Integer> {
 
   @Override
   public Integer call() {
+    if (stageFromLocalDir != null && requirePrestaged) {
+      output.printError("--stage-from-local-dir and --require-prestaged are mutually exclusive.");
+      return USAGE_ERROR_CODE;
+    }
+
     try {
       output.printInfo("Loading target profile: " + targetName);
       TargetProfileLoader loader = new TargetProfileLoader();
@@ -104,9 +144,7 @@ public class BatchRemoteCommand implements Callable<Integer> {
       String type = profile.getType();
 
       if ("kubernetes".equals(type)) {
-        KubernetesTarget k8sTarget = buildKubernetesTarget(
-            profile
-        );
+        KubernetesTarget k8sTarget = buildKubernetesTarget(profile);
         target = k8sTarget;
         poller = buildPoller(k8sTarget);
       } else if ("http".equals(type)) {
@@ -119,29 +157,36 @@ public class BatchRemoteCommand implements Callable<Integer> {
         );
       }
 
+      String normalizedPrefix = MinioHandler.normalizePrefix(minioPrefix);
+
+      if (stageFromLocalDir != null) {
+        Integer stagingResult = stageLocalDir(minioHandler, normalizedPrefix);
+        if (stagingResult != null) {
+          return stagingResult;
+        }
+      } else {
+        Integer preflightResult = checkSentinel(minioHandler, normalizedPrefix);
+        if (preflightResult != null) {
+          return preflightResult;
+        }
+      }
+
       BatchJobStrategy strategy = new BatchJobStrategy(
-          target, poller, minioHandler, output,
+          target, poller, output,
           pollIntervalSeconds * 1000L, timeoutSeconds * 1000L
       );
 
-      File inputDir = resolveInputDir();
-
       if (noWait) {
-        String jobId = strategy.executeNoWait(
-            inputDir, simulation, replicates
-        );
+        String jobId = strategy.executeNoWait(normalizedPrefix, simulation, replicates);
         ObjectNode node = MAPPER.createObjectNode();
         node.put("jobId", jobId);
         node.put("target", targetName);
-        node.put(
-            "statusPath",
-            "batch-status/" + jobId + "/status.json"
-        );
+        node.put("statusPath", "batch-status/" + jobId + "/status.json");
         System.out.println(node.toString());
         return 0;
       }
 
-      JobStatus finalStatus = strategy.execute(inputDir, simulation, replicates);
+      JobStatus finalStatus = strategy.execute(normalizedPrefix, simulation, replicates);
 
       if (finalStatus.getState() == JobStatus.State.COMPLETE) {
         output.printInfo("Batch job completed successfully.");
@@ -158,42 +203,110 @@ public class BatchRemoteCommand implements Callable<Integer> {
     }
   }
 
+  private Integer stageLocalDir(MinioHandler minioHandler, String normalizedPrefix) {
+    if (!stageFromLocalDir.exists()) {
+      output.printError("--stage-from-local-dir not found: " + stageFromLocalDir.getPath());
+      return USAGE_ERROR_CODE;
+    }
+    if (!stageFromLocalDir.isDirectory()) {
+      output.printError("--stage-from-local-dir is not a directory: "
+          + stageFromLocalDir.getPath());
+      return USAGE_ERROR_CODE;
+    }
+
+    output.printInfo("Staging " + stageFromLocalDir.getName() + " to " + normalizedPrefix + "...");
+    try {
+      minioHandler.writeStagedSentinel(normalizedPrefix, StagedState.STAGING, null);
+      int uploaded;
+      try {
+        uploaded = minioHandler.uploadDirectory(stageFromLocalDir, normalizedPrefix);
+      } catch (IOException uploadError) {
+        try {
+          minioHandler.writeStagedSentinel(
+              normalizedPrefix, StagedState.ERROR, uploadError.getMessage());
+        } catch (IOException sentinelError) {
+          output.printError("Additionally failed to write error sentinel: "
+              + sentinelError.getMessage());
+        }
+        throw uploadError;
+      }
+      minioHandler.writeStagedSentinel(normalizedPrefix, StagedState.COMPLETE, null);
+      output.printInfo("Staged " + uploaded + " file(s).");
+    } catch (IOException e) {
+      output.printError("Staging failed: " + e.getMessage());
+      return STAGING_ERROR_CODE;
+    }
+    return null;
+  }
+
+  private Integer checkSentinel(MinioHandler minioHandler, String normalizedPrefix) {
+    Optional<StagedStatus> sentinel;
+    try {
+      sentinel = minioHandler.readStagedSentinel(normalizedPrefix);
+    } catch (IOException e) {
+      output.printError("Failed to read staging sentinel at " + normalizedPrefix + ": "
+          + e.getMessage());
+      return STAGING_ERROR_CODE;
+    }
+
+    if (sentinel.isEmpty()) {
+      if (requirePrestaged) {
+        output.printError("--require-prestaged: no .josh-staged.json under " + normalizedPrefix
+            + ". Run stageToMinio or use --stage-from-local-dir first.");
+        return STAGING_ERROR_CODE;
+      }
+      output.printInfo("WARNING: Josh did not detect .josh-staged.json under "
+          + normalizedPrefix + " — expected if you uploaded manually; "
+          + "dispatch will fail if required files are missing.");
+      return null;
+    }
+
+    StagedState state = sentinel.get().state();
+    if (state == StagedState.COMPLETE) {
+      return null;
+    }
+    if (requirePrestaged) {
+      output.printError("--require-prestaged: sentinel reports state=" + describeState(state)
+          + describeMessage(sentinel.get()));
+      return STAGING_ERROR_CODE;
+    }
+    if (state == StagedState.STAGING) {
+      output.printError("Sentinel at " + normalizedPrefix
+          + " reports staging still in progress. Retry once staging completes.");
+      return STAGING_ERROR_CODE;
+    }
+    output.printError("Sentinel at " + normalizedPrefix + " reports prior staging failed"
+        + describeMessage(sentinel.get()));
+    return STAGING_ERROR_CODE;
+  }
+
+  private static String describeState(StagedState state) {
+    return state == null ? "unknown" : state.name().toLowerCase();
+  }
+
+  private static String describeMessage(StagedStatus status) {
+    return status.message() != null ? ": " + status.message() : ".";
+  }
+
   private HttpBatchTarget buildHttpTarget(TargetProfile profile) {
     return new HttpBatchTarget(profile.getHttpConfig());
   }
 
-  private KubernetesTarget buildKubernetesTarget(
-      TargetProfile profile
-  ) {
+  private KubernetesTarget buildKubernetesTarget(TargetProfile profile) {
     return new KubernetesTarget(
         profile.getKubernetesConfig(),
         profile.buildMinioOptions()
     );
   }
 
-  private BatchPollingStrategy buildPoller(
-      MinioHandler minioHandler
-  ) {
+  private BatchPollingStrategy buildPoller(MinioHandler minioHandler) {
     return new MinioPollingStrategy(minioHandler);
   }
 
-  private BatchPollingStrategy buildPoller(
-      KubernetesTarget k8sTarget
-  ) {
+  private BatchPollingStrategy buildPoller(KubernetesTarget k8sTarget) {
     return new KubernetesPollingStrategy(
         k8sTarget.getClient(),
         k8sTarget.getConfig().getNamespace()
     );
-  }
-
-  /**
-   * Resolves the input to a directory. If the input is a file (e.g., simulation.josh),
-   * uses its parent directory. If it's already a directory, uses it directly.
-   */
-  private File resolveInputDir() {
-    if (input.isDirectory()) {
-      return input;
-    }
-    return input.getParentFile() != null ? input.getParentFile() : new File(".");
   }
 }

--- a/src/main/java/org/joshsim/command/StageToMinioCommand.java
+++ b/src/main/java/org/joshsim/command/StageToMinioCommand.java
@@ -12,12 +12,9 @@ package org.joshsim.command;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.stream.Stream;
 import org.joshsim.util.MinioHandler;
+import org.joshsim.util.MinioHandler.StagedState;
 import org.joshsim.util.MinioOptions;
 import org.joshsim.util.OutputOptions;
 import picocli.CommandLine.Command;
@@ -29,7 +26,10 @@ import picocli.CommandLine.Option;
  * Uploads all files in a local directory to a MinIO prefix.
  *
  * <p>Each file is uploaded to {@code <bucket>/<prefix>/<relative-path>} where relative-path
- * preserves the directory structure under the input directory.</p>
+ * preserves the directory structure under the input directory. A
+ * {@link MinioHandler#STAGED_SENTINEL_FILENAME} sentinel is written at the root of the
+ * prefix recording the staging lifecycle ({@code staging} → {@code complete}, or
+ * {@code error} if the upload fails).</p>
  */
 @Command(
     name = "stageToMinio",
@@ -72,39 +72,28 @@ public class StageToMinioCommand implements Callable<Integer> {
       }
 
       MinioHandler minio = new MinioHandler(minioOptions, output);
-      String normalizedPrefix = normalizePrefix(prefix);
+      String normalizedPrefix = MinioHandler.normalizePrefix(prefix);
 
-      int uploaded = uploadDirectory(minio, inputDir, normalizedPrefix);
-      output.printInfo("Staged " + uploaded + " file(s) to " + prefix);
+      minio.writeStagedSentinel(normalizedPrefix, StagedState.STAGING, null);
+      int uploaded;
+      try {
+        uploaded = minio.uploadDirectory(inputDir, normalizedPrefix);
+      } catch (IOException uploadError) {
+        try {
+          minio.writeStagedSentinel(normalizedPrefix, StagedState.ERROR, uploadError.getMessage());
+        } catch (IOException sentinelError) {
+          output.printError("Additionally failed to write error sentinel: "
+              + sentinelError.getMessage());
+        }
+        throw uploadError;
+      }
+      minio.writeStagedSentinel(normalizedPrefix, StagedState.COMPLETE, null);
+      output.printInfo("Staged " + uploaded + " file(s) to " + normalizedPrefix);
       return 0;
 
     } catch (Exception e) {
       output.printError("stageToMinio failed: " + e.getMessage());
       return MINIO_ERROR_CODE;
     }
-  }
-
-  private int uploadDirectory(MinioHandler minio, File dir, String prefix) throws IOException {
-    Path basePath = dir.toPath();
-    int count = 0;
-    try (Stream<Path> walker = Files.walk(basePath)) {
-      List<Path> files = walker.filter(Files::isRegularFile).toList();
-      for (Path file : files) {
-        String relativePath = basePath.relativize(file).toString();
-        String objectPath = prefix + relativePath;
-        if (!minio.uploadFile(file.toFile(), objectPath)) {
-          throw new IOException("Failed to upload " + file);
-        }
-        count++;
-      }
-    }
-    return count;
-  }
-
-  private String normalizePrefix(String prefix) {
-    if (prefix.endsWith("/")) {
-      return prefix;
-    }
-    return prefix + "/";
   }
 }

--- a/src/main/java/org/joshsim/pipeline/target/BatchJobStrategy.java
+++ b/src/main/java/org/joshsim/pipeline/target/BatchJobStrategy.java
@@ -1,31 +1,24 @@
 /**
- * Orchestrates batch job execution: stage, dispatch, poll.
+ * Orchestrates batch job dispatch and polling against a pre-staged MinIO prefix.
  *
  * @license BSD-3-Clause
  */
 
 package org.joshsim.pipeline.target;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
 import org.joshsim.util.MinioHandler;
 import org.joshsim.util.OutputOptions;
 
 
 /**
- * Orchestrates the full batch remote execution flow.
+ * Orchestrates remote batch execution: dispatch an already-staged MinIO prefix and poll.
  *
- * <p>The strategy handles three phases:</p>
- * <ol>
- *   <li><b>Stage</b> — upload local input files to MinIO under a job-specific prefix</li>
- *   <li><b>Dispatch</b> — tell the target to execute the simulation</li>
- *   <li><b>Poll</b> — wait for completion by polling status via {@link BatchPollingStrategy}</li>
- * </ol>
+ * <p>This strategy assumes the caller (typically {@code BatchRemoteCommand}) has already
+ * staged inputs to the MinIO prefix — whether by delegating upload to this same process
+ * via {@code --stage-from-local-dir} or by an upstream {@code stageToMinio} invocation.
+ * This class never uploads; it only dispatches to a {@link RemoteBatchTarget} and polls
+ * via a {@link BatchPollingStrategy}.</p>
  */
 public class BatchJobStrategy {
 
@@ -34,7 +27,6 @@ public class BatchJobStrategy {
 
   private final RemoteBatchTarget target;
   private final BatchPollingStrategy poller;
-  private final MinioHandler minioHandler;
   private final OutputOptions output;
   private final long pollIntervalMs;
   private final long timeoutMs;
@@ -44,12 +36,11 @@ public class BatchJobStrategy {
    *
    * @param target The compute target to dispatch to.
    * @param poller The polling strategy for checking job status.
-   * @param minioHandler The MinIO handler for staging inputs (configured with target's creds).
    * @param output For logging.
    */
   public BatchJobStrategy(RemoteBatchTarget target, BatchPollingStrategy poller,
-      MinioHandler minioHandler, OutputOptions output) {
-    this(target, poller, minioHandler, output, DEFAULT_POLL_INTERVAL_MS, DEFAULT_TIMEOUT_MS);
+      OutputOptions output) {
+    this(target, poller, output, DEFAULT_POLL_INTERVAL_MS, DEFAULT_TIMEOUT_MS);
   }
 
   /**
@@ -57,81 +48,62 @@ public class BatchJobStrategy {
    *
    * @param target The compute target to dispatch to.
    * @param poller The polling strategy for checking job status.
-   * @param minioHandler The MinIO handler for staging inputs.
    * @param output For logging.
    * @param pollIntervalMs Milliseconds between poll attempts.
    * @param timeoutMs Maximum milliseconds to wait before timing out.
    */
   public BatchJobStrategy(RemoteBatchTarget target, BatchPollingStrategy poller,
-      MinioHandler minioHandler, OutputOptions output, long pollIntervalMs, long timeoutMs) {
+      OutputOptions output, long pollIntervalMs, long timeoutMs) {
     this.target = target;
     this.poller = poller;
-    this.minioHandler = minioHandler;
     this.output = output;
     this.pollIntervalMs = pollIntervalMs;
     this.timeoutMs = timeoutMs;
   }
 
   /**
-   * Executes the full batch flow: stage, dispatch, poll until terminal.
+   * Dispatches a batch job against the given pre-staged MinIO prefix and polls until
+   * the job reaches a terminal state.
    *
-   * @param inputDir Local directory containing simulation files to stage.
+   * @param minioPrefix The MinIO object prefix where inputs are already staged.
    * @param simulation Name of the simulation to run.
    * @param replicates Number of replicates to execute.
    * @return The final job status.
-   * @throws Exception If staging, dispatch, or polling fails.
+   * @throws Exception If dispatch or polling fails.
    */
-  public JobStatus execute(File inputDir, String simulation, int replicates) throws Exception {
+  public JobStatus execute(String minioPrefix, String simulation, int replicates)
+      throws Exception {
     String jobId = UUID.randomUUID().toString();
-    String minioPrefix = "batch-jobs/" + jobId + "/inputs/";
+    String prefix = MinioHandler.normalizePrefix(minioPrefix);
 
-    output.printInfo("Staging " + inputDir.getName() + " to MinIO (" + minioPrefix + ")...");
-    stageDirectory(inputDir, minioPrefix);
-    output.printInfo("Staging complete.");
-
-    output.printInfo("Dispatching to target (" + replicates + " replicates)...");
-    target.dispatch(jobId, minioPrefix, simulation, replicates);
+    output.printInfo("Dispatching to target (" + replicates + " replicates) against "
+        + prefix + "...");
+    target.dispatch(jobId, prefix, simulation, replicates);
     output.printInfo("Dispatched. Polling for completion...");
 
     return pollUntilTerminal(jobId);
   }
 
   /**
-   * Stages and dispatches without waiting for completion.
+   * Dispatches without waiting for completion. Returns the jobId for manual tracking.
    *
-   * @param inputDir Local directory containing simulation files to stage.
+   * @param minioPrefix The MinIO object prefix where inputs are already staged.
    * @param simulation Name of the simulation to run.
    * @param replicates Number of replicates to execute.
    * @return The jobId for manual status tracking.
-   * @throws Exception If staging or dispatch fails.
+   * @throws Exception If dispatch fails.
    */
-  public String executeNoWait(File inputDir, String simulation, int replicates) throws Exception {
+  public String executeNoWait(String minioPrefix, String simulation, int replicates)
+      throws Exception {
     String jobId = UUID.randomUUID().toString();
-    String minioPrefix = "batch-jobs/" + jobId + "/inputs/";
+    String prefix = MinioHandler.normalizePrefix(minioPrefix);
 
-    output.printInfo("Staging " + inputDir.getName() + " to MinIO (" + minioPrefix + ")...");
-    stageDirectory(inputDir, minioPrefix);
-    output.printInfo("Staging complete.");
-
-    output.printInfo("Dispatching to target (" + replicates + " replicates)...");
-    target.dispatch(jobId, minioPrefix, simulation, replicates);
+    output.printInfo("Dispatching to target (" + replicates + " replicates) against "
+        + prefix + "...");
+    target.dispatch(jobId, prefix, simulation, replicates);
     output.printInfo("Dispatched. Status path: batch-status/" + jobId + "/status.json");
 
     return jobId;
-  }
-
-  private void stageDirectory(File inputDir, String prefix) throws IOException {
-    Path basePath = inputDir.toPath();
-    try (Stream<Path> walker = Files.walk(basePath)) {
-      List<Path> files = walker.filter(Files::isRegularFile).toList();
-      for (Path file : files) {
-        String relativePath = basePath.relativize(file).toString();
-        String objectPath = prefix + relativePath;
-        if (!minioHandler.uploadFile(file.toFile(), objectPath)) {
-          throw new IOException("Failed to upload " + file);
-        }
-      }
-    }
   }
 
   private JobStatus pollUntilTerminal(String jobId) throws Exception {

--- a/src/main/java/org/joshsim/util/MinioHandler.java
+++ b/src/main/java/org/joshsim/util/MinioHandler.java
@@ -4,6 +4,8 @@
 
 package org.joshsim.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.minio.BucketExistsArgs;
 import io.minio.GetObjectArgs;
 import io.minio.ListObjectsArgs;
@@ -17,14 +19,67 @@ import io.minio.messages.Item;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Handles operations related to Minio, such as bucket management and file uploads.
  */
 public class MinioHandler {
+
+  /**
+   * Basename of the sentinel file written by {@link #writeStagedSentinel} at the root of a
+   * staged MinIO prefix. Downstream dispatchers read this to confirm that staging completed
+   * cleanly before dispatching a batch job against the prefix.
+   */
+  public static final String STAGED_SENTINEL_FILENAME = ".josh-staged.json";
+
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  /** Lifecycle state of a staged MinIO prefix, serialized to {@code .josh-staged.json}. */
+  public enum StagedState {
+    STAGING, COMPLETE, ERROR;
+
+    String jsonValue() {
+      return name().toLowerCase();
+    }
+
+    static StagedState fromJson(String value) {
+      if (value == null) {
+        return null;
+      }
+      return switch (value) {
+        case "staging" -> STAGING;
+        case "complete" -> COMPLETE;
+        case "error" -> ERROR;
+        default -> null;
+      };
+    }
+  }
+
+  /**
+   * Parsed contents of a {@code .josh-staged.json} sentinel. Only the timestamp matching the
+   * current {@link #state()} is expected to be populated by the writer; all other fields may
+   * be null.
+   */
+  public record StagedStatus(
+      StagedState state,
+      String startedAt,
+      String completedAt,
+      String failedAt,
+      String message
+  ) {}
+
   private final MinioClient minioClient;
   private final String bucketName;
   private final String basePath;
@@ -263,6 +318,121 @@ public class MinioHandler {
       output.printInfo("Deleted " + keys.size() + " objects under " + prefix);
     }
     return keys.size();
+  }
+
+  /**
+   * Append a trailing slash to a MinIO object prefix if one is not already present.
+   *
+   * @param prefix The prefix to normalize.
+   * @return The prefix with a guaranteed trailing slash.
+   */
+  public static String normalizePrefix(String prefix) {
+    return prefix.endsWith("/") ? prefix : prefix + "/";
+  }
+
+  /**
+   * Upload every regular file under {@code localDir} to {@code <prefix><relative-path>}.
+   *
+   * <p>Directory structure under {@code localDir} is preserved. The prefix is normalized
+   * with {@link #normalizePrefix(String)} before use. Fails fast on the first upload error.</p>
+   *
+   * @param localDir The local directory to upload from.
+   * @param prefix The MinIO object prefix to upload into.
+   * @return The number of files uploaded.
+   * @throws IOException If any upload fails or the directory cannot be walked.
+   */
+  public int uploadDirectory(File localDir, String prefix) throws IOException {
+    String normalizedPrefix = normalizePrefix(prefix);
+    Path basePath = localDir.toPath();
+    int count = 0;
+    try (Stream<Path> walker = Files.walk(basePath)) {
+      List<Path> files = walker.filter(Files::isRegularFile).toList();
+      for (Path file : files) {
+        String relativePath = basePath.relativize(file).toString();
+        String objectPath = normalizedPrefix + relativePath;
+        if (!uploadFile(file.toFile(), objectPath)) {
+          throw new IOException("Failed to upload " + file);
+        }
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Write the {@link #STAGED_SENTINEL_FILENAME} sentinel at the root of the given prefix.
+   *
+   * <p>The JSON payload carries a {@code status} field (matching the shape used by
+   * {@code JoshSimBatchHandler} for job status) plus the timestamp field corresponding to
+   * the state, and an optional {@code message} field for {@link StagedState#ERROR}.</p>
+   *
+   * @param prefix The MinIO object prefix the sentinel describes.
+   * @param state The lifecycle state to record.
+   * @param messageOrNull Optional human-readable message (used for {@code ERROR}; may be null).
+   * @throws IOException If writing the sentinel fails.
+   */
+  public void writeStagedSentinel(String prefix, StagedState state, String messageOrNull)
+      throws IOException {
+    String path = normalizePrefix(prefix) + STAGED_SENTINEL_FILENAME;
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("status", state.jsonValue());
+    String now = Instant.now().toString();
+    switch (state) {
+      case STAGING -> fields.put("startedAt", now);
+      case COMPLETE -> fields.put("completedAt", now);
+      case ERROR -> fields.put("failedAt", now);
+      default -> { }
+    }
+    if (state == StagedState.ERROR && messageOrNull != null) {
+      fields.put("message", messageOrNull);
+    }
+    byte[] bytes = JSON.writeValueAsBytes(fields);
+    try {
+      putBytes(bytes, path, "application/json");
+    } catch (Exception e) {
+      throw new IOException("Failed to write staged sentinel to " + path + ": "
+          + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Read and parse the {@link #STAGED_SENTINEL_FILENAME} sentinel at the root of the given
+   * prefix. Returns {@link Optional#empty()} if the sentinel does not exist.
+   *
+   * @param prefix The MinIO object prefix whose sentinel should be read.
+   * @return The parsed sentinel, or empty if absent.
+   * @throws IOException If reading fails for any reason other than missing object.
+   */
+  public Optional<StagedStatus> readStagedSentinel(String prefix) throws IOException {
+    String path = normalizePrefix(prefix) + STAGED_SENTINEL_FILENAME;
+    String json;
+    try (InputStream stream = downloadStream(path)) {
+      json = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      if (isNotFoundError(e)) {
+        return Optional.empty();
+      }
+      throw new IOException("Failed to read staged sentinel at " + path + ": "
+          + e.getMessage(), e);
+    }
+    JsonNode root = JSON.readTree(json);
+    return Optional.of(new StagedStatus(
+        StagedState.fromJson(root.has("status") ? root.get("status").asText() : null),
+        root.has("startedAt") ? root.get("startedAt").asText() : null,
+        root.has("completedAt") ? root.get("completedAt").asText() : null,
+        root.has("failedAt") ? root.get("failedAt").asText() : null,
+        root.has("message") ? root.get("message").asText() : null
+    ));
+  }
+
+  private static boolean isNotFoundError(Exception exception) {
+    String message = exception.getMessage();
+    if (message == null) {
+      return false;
+    }
+    return message.contains("NoSuchKey")
+        || message.contains("The specified key does not exist")
+        || message.contains("Object does not exist");
   }
 
   /**

--- a/src/main/java/org/joshsim/util/MinioHandler.java
+++ b/src/main/java/org/joshsim/util/MinioHandler.java
@@ -381,7 +381,6 @@ public class MinioHandler {
       case STAGING -> fields.put("startedAt", now);
       case COMPLETE -> fields.put("completedAt", now);
       case ERROR -> fields.put("failedAt", now);
-      default -> { }
     }
     if (state == StagedState.ERROR && messageOrNull != null) {
       fields.put("message", messageOrNull);

--- a/src/main/java/org/joshsim/util/MinioHandler.java
+++ b/src/main/java/org/joshsim/util/MinioHandler.java
@@ -381,6 +381,7 @@ public class MinioHandler {
       case STAGING -> fields.put("startedAt", now);
       case COMPLETE -> fields.put("completedAt", now);
       case ERROR -> fields.put("failedAt", now);
+      default -> throw new IllegalStateException("Unhandled StagedState: " + state);
     }
     if (state == StagedState.ERROR && messageOrNull != null) {
       fields.put("message", messageOrNull);

--- a/src/main/java/org/joshsim/util/MinioStagingUtil.java
+++ b/src/main/java/org/joshsim/util/MinioStagingUtil.java
@@ -49,6 +49,10 @@ public class MinioStagingUtil {
       if (relativePath.isEmpty()) {
         continue;
       }
+      if (relativePath.equals(MinioHandler.STAGED_SENTINEL_FILENAME)
+          || relativePath.endsWith("/" + MinioHandler.STAGED_SENTINEL_FILENAME)) {
+        continue;
+      }
       File destination = new File(outputDir, relativePath);
 
       File parentDir = destination.getParentFile();
@@ -58,6 +62,12 @@ public class MinioStagingUtil {
 
       minio.downloadFile(key, destination);
       downloaded++;
+    }
+
+    if (downloaded == 0) {
+      throw new IllegalArgumentException(
+          "No input objects found under prefix: " + normalizedPrefix
+              + " (sentinel present but no data files)");
     }
 
     output.printInfo("Downloaded " + downloaded + " file(s) to " + outputDir.getPath());

--- a/src/test/java/org/joshsim/command/BatchRemoteCommandTest.java
+++ b/src/test/java/org/joshsim/command/BatchRemoteCommandTest.java
@@ -1,0 +1,89 @@
+/**
+ * Tests for BatchRemoteCommand wiring.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+
+/**
+ * Schema and usage tests for {@link BatchRemoteCommand}.
+ *
+ * <p>Verifies the flag layout (simulation as positional; {@code --minio-prefix} required;
+ * {@code --stage-from-local-dir} and {@code --require-prestaged} optional) and exercises
+ * the mutex check via a real command invocation.</p>
+ */
+public class BatchRemoteCommandTest {
+
+  @Test
+  void command_shouldBeRegisteredWithCorrectName() {
+    var annotation = BatchRemoteCommand.class.getAnnotation(CommandLine.Command.class);
+    assertEquals("batchRemote", annotation.name());
+  }
+
+  @Test
+  void simulation_shouldBeIndexZeroPositional() throws Exception {
+    var field = BatchRemoteCommand.class.getDeclaredField("simulation");
+    var parameter = field.getAnnotation(CommandLine.Parameters.class);
+    assertEquals("0", parameter.index());
+  }
+
+  @Test
+  void minioPrefix_shouldBeRequired() throws Exception {
+    var field = BatchRemoteCommand.class.getDeclaredField("minioPrefix");
+    var option = field.getAnnotation(CommandLine.Option.class);
+    assertEquals(true, option.required());
+    assertTrue(java.util.Arrays.asList(option.names()).contains("--minio-prefix"));
+  }
+
+  @Test
+  void stageFromLocalDir_shouldBeOptional() throws Exception {
+    var field = BatchRemoteCommand.class.getDeclaredField("stageFromLocalDir");
+    var option = field.getAnnotation(CommandLine.Option.class);
+    assertEquals(false, option.required());
+    assertEquals(File.class, field.getType());
+    assertTrue(java.util.Arrays.asList(option.names()).contains("--stage-from-local-dir"));
+  }
+
+  @Test
+  void requirePrestaged_shouldBeOptionalBoolean() throws Exception {
+    var field = BatchRemoteCommand.class.getDeclaredField("requirePrestaged");
+    var option = field.getAnnotation(CommandLine.Option.class);
+    assertEquals(false, option.required());
+    assertEquals(boolean.class, field.getType());
+    assertTrue(java.util.Arrays.asList(option.names()).contains("--require-prestaged"));
+  }
+
+  @Test
+  void input_shouldNoLongerExist() {
+    try {
+      BatchRemoteCommand.class.getDeclaredField("input");
+      throw new AssertionError("positional <input> field should have been removed");
+    } catch (NoSuchFieldException expected) {
+      // ok
+    }
+  }
+
+  @Test
+  void mutuallyExclusiveFlags_returnUsageError() {
+    BatchRemoteCommand command = new BatchRemoteCommand();
+    CommandLine cli = new CommandLine(command);
+    int exit = cli.execute(
+        "MySim",
+        "--target=nonexistent-profile",
+        "--minio-prefix=batch-jobs/foo/inputs/",
+        "--stage-from-local-dir=/tmp",
+        "--require-prestaged"
+    );
+    // 102 is USAGE_ERROR_CODE in BatchRemoteCommand.
+    assertEquals(102, exit);
+  }
+}

--- a/src/test/java/org/joshsim/pipeline/target/BatchJobStrategyTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/BatchJobStrategyTest.java
@@ -9,7 +9,6 @@ package org.joshsim.pipeline.target;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -18,14 +17,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import org.joshsim.util.MinioHandler;
 import org.joshsim.util.OutputOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 
 
 /**
@@ -35,41 +30,40 @@ class BatchJobStrategyTest {
 
   private RemoteBatchTarget target;
   private BatchPollingStrategy poller;
-  private MinioHandler minioHandler;
   private OutputOptions output;
 
-  @TempDir
-  File tempDir;
-
   @BeforeEach
-  void setUp() throws IOException {
+  void setUp() {
     target = mock(RemoteBatchTarget.class);
     poller = mock(BatchPollingStrategy.class);
-    minioHandler = mock(MinioHandler.class);
     output = new OutputOptions();
-
-    // Create a test file in the temp directory
-    Files.writeString(new File(tempDir, "test.josh").toPath(), "start simulation Test end");
-
-    // Make uploads succeed by default
-    when(minioHandler.uploadFile(any(File.class), anyString())).thenReturn(true);
   }
 
   @Test
-  void executeStagesDispatchesAndPolls() throws Exception {
+  void executeDispatchesAndPolls() throws Exception {
     when(poller.poll(anyString()))
         .thenReturn(new JobStatus(JobStatus.State.RUNNING))
         .thenReturn(new JobStatus(JobStatus.State.COMPLETE, null, "2026-04-14T12:00:00Z"));
 
-    BatchJobStrategy strategy = new BatchJobStrategy(
-        target, poller, minioHandler, output, 10, 60000
-    );
+    BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    JobStatus result = strategy.execute(tempDir, "Test", 1);
+    JobStatus result = strategy.execute("batch-jobs/foo/inputs/", "Test", 1);
 
     assertEquals(JobStatus.State.COMPLETE, result.getState());
-    verify(minioHandler).uploadFile(any(File.class), anyString());
-    verify(target).dispatch(anyString(), anyString(), eq("Test"), eq(1));
+    verify(target).dispatch(anyString(), eq("batch-jobs/foo/inputs/"), eq("Test"), eq(1));
+  }
+
+  @Test
+  void executeNormalizesTrailingSlash() throws Exception {
+    when(poller.poll(anyString())).thenReturn(new JobStatus(JobStatus.State.COMPLETE));
+
+    BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
+
+    strategy.execute("batch-jobs/foo/inputs", "Test", 1);
+
+    ArgumentCaptor<String> prefixCaptor = ArgumentCaptor.forClass(String.class);
+    verify(target).dispatch(anyString(), prefixCaptor.capture(), eq("Test"), eq(1));
+    assertEquals("batch-jobs/foo/inputs/", prefixCaptor.getValue());
   }
 
   @Test
@@ -77,11 +71,9 @@ class BatchJobStrategyTest {
     when(poller.poll(anyString()))
         .thenReturn(new JobStatus(JobStatus.State.COMPLETE));
 
-    BatchJobStrategy strategy = new BatchJobStrategy(
-        target, poller, minioHandler, output, 10, 60000
-    );
+    BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    strategy.execute(tempDir, "Main", 10);
+    strategy.execute("batch-jobs/foo/inputs/", "Main", 10);
 
     verify(target).dispatch(anyString(), anyString(), eq("Main"), eq(10));
   }
@@ -91,11 +83,9 @@ class BatchJobStrategyTest {
     when(poller.poll(anyString()))
         .thenReturn(new JobStatus(JobStatus.State.ERROR, "Simulation not found", null));
 
-    BatchJobStrategy strategy = new BatchJobStrategy(
-        target, poller, minioHandler, output, 10, 60000
-    );
+    BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    JobStatus result = strategy.execute(tempDir, "BadSim", 1);
+    JobStatus result = strategy.execute("batch-jobs/foo/inputs/", "BadSim", 1);
 
     assertEquals(JobStatus.State.ERROR, result.getState());
     assertEquals("Simulation not found", result.getMessage().get());
@@ -103,15 +93,11 @@ class BatchJobStrategyTest {
 
   @Test
   void executeTimesOut() throws Exception {
-    when(poller.poll(anyString()))
-        .thenReturn(new JobStatus(JobStatus.State.RUNNING));
+    when(poller.poll(anyString())).thenReturn(new JobStatus(JobStatus.State.RUNNING));
 
-    // Very short timeout
-    BatchJobStrategy strategy = new BatchJobStrategy(
-        target, poller, minioHandler, output, 10, 50
-    );
+    BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 50);
 
-    JobStatus result = strategy.execute(tempDir, "SlowSim", 1);
+    JobStatus result = strategy.execute("batch-jobs/foo/inputs/", "SlowSim", 1);
 
     assertEquals(JobStatus.State.ERROR, result.getState());
     assertTrue(result.getMessage().get().contains("timed out"));
@@ -119,26 +105,13 @@ class BatchJobStrategyTest {
 
   @Test
   void executeNoWaitSkipsPolling() throws Exception {
-    BatchJobStrategy strategy = new BatchJobStrategy(
-        target, poller, minioHandler, output, 10, 60000
-    );
+    BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    String jobId = strategy.executeNoWait(tempDir, "Test", 5);
+    String jobId = strategy.executeNoWait("batch-jobs/foo/inputs/", "Test", 5);
 
     assertTrue(jobId != null && !jobId.isEmpty());
-    verify(target).dispatch(anyString(), anyString(), eq("Test"), eq(5));
+    verify(target).dispatch(anyString(), eq("batch-jobs/foo/inputs/"), eq("Test"), eq(5));
     verify(poller, never()).poll(anyString());
-  }
-
-  @Test
-  void executeThrowsOnStagingFailure() throws Exception {
-    when(minioHandler.uploadFile(any(File.class), anyString())).thenReturn(false);
-
-    BatchJobStrategy strategy = new BatchJobStrategy(
-        target, poller, minioHandler, output, 10, 60000
-    );
-
-    assertThrows(IOException.class, () -> strategy.execute(tempDir, "Test", 1));
   }
 
   @Test
@@ -146,10 +119,9 @@ class BatchJobStrategyTest {
     doThrow(new RuntimeException("Connection refused"))
         .when(target).dispatch(anyString(), anyString(), anyString(), eq(1));
 
-    BatchJobStrategy strategy = new BatchJobStrategy(
-        target, poller, minioHandler, output, 10, 60000
-    );
+    BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    assertThrows(RuntimeException.class, () -> strategy.execute(tempDir, "Test", 1));
+    assertThrows(RuntimeException.class,
+        () -> strategy.execute("batch-jobs/foo/inputs/", "Test", 1));
   }
 }

--- a/src/test/java/org/joshsim/util/MinioHandlerTest.java
+++ b/src/test/java/org/joshsim/util/MinioHandlerTest.java
@@ -19,16 +19,21 @@ import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
 import io.minio.RemoveObjectArgs;
 import io.minio.Result;
+import io.minio.UploadObjectArgs;
 import io.minio.messages.Item;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import okhttp3.Headers;
+import org.joshsim.util.MinioHandler.StagedState;
+import org.joshsim.util.MinioHandler.StagedStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -359,5 +364,165 @@ public class MinioHandlerTest {
     // Verify
     assertEquals(0, deleted);
     verify(minioClient, never()).removeObject(any(RemoveObjectArgs.class));
+  }
+
+  // --- normalizePrefix tests ---
+
+  @Test
+  void normalizePrefix_appendsSlashWhenMissing() {
+    assertEquals("batch-jobs/foo/inputs/", MinioHandler.normalizePrefix("batch-jobs/foo/inputs"));
+  }
+
+  @Test
+  void normalizePrefix_leavesTrailingSlashAlone() {
+    assertEquals("batch-jobs/foo/inputs/", MinioHandler.normalizePrefix("batch-jobs/foo/inputs/"));
+  }
+
+  // --- uploadDirectory tests ---
+
+  @Test
+  void uploadDirectory_walksAndUploadsWithRelativeKeys() throws Exception {
+    MinioHandler handler = createHandler();
+    File root = new File(tempDir, "inputs");
+    File nested = new File(root, "sub");
+    assertTrue(nested.mkdirs());
+    Files.writeString(new File(root, "a.txt").toPath(), "a");
+    Files.writeString(new File(nested, "b.txt").toPath(), "b");
+
+    int count = handler.uploadDirectory(root, "prefix/");
+
+    assertEquals(2, count);
+    ArgumentCaptor<UploadObjectArgs> captor = ArgumentCaptor.forClass(UploadObjectArgs.class);
+    verify(minioClient, times(2)).uploadObject(captor.capture());
+    List<String> objects = captor.getAllValues().stream().map(UploadObjectArgs::object).sorted()
+        .toList();
+    assertEquals(List.of("prefix/a.txt", "prefix/sub/b.txt"), objects);
+  }
+
+  @Test
+  void uploadDirectory_normalizesPrefixWithoutTrailingSlash() throws Exception {
+    MinioHandler handler = createHandler();
+    File root = new File(tempDir, "inputs");
+    assertTrue(root.mkdirs());
+    Files.writeString(new File(root, "a.txt").toPath(), "a");
+
+    handler.uploadDirectory(root, "prefix");
+
+    ArgumentCaptor<UploadObjectArgs> captor = ArgumentCaptor.forClass(UploadObjectArgs.class);
+    verify(minioClient).uploadObject(captor.capture());
+    assertEquals("prefix/a.txt", captor.getValue().object());
+  }
+
+  @Test
+  void uploadDirectory_throwsOnUploadFailure() throws Exception {
+    MinioHandler handler = createHandler();
+    File root = new File(tempDir, "inputs");
+    assertTrue(root.mkdirs());
+    Files.writeString(new File(root, "a.txt").toPath(), "a");
+    when(minioClient.uploadObject(any(UploadObjectArgs.class)))
+        .thenThrow(new RuntimeException("upload kaboom"));
+
+    assertThrows(IOException.class, () -> handler.uploadDirectory(root, "prefix/"));
+  }
+
+  // --- sentinel tests ---
+
+  @Test
+  void writeStagedSentinel_writesCorrectObjectPath() throws Exception {
+    MinioHandler handler = createHandler();
+
+    handler.writeStagedSentinel("batch-jobs/foo/inputs/", StagedState.STAGING, null);
+
+    ArgumentCaptor<PutObjectArgs> captor = ArgumentCaptor.forClass(PutObjectArgs.class);
+    verify(minioClient).putObject(captor.capture());
+    assertEquals("batch-jobs/foo/inputs/.josh-staged.json", captor.getValue().object());
+    assertEquals("application/json", captor.getValue().contentType());
+  }
+
+  @Test
+  void writeStagedSentinel_normalizesPrefixWithoutTrailingSlash() throws Exception {
+    MinioHandler handler = createHandler();
+
+    handler.writeStagedSentinel("batch-jobs/foo/inputs", StagedState.COMPLETE, null);
+
+    ArgumentCaptor<PutObjectArgs> captor = ArgumentCaptor.forClass(PutObjectArgs.class);
+    verify(minioClient).putObject(captor.capture());
+    assertEquals("batch-jobs/foo/inputs/.josh-staged.json", captor.getValue().object());
+  }
+
+  @Test
+  void readStagedSentinel_parsesCompleteState() throws Exception {
+    MinioHandler handler = createHandler();
+    byte[] json = "{\"status\":\"complete\",\"completedAt\":\"2026-04-22T12:00:00Z\"}"
+        .getBytes(StandardCharsets.UTF_8);
+    GetObjectResponse mockResponse = new GetObjectResponse(
+        Headers.of(), testBucket, "", "prefix/.josh-staged.json",
+        new ByteArrayInputStream(json)
+    );
+    when(minioClient.getObject(any(GetObjectArgs.class))).thenReturn(mockResponse);
+
+    Optional<StagedStatus> status = handler.readStagedSentinel("prefix/");
+
+    assertTrue(status.isPresent());
+    assertEquals(StagedState.COMPLETE, status.get().state());
+    assertEquals("2026-04-22T12:00:00Z", status.get().completedAt());
+    assertTrue(status.get().startedAt() == null);
+    assertTrue(status.get().message() == null);
+  }
+
+  @Test
+  void readStagedSentinel_parsesErrorStateWithMessage() throws Exception {
+    MinioHandler handler = createHandler();
+    byte[] json = ("{\"status\":\"error\",\"failedAt\":\"2026-04-22T12:00:00Z\","
+        + "\"message\":\"disk full\"}").getBytes(StandardCharsets.UTF_8);
+    GetObjectResponse mockResponse = new GetObjectResponse(
+        Headers.of(), testBucket, "", "prefix/.josh-staged.json",
+        new ByteArrayInputStream(json)
+    );
+    when(minioClient.getObject(any(GetObjectArgs.class))).thenReturn(mockResponse);
+
+    Optional<StagedStatus> status = handler.readStagedSentinel("prefix/");
+
+    assertTrue(status.isPresent());
+    assertEquals(StagedState.ERROR, status.get().state());
+    assertEquals("disk full", status.get().message());
+    assertEquals("2026-04-22T12:00:00Z", status.get().failedAt());
+  }
+
+  @Test
+  void readStagedSentinel_readsFromCorrectPath() throws Exception {
+    MinioHandler handler = createHandler();
+    byte[] json = "{\"status\":\"complete\"}".getBytes(StandardCharsets.UTF_8);
+    GetObjectResponse mockResponse = new GetObjectResponse(
+        Headers.of(), testBucket, "", "prefix/.josh-staged.json",
+        new ByteArrayInputStream(json)
+    );
+    when(minioClient.getObject(any(GetObjectArgs.class))).thenReturn(mockResponse);
+
+    handler.readStagedSentinel("prefix");
+
+    ArgumentCaptor<GetObjectArgs> captor = ArgumentCaptor.forClass(GetObjectArgs.class);
+    verify(minioClient).getObject(captor.capture());
+    assertEquals("prefix/.josh-staged.json", captor.getValue().object());
+  }
+
+  @Test
+  void readStagedSentinel_returnsEmptyWhenMissing() throws Exception {
+    MinioHandler handler = createHandler();
+    when(minioClient.getObject(any(GetObjectArgs.class)))
+        .thenThrow(new RuntimeException("NoSuchKey: no such object exists"));
+
+    Optional<StagedStatus> status = handler.readStagedSentinel("prefix/");
+
+    assertTrue(status.isEmpty());
+  }
+
+  @Test
+  void readStagedSentinel_propagatesNonNotFoundError() throws Exception {
+    MinioHandler handler = createHandler();
+    when(minioClient.getObject(any(GetObjectArgs.class)))
+        .thenThrow(new RuntimeException("permission denied"));
+
+    assertThrows(IOException.class, () -> handler.readStagedSentinel("prefix/"));
   }
 }

--- a/src/test/java/org/joshsim/util/MinioHandlerTest.java
+++ b/src/test/java/org/joshsim/util/MinioHandlerTest.java
@@ -382,13 +382,13 @@ public class MinioHandlerTest {
 
   @Test
   void uploadDirectory_walksAndUploadsWithRelativeKeys() throws Exception {
-    MinioHandler handler = createHandler();
     File root = new File(tempDir, "inputs");
     File nested = new File(root, "sub");
     assertTrue(nested.mkdirs());
     Files.writeString(new File(root, "a.txt").toPath(), "a");
     Files.writeString(new File(nested, "b.txt").toPath(), "b");
 
+    MinioHandler handler = createHandler();
     int count = handler.uploadDirectory(root, "prefix/");
 
     assertEquals(2, count);
@@ -415,13 +415,13 @@ public class MinioHandlerTest {
 
   @Test
   void uploadDirectory_throwsOnUploadFailure() throws Exception {
-    MinioHandler handler = createHandler();
     File root = new File(tempDir, "inputs");
     assertTrue(root.mkdirs());
     Files.writeString(new File(root, "a.txt").toPath(), "a");
     when(minioClient.uploadObject(any(UploadObjectArgs.class)))
         .thenThrow(new RuntimeException("upload kaboom"));
 
+    MinioHandler handler = createHandler();
     assertThrows(IOException.class, () -> handler.uploadDirectory(root, "prefix/"));
   }
 

--- a/src/test/java/org/joshsim/util/MinioStagingUtilTest.java
+++ b/src/test/java/org/joshsim/util/MinioStagingUtilTest.java
@@ -1,0 +1,110 @@
+/**
+ * Tests for MinioStagingUtil.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+
+/**
+ * Unit tests for {@link MinioStagingUtil}, focused on the {@code .josh-staged.json}
+ * sentinel skip and the "no data files" guard.
+ */
+public class MinioStagingUtilTest {
+
+  private MinioHandler minio;
+  private OutputOptions output;
+
+  @TempDir
+  File tempDir;
+
+  @BeforeEach
+  void setUp() {
+    minio = mock(MinioHandler.class);
+    output = mock(OutputOptions.class);
+  }
+
+  private void stubDownload(String relativePath, String contents) throws Exception {
+    doAnswer(inv -> {
+      File dest = inv.getArgument(1);
+      Files.writeString(dest.toPath(), contents);
+      return null;
+    }).when(minio).downloadFile(eq(relativePath), any(File.class));
+  }
+
+  @Test
+  void skipsSentinelAtPrefixRoot() throws Exception {
+    when(minio.listObjects(anyString())).thenReturn(List.of(
+        "batch-jobs/foo/inputs/a.txt",
+        "batch-jobs/foo/inputs/.josh-staged.json"
+    ));
+    stubDownload("batch-jobs/foo/inputs/a.txt", "hello");
+
+    int downloaded = MinioStagingUtil.stageFromMinio(
+        minio, "batch-jobs/foo/inputs/", tempDir, output);
+
+    assertEquals(1, downloaded);
+    assertTrue(new File(tempDir, "a.txt").exists());
+    assertFalse(new File(tempDir, ".josh-staged.json").exists());
+    verify(minio, never()).downloadFile(eq("batch-jobs/foo/inputs/.josh-staged.json"),
+        any(File.class));
+  }
+
+  @Test
+  void skipsNestedSentinelFiles() throws Exception {
+    when(minio.listObjects(anyString())).thenReturn(List.of(
+        "batch-jobs/foo/inputs/.josh-staged.json",
+        "batch-jobs/foo/inputs/sub/.josh-staged.json",
+        "batch-jobs/foo/inputs/sub/data.csv"
+    ));
+    stubDownload("batch-jobs/foo/inputs/sub/data.csv", "x,y");
+
+    int downloaded = MinioStagingUtil.stageFromMinio(
+        minio, "batch-jobs/foo/inputs/", tempDir, output);
+
+    assertEquals(1, downloaded);
+    assertTrue(new File(new File(tempDir, "sub"), "data.csv").exists());
+    assertFalse(new File(tempDir, ".josh-staged.json").exists());
+    assertFalse(new File(new File(tempDir, "sub"), ".josh-staged.json").exists());
+  }
+
+  @Test
+  void throwsWhenPrefixContainsOnlySentinel() throws Exception {
+    when(minio.listObjects(anyString())).thenReturn(List.of(
+        "batch-jobs/foo/inputs/.josh-staged.json"
+    ));
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> MinioStagingUtil.stageFromMinio(minio, "batch-jobs/foo/inputs/", tempDir, output));
+    assertTrue(ex.getMessage().contains("No input objects"));
+  }
+
+  @Test
+  void throwsWhenPrefixIsEmpty() throws Exception {
+    when(minio.listObjects(anyString())).thenReturn(List.of());
+
+    assertThrows(IllegalArgumentException.class,
+        () -> MinioStagingUtil.stageFromMinio(minio, "empty/", tempDir, output));
+  }
+}


### PR DESCRIPTION
## Summary

Replaces `batchRemote`'s positional `<input>` arg with flag-based UX (simulation stays positional, everything else flags — modeled on `run`/`runRemote`), and introduces a `.josh-staged.json` sentinel so self-staging and pre-staged dispatch share a readiness protocol.

Three modes:
- **`--stage-from-local-dir=DIR`** — upload + write sentinel, then dispatch (the former positional default, now explicit).
- **default** — read sentinel; warn if absent (manual-upload case), fail if in-progress/errored, proceed if `complete`.
- **`--require-prestaged`** — fail fast unless the sentinel reports `complete`. For shared/multi-dispatch workflows.

`--stage-from-local-dir` and `--require-prestaged` are mutually exclusive.

## Changes

- **`MinioHandler`** — adds `normalizePrefix`, `uploadDirectory`, `writeStagedSentinel`, `readStagedSentinel`, plus `StagedState` enum and `StagedStatus` record. Sentinel JSON shape matches `JoshSimBatchHandler`'s job-status format verbatim so the two writers can be consolidated in a follow-up.
- **`StageToMinioCommand`** — always writes the sentinel (`staging` → `complete`, or `error` with the upload exception message on failure); delegates the walk+upload to `MinioHandler.uploadDirectory`.
- **`MinioStagingUtil.stageFromMinio`** — skips `.josh-staged.json` at any depth so workers never see the sentinel; throws if every key was filtered out (prevents silently empty workdirs).
- **`BatchJobStrategy`** — now prefix-only. `execute` and `executeNoWait` take `String minioPrefix`; the `File inputDir` entrypoints are gone. Staging is the command's responsibility.
- **`BatchRemoteCommand`** — rewritten schema (positional simulation; required `--minio-prefix`; optional `--stage-from-local-dir`, `--require-prestaged`). Preserves this branch's K8s target support and the `--no-wait` structured JSON output from PR #409.
- Tests updated/added: rewrote `BatchJobStrategyTest` for the prefix API, added sentinel coverage to `MinioHandlerTest`, new `MinioStagingUtilTest` (skip + empty-guard), new `BatchRemoteCommandTest` (schema + mutex-exit behavior).

## Breaking change

Positional `<input>` is removed outright — no deprecation window. The feature landed in PR #394 and has no known external users yet; keeping the old positional form alive would preserve the exact non-self-documenting syntax this change is here to kill.

## Follow-up

`JoshSimBatchHandler.java:267-305` writes job-status JSON with the same shape/approach as the new sentinel. Should be consolidated onto the shared `writeStagedSentinel` / `StagedStatus` helper once this lands — tracking as a separate issue.

## Test plan

- [ ] `./gradlew test` — I was unable to run locally (sandbox can't reach `services.gradle.org` for the wrapper or `repo.osgeo.org` for geotools/ucar POMs, and nothing was in the offline cache). CI needs to validate.
- [ ] `./gradlew build` — same.
- [ ] End-to-end against an HTTP target + MinIO:
  - Mode 1 (`--stage-from-local-dir`): confirm sentinel transitions `staging` → `complete` and dispatch proceeds.
  - Mode 2 (no staging flag, sentinel present & complete): dispatch proceeds silently.
  - Mode 2 (sentinel absent): warning fires, dispatch proceeds.
  - Mode 3 (`--require-prestaged`, sentinel missing): hard fail without dispatching.
  - Mutex: `--stage-from-local-dir=X --require-prestaged` → clear usage error, exit 102.
- [ ] Kubernetes target: verify the K8s dispatch path still works with the new prefix-only `BatchJobStrategy` signature.
- [ ] Verify worker workdirs on the batch host never contain `.josh-staged.json`.

https://claude.ai/code/session_01RchqGomciS8ZJxkWpdR3qH