### PR TITLE
batchRemote: remove --stage-from-local-dir flag

### DIFF
--- a/.github/workflows/test-k8s.yaml
+++ b/.github/workflows/test-k8s.yaml
@@ -134,12 +134,22 @@ jobs:
           echo "Test data ready ($(stat -c%s examples/test/k8s-preprocess/grid_10x10_constant.tiff) bytes)"
 
       - name: Run batchRemote end-to-end
+        env:
+          MINIO_ENDPOINT: http://localhost:9000
+          MINIO_ACCESS_KEY: minioadmin
+          MINIO_SECRET_KEY: minioadmin
+          MINIO_BUCKET: josh-test-bucket
         run: |
+          echo "Staging inputs to MinIO..."
+          java -jar build/libs/joshsim-fat.jar stageToMinio \
+            --input-dir=examples/test/k8s/ \
+            --prefix=batch-jobs/k8s-e2e/inputs/
+
           echo "Running batchRemote with K8s target..."
           java -jar build/libs/joshsim-fat.jar batchRemote K8sTest \
             --target=ci-k8s \
             --minio-prefix=batch-jobs/k8s-e2e/inputs/ \
-            --stage-from-local-dir=examples/test/k8s/ \
+            --require-prestaged \
             --replicates=2 \
             --poll-interval=5 \
             --timeout=300
@@ -181,16 +191,26 @@ jobs:
           fi
 
       - name: Test failure detection - bad image
+        env:
+          MINIO_ENDPOINT: http://localhost:9000
+          MINIO_ACCESS_KEY: minioadmin
+          MINIO_SECRET_KEY: minioadmin
+          MINIO_BUCKET: josh-test-bucket
         run: |
           set -o pipefail
           echo "Testing ImagePullBackOff detection..."
+
+          # Stage inputs first (should succeed); batchRemote then fails at dispatch
+          java -jar build/libs/joshsim-fat.jar stageToMinio \
+            --input-dir=examples/test/k8s/ \
+            --prefix=batch-jobs/k8s-bad-image/inputs/
 
           # batchRemote should fail — capture exit code through tee
           EXIT_CODE=0
           java -jar build/libs/joshsim-fat.jar batchRemote K8sTest \
             --target=ci-k8s-bad-image \
             --minio-prefix=batch-jobs/k8s-bad-image/inputs/ \
-            --stage-from-local-dir=examples/test/k8s/ \
+            --require-prestaged \
             --replicates=1 \
             --poll-interval=10 \
             --timeout=120 2>&1 | tee /tmp/bad-image-output.txt || EXIT_CODE=$?

--- a/.github/workflows/test-minio.yaml
+++ b/.github/workflows/test-minio.yaml
@@ -326,11 +326,15 @@ jobs:
           end organism
           JOSH
 
-          # Run batchRemote with wait
+          # Stage inputs first, then dispatch
+          java -jar build/libs/joshsim-fat.jar stageToMinio \
+            --input-dir=/tmp/batch-e2e-test \
+            --prefix=batch-jobs/http-e2e/inputs/
+
           java -jar build/libs/joshsim-fat.jar batchRemote E2ETest \
             --target=ci-local \
             --minio-prefix=batch-jobs/http-e2e/inputs/ \
-            --stage-from-local-dir=/tmp/batch-e2e-test \
+            --require-prestaged \
             --replicates=1 \
             --poll-interval=2 \
             --timeout=120

