### PR TITLE
preprocessBatch: relativize absolute dataFile paths before dispatch

### DIFF
--- a/src/main/java/org/joshsim/command/PreprocessBatchCommand.java
+++ b/src/main/java/org/joshsim/command/PreprocessBatchCommand.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -200,8 +201,9 @@ public class PreprocessBatchCommand implements Callable<Integer> {
 
       // Dispatch
       output.printInfo("Dispatching to target...");
+      final String relativeDataFile = resolveDataFileRelativeToInputDir(dataFile, inputDir);
       final PreprocessParams params = new PreprocessParams(
-          dataFile, variable, units, outputFile.getName(),
+          relativeDataFile, variable, units, outputFile.getName(),
           crs, horizCoordName, vertCoordName, timeDim,
           timestep.isBlank() ? null : timestep,
           defaultValue, parallel, amend
@@ -236,6 +238,37 @@ public class PreprocessBatchCommand implements Callable<Integer> {
       output.printError("preprocessBatch failed: " + e.getMessage());
       return TARGET_ERROR_CODE;
     }
+  }
+
+  /**
+   * Resolves {@code dataFile} to a path relative to {@code inputDir}.
+   *
+   * <p>{@link PreprocessParams#getDataFile()} is documented as "filename within workDir" and is
+   * propagated into the pod entrypoint as {@code $WORK_DIR/$JOSH_DATA_FILE}. Callers that pass
+   * an absolute path under {@code inputDir} (e.g. clients using {@code Path.resolve()} for all
+   * arguments) would otherwise produce a broken concatenated path inside the pod.</p>
+   *
+   * @param dataFile User-supplied data file argument: either a relative path, or an absolute path
+   *     under {@code inputDir}.
+   * @param inputDir The input directory being staged to MinIO.
+   * @return The path relative to {@code inputDir}, suitable for {@link PreprocessParams}.
+   * @throws IllegalArgumentException if {@code dataFile} is absolute and not under
+   *     {@code inputDir}.
+   */
+  static String resolveDataFileRelativeToInputDir(String dataFile, File inputDir) {
+    Path dataFilePath = Paths.get(dataFile);
+    if (!dataFilePath.isAbsolute()) {
+      return dataFile;
+    }
+    Path inputDirPath = inputDir.toPath().toAbsolutePath().normalize();
+    Path normalizedDataFile = dataFilePath.normalize();
+    if (!normalizedDataFile.startsWith(inputDirPath)) {
+      throw new IllegalArgumentException(
+          "dataFile '" + dataFile + "' is outside input directory '" + inputDir + "'. "
+          + "Data files must live under the input directory for batch dispatch."
+      );
+    }
+    return inputDirPath.relativize(normalizedDataFile).toString();
   }
 
   private void stageDirectory(MinioHandler minioHandler, File inputDir, String prefix)

--- a/src/test/java/org/joshsim/command/PreprocessBatchCommandTest.java
+++ b/src/test/java/org/joshsim/command/PreprocessBatchCommandTest.java
@@ -1,0 +1,90 @@
+/**
+ * Tests for PreprocessBatchCommand helpers.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+
+/**
+ * Unit tests for {@link PreprocessBatchCommand#resolveDataFileRelativeToInputDir}.
+ *
+ * <p>Covers the three paths the helper must handle: absolute paths under {@code inputDir}
+ * (relativized), relative paths (passed through), and absolute paths outside {@code inputDir}
+ * (rejected with a clear error).</p>
+ */
+public class PreprocessBatchCommandTest {
+
+  @Test
+  void absolutePathUnderInputDir_isRelativized(@TempDir Path tempDir) throws Exception {
+    File inputDir = tempDir.toFile();
+    String absoluteDataFile = tempDir.resolve("data.nc").toAbsolutePath().toString();
+
+    String result = PreprocessBatchCommand.resolveDataFileRelativeToInputDir(
+        absoluteDataFile, inputDir
+    );
+
+    assertEquals("data.nc", result);
+  }
+
+  @Test
+  void absolutePathInSubdirectory_isRelativized(@TempDir Path tempDir) throws Exception {
+    File inputDir = tempDir.toFile();
+    Path subdir = tempDir.resolve("nested");
+    subdir.toFile().mkdirs();
+    String absoluteDataFile = subdir.resolve("data.nc").toAbsolutePath().toString();
+
+    String result = PreprocessBatchCommand.resolveDataFileRelativeToInputDir(
+        absoluteDataFile, inputDir
+    );
+
+    assertEquals(Path.of("nested", "data.nc").toString(), result);
+  }
+
+  @Test
+  void relativePath_isPassedThrough() {
+    File inputDir = new File("some/input/dir");
+
+    String result = PreprocessBatchCommand.resolveDataFileRelativeToInputDir(
+        "data.nc", inputDir
+    );
+
+    assertEquals("data.nc", result);
+  }
+
+  @Test
+  void relativePathWithSubdirectory_isPassedThrough() {
+    File inputDir = new File("some/input/dir");
+
+    String result = PreprocessBatchCommand.resolveDataFileRelativeToInputDir(
+        "nested/data.nc", inputDir
+    );
+
+    assertEquals("nested/data.nc", result);
+  }
+
+  @Test
+  void absolutePathOutsideInputDir_throws(@TempDir Path tempDir) {
+    File inputDir = tempDir.resolve("only-this-dir").toFile();
+    inputDir.mkdirs();
+    String absoluteDataFile = tempDir.resolve("elsewhere").resolve("data.nc")
+        .toAbsolutePath().toString();
+
+    IllegalArgumentException ex = assertThrows(
+        IllegalArgumentException.class,
+        () -> PreprocessBatchCommand.resolveDataFileRelativeToInputDir(absoluteDataFile, inputDir)
+    );
+    assertTrue(ex.getMessage().contains("outside input directory"),
+        "Error should mention 'outside input directory', got: " + ex.getMessage());
+  }
+}


### PR DESCRIPTION
## Summary
- Normalize `dataFile` to its path relative to `inputDir` before constructing `PreprocessParams`
- Absolute paths under `inputDir` are relativized; relative paths pass through untouched; absolute paths outside `inputDir` raise a clear `IllegalArgumentException`
- Enforces the existing `PreprocessParams.getDataFile()` contract ("filename within workDir") at param construction, so every target (HTTP, Kubernetes, future) benefits

## Background
Clients that use `Path.resolve()` for all CLI args (e.g. joshpy's `feat/batch-run`) passed absolute paths like `/abs/path/to/inputdir/data.nc`. `PreprocessParams` propagated them verbatim into `JOSH_DATA_FILE`, and the pod entrypoint concatenated `$WORK_DIR/$JOSH_DATA_FILE` to get `/tmp/work//abs/path/to/inputdir/data.nc` — broken.

The existing `outputFile.getName()` call on the same line already does this normalization for the output path; this mirrors that pattern for `dataFile`.

## Test plan
- [x] Unit tests cover: absolute under inputDir (relativized), absolute in subdirectory, relative (pass-through), relative with subdir, absolute outside inputDir (rejected)
- [x] `./gradlew test --tests "org.joshsim.command.PreprocessBatchCommandTest"` passes
- [x] `./gradlew checkstyleMain checkstyleTest` clean
- [ ] Reviewer: joshpy `tests/test5_preprocess_async.py` / `tests/test5b_blocking.py` go from red to green after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)