### PR TITLE
external: resolve .jshdz/.jshd transparently for bare resource names

### DIFF
--- a/src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java
+++ b/src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java
@@ -192,9 +192,8 @@ public class MinimalEngineBridge implements EngineBridge {
 
   @Override
   public EngineValue getExternal(GeoKey key, String name, long step) {
-    String fileName = name.endsWith(".jshd") ? name : name + ".jshd";
     DataGridLayer layer = externalData.computeIfAbsent(name,
-        k -> externalResourceGetter.getResource(fileName));
+        k -> externalResourceGetter.getResource(name));
     return layer.getAt(key, step);
   }
 

--- a/src/main/java/org/joshsim/precompute/JshdExternalGetter.java
+++ b/src/main/java/org/joshsim/precompute/JshdExternalGetter.java
@@ -34,13 +34,11 @@ public class JshdExternalGetter implements ExternalResourceGetter {
 
   @Override
   public DataGridLayer getResource(String name) {
-    // Validate that the name is a jshd file
-    if (!name.endsWith(".jshd")) {
-      throw new IllegalArgumentException("Expected a .jshd file name. Got: " + name);
-    }
+    // Bare names synthesize .jshd; already-suffixed names pass through.
+    // This is the sole format this getter supports, so no ambiguity.
+    String resolved = name.endsWith(".jshd") ? name : name + ".jshd";
 
-    // Use the name directly - caller is responsible for providing full filename
-    try (InputStream binaryInputStream = inputStrategy.open(name)) {
+    try (InputStream binaryInputStream = inputStrategy.open(resolved)) {
       byte[] fileBytes = binaryInputStream.readAllBytes();
       return JshdUtil.loadFromBytes(valueFactory, fileBytes);
     } catch (IOException e) {

--- a/src/main/java/org/joshsim/precompute/MultiFormatExternalGetter.java
+++ b/src/main/java/org/joshsim/precompute/MultiFormatExternalGetter.java
@@ -6,6 +6,8 @@
 
 package org.joshsim.precompute;
 
+import java.io.FileNotFoundException;
+import java.nio.file.NoSuchFileException;
 import org.joshsim.lang.bridge.ExternalResourceGetter;
 
 
@@ -13,8 +15,11 @@ import org.joshsim.lang.bridge.ExternalResourceGetter;
  * Composite {@link ExternalResourceGetter} that routes requests by file extension.
  *
  * <p>Supports {@code .jshd} files via {@link JshdExternalGetter} and {@code .jshdz} (XZ-compressed)
- * files via {@link JshdzExternalGetter}. This class is JVM-only and must not be referenced from
- * any code path compiled by TeaVM.</p>
+ * files via {@link JshdzExternalGetter}. Names that end in a known extension route directly;
+ * bare names (no extension) probe {@code .jshdz} first and fall back to {@code .jshd}, letting
+ * simulation authors reference an external resource without committing to a compression choice.</p>
+ *
+ * <p>This class is JVM-only and must not be referenced from any code path compiled by TeaVM.</p>
  */
 public class MultiFormatExternalGetter implements ExternalResourceGetter {
 
@@ -36,13 +41,40 @@ public class MultiFormatExternalGetter implements ExternalResourceGetter {
   public DataGridLayer getResource(String name) {
     if (name.endsWith(".jshdz")) {
       return jshdzGetter.getResource(name);
-    } else if (name.endsWith(".jshd")) {
-      return jshdGetter.getResource(name);
-    } else {
-      throw new IllegalArgumentException(
-          "Expected a .jshd or .jshdz file name. Got: " + name
-      );
     }
+    if (name.endsWith(".jshd")) {
+      return jshdGetter.getResource(name);
+    }
+    // Bare name: try compressed first (authors typically compress when they can),
+    // then fall back to uncompressed. Only swallow file-not-found — other failures
+    // (corrupt file, decompression error, permission denied) must surface.
+    try {
+      return jshdzGetter.getResource(name + ".jshdz");
+    } catch (RuntimeException compressedMiss) {
+      if (!isFileNotFound(compressedMiss)) {
+        throw compressedMiss;
+      }
+      try {
+        return jshdGetter.getResource(name + ".jshd");
+      } catch (RuntimeException uncompressedMiss) {
+        if (!isFileNotFound(uncompressedMiss)) {
+          throw uncompressedMiss;
+        }
+        throw new RuntimeException(
+            "External resource not found as " + name + ".jshdz or " + name + ".jshd",
+            compressedMiss
+        );
+      }
+    }
+  }
+
+  private static boolean isFileNotFound(Throwable thrown) {
+    for (Throwable cursor = thrown; cursor != null; cursor = cursor.getCause()) {
+      if (cursor instanceof FileNotFoundException || cursor instanceof NoSuchFileException) {
+        return true;
+      }
+    }
+    return false;
   }
 
 }

--- a/src/test/java/org/joshsim/lang/bridge/MinimalEngineBridgeTest.java
+++ b/src/test/java/org/joshsim/lang/bridge/MinimalEngineBridgeTest.java
@@ -193,8 +193,10 @@ public class MinimalEngineBridgeTest {
   }
 
   @Test
-  void testGetExternalWithExtensionHandling() {
-    // Setup
+  void testGetExternalPassesNameUnchangedToResourceGetter() {
+    // The bridge no longer synthesizes .jshd; extension resolution is the resource getter's
+    // responsibility (MultiFormatExternalGetter probes both .jshdz and .jshd for bare names;
+    // JshdExternalGetter synthesizes .jshd when used alone on the TeaVM path).
     ExternalResourceGetter mockExternalGetter = mock(ExternalResourceGetter.class);
     DataGridLayer mockLayer = mock(DataGridLayer.class);
     ValueSupportFactory engineValueFactory = new ValueSupportFactory();
@@ -202,7 +204,7 @@ public class MinimalEngineBridgeTest {
     GeoKey mockKey = mock(GeoKey.class);
 
     when(mockLayer.getAt(mockKey, 0L)).thenReturn(mockValue);
-    when(mockExternalGetter.getResource("Precipitation.jshd")).thenReturn(mockLayer);
+    when(mockExternalGetter.getResource("Precipitation")).thenReturn(mockLayer);
 
     EngineBridge bridgeWithExternal = new MinimalEngineBridge(
         new ValueSupportFactory(),
@@ -215,12 +217,10 @@ public class MinimalEngineBridgeTest {
         mockReplicate
     );
 
-    // Execute - note: Josh code uses "external Precipitation" without extension
     EngineValue result = bridgeWithExternal.getExternal(mockKey, "Precipitation", 0L);
 
-    // Verify - bridge should append .jshd before calling getter
     assertEquals(10.0, result.getAsDouble(), 0.001);
-    verify(mockExternalGetter).getResource("Precipitation.jshd");
+    verify(mockExternalGetter).getResource("Precipitation");
   }
 
   private void expectQuery(Query query, List<Patch> result) {

--- a/src/test/java/org/joshsim/precompute/JshdExternalGetterTest.java
+++ b/src/test/java/org/joshsim/precompute/JshdExternalGetterTest.java
@@ -1,7 +1,6 @@
 package org.joshsim.precompute;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
@@ -66,16 +65,24 @@ class JshdExternalGetterTest {
   }
 
   @Test
-  void testGetResourceWithInvalidExtension() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      getter.getResource("test.txt");
-    });
-  }
+  void testGetResourceBareNameSynthesizesExtension() throws IOException {
+    PatchBuilderExtentsBuilder extentsBuilder = new PatchBuilderExtentsBuilder();
+    extentsBuilder.setTopLeftX(BigDecimal.ZERO);
+    extentsBuilder.setTopLeftY(BigDecimal.ZERO);
+    extentsBuilder.setBottomRightX(BigDecimal.TWO);
+    extentsBuilder.setBottomRightY(BigDecimal.TWO);
+    PatchBuilderExtents extents = extentsBuilder.build();
+    DoublePrecomputedGrid originalGrid = new DoublePrecomputedGrid(
+        factory, extents, 0L, 2L, Units.of("meters"), new double[3][3][3]
+    );
+    byte[] gridBytes = JshdUtil.serializeToBytes(originalGrid);
 
-  @Test
-  void testGetResourceWithoutExtension() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      getter.getResource("test");
-    });
+    // Bare name "test" should load "test.jshd" on the underlying input strategy.
+    when(mockInputStrategy.open("test.jshd"))
+        .thenReturn(new ByteArrayInputStream(gridBytes));
+
+    DoublePrecomputedGrid result = (DoublePrecomputedGrid) getter.getResource("test");
+
+    assertEquals(originalGrid.getMinTimestep(), result.getMinTimestep());
   }
 }

--- a/src/test/java/org/joshsim/precompute/MultiFormatExternalGetterTest.java
+++ b/src/test/java/org/joshsim/precompute/MultiFormatExternalGetterTest.java
@@ -1,0 +1,151 @@
+/**
+ * Tests for MultiFormatExternalGetter routing and extension probing.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.precompute;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.FileNotFoundException;
+import java.nio.file.NoSuchFileException;
+import org.joshsim.engine.value.engine.ValueSupportFactory;
+import org.joshsim.lang.io.InputGetterStrategy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+/**
+ * Covers extension-based routing for suffixed names and the bare-name probing fallback.
+ *
+ * <p>Uses real {@code Jshd*ExternalGetter} instances wrapping a mocked
+ * {@link InputGetterStrategy} so the test exercises the exact exception shape that
+ * propagates from file-not-found to the dispatcher's {@code isFileNotFound} check.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class MultiFormatExternalGetterTest {
+
+  private MultiFormatExternalGetter getter;
+  private JshdExternalGetter jshdGetter;
+  private JshdzExternalGetter jshdzGetter;
+
+  @Mock
+  private InputGetterStrategy mockInputStrategy;
+
+  @BeforeEach
+  void setUp() {
+    ValueSupportFactory factory = new ValueSupportFactory();
+    jshdGetter = new JshdExternalGetter(mockInputStrategy, factory);
+    jshdzGetter = new JshdzExternalGetter(mockInputStrategy, factory);
+    getter = new MultiFormatExternalGetter(jshdGetter, jshdzGetter);
+  }
+
+  @Test
+  void suffixedJshdz_routesDirectly() {
+    // Arrange: jshdz getter throws a known error so we can confirm routing without
+    // building real jshdz bytes.
+    when(mockInputStrategy.open("foo.jshdz"))
+        .thenThrow(new RuntimeException("routed", new FileNotFoundException("foo.jshdz")));
+
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> getter.getResource("foo.jshdz"));
+    assertTrue(ex.getMessage().contains("routed"));
+    // Direct route — should not have probed .jshd.
+    verify(mockInputStrategy).open("foo.jshdz");
+  }
+
+  @Test
+  void suffixedJshd_routesDirectly() {
+    when(mockInputStrategy.open("foo.jshd"))
+        .thenThrow(new RuntimeException("routed", new FileNotFoundException("foo.jshd")));
+
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> getter.getResource("foo.jshd"));
+    assertTrue(ex.getMessage().contains("routed"));
+    verify(mockInputStrategy).open("foo.jshd");
+  }
+
+  @Test
+  void bareName_probesJshdzFirstThenJshd_bothMissingRaisesClearError() {
+    when(mockInputStrategy.open("foo.jshdz"))
+        .thenThrow(new RuntimeException("open failed", new FileNotFoundException("foo.jshdz")));
+    when(mockInputStrategy.open("foo.jshd"))
+        .thenThrow(new RuntimeException("open failed", new FileNotFoundException("foo.jshd")));
+
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> getter.getResource("foo"));
+
+    assertTrue(ex.getMessage().contains("foo.jshdz"),
+        "error should mention both probed names, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("foo.jshd"),
+        "error should mention both probed names, got: " + ex.getMessage());
+  }
+
+  @Test
+  void bareName_nonFileNotFoundError_isRethrownWithoutFallback() {
+    // A non-FileNotFoundException failure (e.g. corrupt file, decompression error) on the
+    // .jshdz attempt must not fall back to .jshd — surface the real error.
+    RuntimeException realError = new RuntimeException("XZ decompression failed",
+        new java.util.zip.ZipException("bad block"));
+    when(mockInputStrategy.open("foo.jshdz")).thenThrow(realError);
+
+    RuntimeException thrown = assertThrows(RuntimeException.class,
+        () -> getter.getResource("foo"));
+
+    assertSame(realError, thrown, "original error should propagate unchanged");
+    // Critically, .jshd must not have been probed.
+    verify(mockInputStrategy, never()).open("foo.jshd");
+  }
+
+  @Test
+  void bareName_noSuchFileExceptionInCauseChain_triggersFallback() {
+    // NoSuchFileException (java.nio) also counts as file-not-found.
+    when(mockInputStrategy.open("foo.jshdz"))
+        .thenThrow(new RuntimeException("open failed", new NoSuchFileException("foo.jshdz")));
+    when(mockInputStrategy.open("foo.jshd"))
+        .thenThrow(new RuntimeException("open failed", new NoSuchFileException("foo.jshd")));
+
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> getter.getResource("foo"));
+
+    assertTrue(ex.getMessage().contains("not found"));
+  }
+
+  @Test
+  void unknownSuffix_fallsThroughToProbing() {
+    // A name like "foo.bar" is treated as a bare name — probes foo.bar.jshdz then foo.bar.jshd.
+    when(mockInputStrategy.open("foo.bar.jshdz"))
+        .thenThrow(new RuntimeException("missed", new FileNotFoundException("foo.bar.jshdz")));
+    when(mockInputStrategy.open("foo.bar.jshd"))
+        .thenThrow(new RuntimeException("missed", new FileNotFoundException("foo.bar.jshd")));
+
+    assertThrows(RuntimeException.class, () -> getter.getResource("foo.bar"));
+    verify(mockInputStrategy).open("foo.bar.jshdz");
+    verify(mockInputStrategy).open("foo.bar.jshd");
+  }
+
+  @Test
+  void suffixedJshdz_notMissingJshdProbed_whenRouteFails() {
+    // Suffixed name routes directly; a not-found on that exact name must NOT probe the other.
+    when(mockInputStrategy.open("foo.jshdz"))
+        .thenThrow(new RuntimeException("missing", new FileNotFoundException("foo.jshdz")));
+
+    assertThrows(RuntimeException.class, () -> getter.getResource("foo.jshdz"));
+
+    verify(mockInputStrategy).open("foo.jshdz");
+    verifyNoInteractionsWith(mockInputStrategy, "foo.jshd");
+  }
+
+  private static void verifyNoInteractionsWith(InputGetterStrategy strat, String filename) {
+    verify(strat, never()).open(filename);
+  }
+}


### PR DESCRIPTION
## Summary
- Moves extension-resolution from \`MinimalEngineBridge\` into \`MultiFormatExternalGetter\` so the dispatcher owns format routing end-to-end
- Bare names (e.g. \`external \"soil_quality\"\`) now probe \`.jshdz\` first and fall back to \`.jshd\` — scripts can reference external data without committing to a compression choice
- Only \`FileNotFoundException\` / \`NoSuchFileException\` in the cause chain trigger fallback; real errors (corrupt file, decompression failure, etc.) surface instead of being silently masked
- Suffixed names (\`foo.jshdz\`, \`foo.jshd\`) still route directly — behavior unchanged
- \`JshdExternalGetter\` synthesizes \`.jshd\` for bare names too, preserving the TeaVM-path invariant where \`MinimalEngineBridge → JshdExternalGetter\` is used directly (not through the dispatcher)

## Problem
Before this change, \`MinimalEngineBridge.getExternal\` unconditionally appended \`.jshd\` to bare names:
\`\`\`java
String fileName = name.endsWith(".jshd") ? name : name + ".jshd";
\`\`\`
So simulations against a workdir containing only \`soil_quality.jshdz\` (no \`.jshd\`) would fail with \`Failed to open stream from working directory: soil_quality.jshd\`, even though the JVM runtime has a perfectly-capable \`.jshdz\` reader. \`MultiFormatExternalGetter\` never got a chance — the name was already \`.jshd\`-suffixed before it arrived.

## Design choice
Placing the probing in \`MultiFormatExternalGetter\` (Option A from the proposal) keeps format knowledge in the one class whose explicit purpose is format routing. Future format additions only need to teach the dispatcher. \`MinimalEngineBridge\` no longer has to know the extension list.

The file-not-found filter avoids a subtle masking bug: catching bare \`RuntimeException\` would make a corrupt \`.jshdz\` silently fall back to \`.jshd\` and hide the real error. Only the NoSuchFile / FileNotFoundException causes trigger fallback.

## Test plan
- [x] \`MultiFormatExternalGetterTest\` covers: suffixed routes direct; bare names probe both; both-missing raises clear error mentioning both names; non-file-not-found on \`.jshdz\` rethrows without probing \`.jshd\`; \`NoSuchFileException\` triggers fallback; unknown suffix (\`foo.bar\`) falls through to probing
- [x] \`JshdExternalGetterTest\` updated: bare names synthesize \`.jshd\`
- [x] \`MinimalEngineBridgeTest\` updated: asserts bridge passes name unchanged
- [x] Full \`./gradlew test\` passes
- [x] \`./gradlew checkstyleMain checkstyleTest\` clean
- [ ] Reviewer: joshpy \`tests/test4_jshdz.py\` should go from red to green after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)