--- a/README.md
+++ b/README.md
@@ -110,12 +110,13 @@ See also our [example Dockerfile](https://github.com/SchmidtDSE/josh/blob/main/c
 For large-scale runs on your own Kubernetes cluster or server, Josh provides the `batchRemote` command. This stages simulation files to S3-compatible storage (MinIO, GCS, AWS S3), dispatches execution to a configured target, and polls for completion. Results are written back to storage via `minio://` export paths.
 
 ```
+$ java -jar joshsim.jar stageToMinio --input-dir=./sim/ --prefix=batch-jobs/my-run/inputs/
 $ java -jar joshsim.jar batchRemote Main --target=nautilus \
     --minio-prefix=batch-jobs/my-run/inputs/ \
-    --stage-from-local-dir=./sim/ --replicates=50
+    --require-prestaged --replicates=50
 ```
 
-For workflows where inputs are staged once and dispatched many times (e.g. joshpy driving multiple simulations against the same data), stage separately with `stageToMinio` and then dispatch against the shared prefix — pass `--require-prestaged` to fail fast if the sentinel isn't present, or omit it to just warn on manual uploads.
+Stage inputs once with `stageToMinio` and dispatch any number of times against the shared prefix (useful when joshpy drives multiple simulations against the same data). Pass `--require-prestaged` to fail fast if the `.josh-staged.json` sentinel isn't present, or omit it to just warn on manual uploads.
 
 Targets are defined as JSON profiles at `~/.josh/targets/<name>.json`. Two target types are supported:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -303,9 +303,8 @@ java -jar joshsim-fat.jar batchRemote <SimulationName> [OPTIONS]
 
 **Options:**
 - `--target <name>` (required): Target profile name (loads `~/.josh/targets/<name>.json`)
-- `--minio-prefix <prefix>` (required): MinIO object prefix where inputs live (e.g., `batch-jobs/my-run/inputs/`). Populate with `stageToMinio` or `--stage-from-local-dir`.
-- `--stage-from-local-dir <dir>`: Upload this local directory to `--minio-prefix` before dispatching. Writes a `.josh-staged.json` sentinel. Mutually exclusive with `--require-prestaged`.
-- `--require-prestaged`: Fail fast unless `.josh-staged.json` at `--minio-prefix` reports `complete`. Mutually exclusive with `--stage-from-local-dir`.
+- `--minio-prefix <prefix>` (required): MinIO object prefix where inputs already live (e.g., `batch-jobs/my-run/inputs/`). Populate first via `stageToMinio`.
+- `--require-prestaged`: Fail fast unless `.josh-staged.json` at `--minio-prefix` reports `complete`.
 - `--replicates <N>`: Number of replicates (default: 1). Passed to the target — HTTP targets run N in-process, K8s targets create N pods.
 - `--no-wait`: Dispatch and exit without polling for completion
 - `--poll-interval <seconds>`: Seconds between status polls (default: 5)
@@ -313,39 +312,32 @@ java -jar joshsim-fat.jar batchRemote <SimulationName> [OPTIONS]
 
 **Examples:**
 ```bash
-# Stage local directory, run on Cloud Run, wait for completion
+# Stage inputs, then run on Cloud Run and wait for completion
+java -jar joshsim-fat.jar stageToMinio \
+  --input-dir=./sim-files --prefix=batch-jobs/my-run/inputs/
 java -jar joshsim-fat.jar batchRemote Main \
   --target=cloudrun-prod \
   --minio-prefix=batch-jobs/my-run/inputs/ \
-  --stage-from-local-dir=./sim-files
+  --require-prestaged
 
-# Files already on MinIO (via stageToMinio), require sentinel before dispatching
+# Fire-and-forget on Kubernetes; prints JSON with jobId to stdout
 java -jar joshsim-fat.jar batchRemote Main \
   --target=nautilus \
   --minio-prefix=batch-jobs/my-run/inputs/ \
   --require-prestaged \
-  --replicates=50
-
-# Fire-and-forget; prints JSON with jobId to stdout
-java -jar joshsim-fat.jar batchRemote Main \
-  --target=nautilus \
-  --minio-prefix=batch-jobs/my-run/inputs/ \
-  --stage-from-local-dir=./sim-files \
   --replicates=50 --no-wait
 ```
 
 **Workflow:**
 
-Three staging modes — pick one:
+Staging and dispatch are separate commands. Use `stageToMinio` to upload inputs to `--minio-prefix` (this writes a `.josh-staged.json` sentinel: `STAGING` → `COMPLETE` or `ERROR`). Then run `batchRemote`:
 
-1. **Stage-and-dispatch** (`--stage-from-local-dir <dir>`): Uploads the local directory to `--minio-prefix`, writes a `.josh-staged.json` sentinel (`STAGING` → `COMPLETE` or `ERROR`), then dispatches.
-2. **Require-prestaged** (`--require-prestaged`): Reads the sentinel at `--minio-prefix`; fails if absent or not `complete`. Use when inputs were staged separately via `stageToMinio`.
-3. **Trust-the-prefix** (default, neither flag): Reads sentinel if present and warns if absent, then dispatches regardless. Useful when files were uploaded manually.
+- **Default (trust-the-prefix):** Reads the sentinel if present and warns if absent, then dispatches regardless. Useful when files were uploaded manually.
+- **Strict (`--require-prestaged`):** Fails fast unless the sentinel exists and reports `complete`. Use for shared/multi-dispatch workflows where staging is a separate upstream step.
 
-After staging:
-1. Dispatches to the configured target (HTTP POST or K8s Job creation)
-2. Polls for completion unless `--no-wait` (MinIO status file for HTTP, K8s Job API for Kubernetes)
-3. Results land in MinIO via `minio://` export paths in the Josh script
+After dispatch:
+1. Polls for completion unless `--no-wait` (MinIO status file for HTTP, K8s Job API for Kubernetes)
+2. Results land in MinIO via `minio://` export paths in the Josh script
 
 **`--no-wait` output:** Exits 0 immediately and prints JSON to stdout:
 `{"jobId": "<id>", "target": "<name>", "statusPath": "batch-status/<id>/status.json"}`
@@ -497,9 +489,11 @@ java -jar joshsim-fat.jar pollBatch <jobId> --target=<name>
 
 **Example:**
 ```bash
+java -jar joshsim-fat.jar stageToMinio \
+  --input-dir=./sim-files --prefix=batch-jobs/run1/inputs/
 OUT=$(java -jar joshsim-fat.jar batchRemote Main \
   --target=nautilus --minio-prefix=batch-jobs/run1/inputs/ \
-  --stage-from-local-dir=./sim-files --no-wait)
+  --require-prestaged --no-wait)
 JOB_ID=$(echo "$OUT" | jq -r .jobId)
 
 java -jar joshsim-fat.jar pollBatch "$JOB_ID" --target=nautilus

--- a/src/main/java/org/joshsim/command/BatchRemoteCommand.java
+++ b/src/main/java/org/joshsim/command/BatchRemoteCommand.java
@@ -8,7 +8,6 @@ package org.joshsim.command;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -35,16 +34,14 @@ import picocli.CommandLine.Parameters;
 /**
  * Dispatches a batch simulation to a remote compute target against a MinIO prefix.
  *
- * <p>Three modes:</p>
+ * <p>Two modes:</p>
  * <ol>
- *   <li><b>Stage-and-dispatch</b> ({@code --stage-from-local-dir}): upload the local directory
- *   to {@code --minio-prefix} (writing a {@code .josh-staged.json} sentinel), then dispatch.
- *   </li>
- *   <li><b>Trust-the-prefix</b> (no staging flag): read the sentinel; warn if absent (manual
- *   upload case), fail if in-progress or errored, proceed if complete.</li>
+ *   <li><b>Trust-the-prefix</b> (default): read the {@code .josh-staged.json} sentinel at
+ *   {@code --minio-prefix}; warn if absent (manual upload case), fail if in-progress or errored,
+ *   proceed if complete.</li>
  *   <li><b>Strict</b> ({@code --require-prestaged}): fail fast unless the sentinel exists and
  *   reports {@code complete}. Intended for shared/multi-dispatch workflows where staging is
- *   a separate upstream step.</li>
+ *   a separate upstream step (via {@code stageToMinio}).</li>
  * </ol>
  *
  * <p>Supports both HTTP and Kubernetes target types; the target profile determines
@@ -58,7 +55,6 @@ public class BatchRemoteCommand implements Callable<Integer> {
 
   private static final int TARGET_ERROR_CODE = 100;
   private static final int DISPATCH_ERROR_CODE = 101;
-  private static final int USAGE_ERROR_CODE = 102;
   private static final int STAGING_ERROR_CODE = 103;
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -80,16 +76,8 @@ public class BatchRemoteCommand implements Callable<Integer> {
   private String minioPrefix;
 
   @Option(
-      names = "--stage-from-local-dir",
-      description = "Upload this local directory to --minio-prefix before dispatching. "
-          + "Writes a .josh-staged.json sentinel. Mutually exclusive with --require-prestaged."
-  )
-  private File stageFromLocalDir;
-
-  @Option(
       names = "--require-prestaged",
-      description = "Fail fast unless .josh-staged.json at --minio-prefix reports 'complete'. "
-          + "Mutually exclusive with --stage-from-local-dir.",
+      description = "Fail fast unless .josh-staged.json at --minio-prefix reports 'complete'.",
       defaultValue = "false"
   )
   private boolean requirePrestaged = false;
@@ -127,11 +115,6 @@ public class BatchRemoteCommand implements Callable<Integer> {
 
   @Override
   public Integer call() {
-    if (stageFromLocalDir != null && requirePrestaged) {
-      output.printError("--stage-from-local-dir and --require-prestaged are mutually exclusive.");
-      return USAGE_ERROR_CODE;
-    }
-
     try {
       output.printInfo("Loading target profile: " + targetName);
       TargetProfileLoader loader = new TargetProfileLoader();
@@ -159,16 +142,9 @@ public class BatchRemoteCommand implements Callable<Integer> {
 
       String normalizedPrefix = MinioHandler.normalizePrefix(minioPrefix);
 
-      if (stageFromLocalDir != null) {
-        Integer stagingResult = stageLocalDir(minioHandler, normalizedPrefix);
-        if (stagingResult != null) {
-          return stagingResult;
-        }
-      } else {
-        Integer preflightResult = checkSentinel(minioHandler, normalizedPrefix);
-        if (preflightResult != null) {
-          return preflightResult;
-        }
+      Integer preflightResult = checkSentinel(minioHandler, normalizedPrefix);
+      if (preflightResult != null) {
+        return preflightResult;
       }
 
       BatchJobStrategy strategy = new BatchJobStrategy(
@@ -203,42 +179,6 @@ public class BatchRemoteCommand implements Callable<Integer> {
     }
   }
 
-  private Integer stageLocalDir(MinioHandler minioHandler, String normalizedPrefix) {
-    if (!stageFromLocalDir.exists()) {
-      output.printError("--stage-from-local-dir not found: " + stageFromLocalDir.getPath());
-      return USAGE_ERROR_CODE;
-    }
-    if (!stageFromLocalDir.isDirectory()) {
-      output.printError("--stage-from-local-dir is not a directory: "
-          + stageFromLocalDir.getPath());
-      return USAGE_ERROR_CODE;
-    }
-
-    output.printInfo("Staging " + stageFromLocalDir.getName() + " to " + normalizedPrefix + "...");
-    try {
-      minioHandler.writeStagedSentinel(normalizedPrefix, StagedState.STAGING, null);
-      int uploaded;
-      try {
-        uploaded = minioHandler.uploadDirectory(stageFromLocalDir, normalizedPrefix);
-      } catch (IOException uploadError) {
-        try {
-          minioHandler.writeStagedSentinel(
-              normalizedPrefix, StagedState.ERROR, uploadError.getMessage());
-        } catch (IOException sentinelError) {
-          output.printError("Additionally failed to write error sentinel: "
-              + sentinelError.getMessage());
-        }
-        throw uploadError;
-      }
-      minioHandler.writeStagedSentinel(normalizedPrefix, StagedState.COMPLETE, null);
-      output.printInfo("Staged " + uploaded + " file(s).");
-    } catch (IOException e) {
-      output.printError("Staging failed: " + e.getMessage());
-      return STAGING_ERROR_CODE;
-    }
-    return null;
-  }
-
   private Integer checkSentinel(MinioHandler minioHandler, String normalizedPrefix) {
     Optional<StagedStatus> sentinel;
     try {
@@ -252,7 +192,7 @@ public class BatchRemoteCommand implements Callable<Integer> {
     if (sentinel.isEmpty()) {
       if (requirePrestaged) {
         output.printError("--require-prestaged: no .josh-staged.json under " + normalizedPrefix
-            + ". Run stageToMinio or use --stage-from-local-dir first.");
+            + ". Run stageToMinio first.");
         return STAGING_ERROR_CODE;
       }
       output.printInfo("WARNING: Josh did not detect .josh-staged.json under "

--- a/src/main/java/org/joshsim/pipeline/target/BatchJobStrategy.java
+++ b/src/main/java/org/joshsim/pipeline/target/BatchJobStrategy.java
@@ -15,8 +15,7 @@ import org.joshsim.util.OutputOptions;
  * Orchestrates remote batch execution: dispatch an already-staged MinIO prefix and poll.
  *
  * <p>This strategy assumes the caller (typically {@code BatchRemoteCommand}) has already
- * staged inputs to the MinIO prefix — whether by delegating upload to this same process
- * via {@code --stage-from-local-dir} or by an upstream {@code stageToMinio} invocation.
+ * staged inputs to the MinIO prefix via an upstream {@code stageToMinio} invocation.
  * This class never uploads; it only dispatches to a {@link RemoteBatchTarget} and polls
  * via a {@link BatchPollingStrategy}.</p>
  */

--- a/src/test/java/org/joshsim/command/BatchRemoteCommandTest.java
+++ b/src/test/java/org/joshsim/command/BatchRemoteCommandTest.java
@@ -9,7 +9,6 @@ package org.joshsim.command;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
@@ -18,8 +17,7 @@ import picocli.CommandLine;
  * Schema and usage tests for {@link BatchRemoteCommand}.
  *
  * <p>Verifies the flag layout (simulation as positional; {@code --minio-prefix} required;
- * {@code --stage-from-local-dir} and {@code --require-prestaged} optional) and exercises
- * the mutex check via a real command invocation.</p>
+ * {@code --require-prestaged} optional).</p>
  */
 public class BatchRemoteCommandTest {
 
@@ -45,15 +43,6 @@ public class BatchRemoteCommandTest {
   }
 
   @Test
-  void stageFromLocalDir_shouldBeOptional() throws Exception {
-    var field = BatchRemoteCommand.class.getDeclaredField("stageFromLocalDir");
-    var option = field.getAnnotation(CommandLine.Option.class);
-    assertEquals(false, option.required());
-    assertEquals(File.class, field.getType());
-    assertTrue(java.util.Arrays.asList(option.names()).contains("--stage-from-local-dir"));
-  }
-
-  @Test
   void requirePrestaged_shouldBeOptionalBoolean() throws Exception {
     var field = BatchRemoteCommand.class.getDeclaredField("requirePrestaged");
     var option = field.getAnnotation(CommandLine.Option.class);
@@ -72,18 +61,4 @@ public class BatchRemoteCommandTest {
     }
   }
 
-  @Test
-  void mutuallyExclusiveFlags_returnUsageError() {
-    BatchRemoteCommand command = new BatchRemoteCommand();
-    CommandLine cli = new CommandLine(command);
-    int exit = cli.execute(
-        "MySim",
-        "--target=nonexistent-profile",
-        "--minio-prefix=batch-jobs/foo/inputs/",
-        "--stage-from-local-dir=/tmp",
-        "--require-prestaged"
-    );
-    // 102 is USAGE_ERROR_CODE in BatchRemoteCommand.
-    assertEquals(102, exit);
-  }
 }


### PR DESCRIPTION
## Summary
- Removes the `--stage-from-local-dir` flag from `batchRemote`; `stageToMinio` is now the sole client-side upload primitive
- Simplifies the command to two modes: trust-the-prefix (default, warns if sentinel absent) and `--require-prestaged` (strict)
- Strips the inline `stageLocalDir()` helper, the mutex check between staging flags, and the `USAGE_ERROR_CODE` (now unused)
- Updates README + llms-full.txt examples to the two-step `stageToMinio` then `batchRemote` flow

Closes #428.

## Rationale
The two paths produced bit-identical MinIO state (same bytes, same `.josh-staged.json` sentinel, same dispatch) so every staging change had to land in both the `stageToMinio` command and the inline staging code inside `batchRemote`. joshpy already dropped the flag in SchmidtDSE/joshpy#37 anticipating this cleanup.

## Migration
Anyone using `--stage-from-local-dir=<dir>` replaces it with a preceding `stageToMinio` call:

```sh
java -jar joshsim.jar stageToMinio --input-dir=./inputs/ --prefix=p/
java -jar joshsim.jar batchRemote Main --target=T --minio-prefix=p/ --require-prestaged
```

## Test plan
- [x] `./gradlew test` passes
- [x] `./gradlew checkstyleMain checkstyleTest` clean
- [x] `batchRemote --help` no longer shows `--stage-from-local-dir`
- [ ] Reviewer: sanity-check one GKE or HTTP integration run against a pre-staged prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)