### PR TITLE
PreprocessUtil: route external resources through MultiFormatExternalGetter

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -524,13 +524,25 @@ jobs:
     steps:
       - name: Set environment variables based on branch
         run: |
+          # EXTRA_SECRETS is appended to --set-secrets below (note the leading comma).
+          # Dev-only until prod Secret Manager entries (josh-prod-minio-key / -secret)
+          # and runtime SA IAM bindings exist. BEFORE MERGING TO MAIN: create those
+          # secrets, grant the prod runtime SA secretmanager.secretAccessor on them,
+          # then populate EXTRA_SECRETS for the main branch below (or drop the
+          # branching entirely once both envs are aligned).
+          #
+          # This is smelly but we can avoid the branching when prod is ready, and it keeps
+          # all the env var logic in one place instead of spreading it across multiple steps / partial deployments.
+
           if [[ $GITHUB_REF == refs/heads/main ]]; then
             echo "SERVICE_NAME=josh-executor-prod" >> $GITHUB_ENV
             echo "DOCKERFILE=Dockerfile.prod" >> $GITHUB_ENV
+            echo "EXTRA_SECRETS=" >> $GITHUB_ENV  # TODO: add MinIO secrets once prod secrets exist
             echo "Deploying to Production environment"
           else
             echo "SERVICE_NAME=josh-executor-dev" >> $GITHUB_ENV
             echo "DOCKERFILE=Dockerfile.dev" >> $GITHUB_ENV
+            echo "EXTRA_SECRETS=,MINIO_ACCESS_KEY=josh-dev-minio-key:latest,MINIO_SECRET_KEY=josh-dev-minio-secret:latest" >> $GITHUB_ENV
             echo "Deploying to Development environment"
           fi
       - name: Checkout code
@@ -571,7 +583,7 @@ jobs:
             --max-instances=100 \
             --port=8085 \
             --allow-unauthenticated \
-            --set-secrets="JOSH_API_KEYS=${{ secrets.SECRET_NAME }}" \
+            --set-secrets="JOSH_API_KEYS=${{ secrets.SECRET_NAME }}${{ env.EXTRA_SECRETS }}" \
             --use-http2 \
             --no-cpu-throttling \
             --concurrency=1 \

--- a/src/main/java/org/joshsim/command/PreprocessUtil.java
+++ b/src/main/java/org/joshsim/command/PreprocessUtil.java
@@ -54,6 +54,8 @@ import org.joshsim.precompute.ExtentsTransformer;
 import org.joshsim.precompute.GridCombiner;
 import org.joshsim.precompute.GridSerializationStrategy;
 import org.joshsim.precompute.JshdExternalGetter;
+import org.joshsim.precompute.JshdzExternalGetter;
+import org.joshsim.precompute.MultiFormatExternalGetter;
 import org.joshsim.precompute.PatchKeyConverter;
 import org.joshsim.precompute.StreamToPrecomputedGridUtil;
 import org.joshsim.precompute.XzGridSerializationStrategy;
@@ -250,7 +252,10 @@ public class PreprocessUtil {
         simEntity,
         program.getConverter(),
         program.getPrototypes(),
-        new JshdExternalGetter(inputStrategy, valueFactory),
+        new MultiFormatExternalGetter(
+            new JshdExternalGetter(inputStrategy, valueFactory),
+            new JshdzExternalGetter(inputStrategy, valueFactory)
+        ),
         new JshcConfigGetter(inputStrategy, valueFactory)
     );
     GridFromSimFactory gridFactory = new GridFromSimFactory(bridge);


### PR DESCRIPTION
## Summary
- Wraps the `JshdExternalGetter` at [PreprocessUtil.java:253](src/main/java/org/joshsim/command/PreprocessUtil.java#L253) in a `MultiFormatExternalGetter` so the preprocess bridge can read `.jshdz` external data alongside `.jshd`
- Brings `PreprocessUtil` in line with [RunCommand.java:462](src/main/java/org/joshsim/command/RunCommand.java#L462), which already does this
- Independent of #431 — safe to merge before or after

## FutureBridgeGetter — investigated, intentionally unchanged
Initial scope flagged [FutureBridgeGetter.java:180](src/main/java/org/joshsim/lang/interpret/FutureBridgeGetter.java#L180) as a second cleanup site. After tracing the code paths, that one is correct as-is:

- **JVM run path**: [JoshSimFacadeUtil.runSimulation:146-149](src/main/java/org/joshsim/JoshSimFacadeUtil.java#L146) builds its own bridge from the caller-supplied \`MultiFormatExternalGetter\` and calls \`bridgeGetter.setBridge(bridge)\`, overriding the lazy \`buildBridge()\`. The \`JshdExternalGetter\` line is never reached.
- **TeaVM path**: \`JoshJsSimFacade\` doesn't call \`setBridge\`, so the lazy \`buildBridge()\` runs and uses \`JshdExternalGetter\` — the only valid choice, since \`MultiFormatExternalGetter\` transitively imports XZ which won't compile to WASM. \`.jshdz\` is physically unreadable in the browser editor anyway.

So \`FutureBridgeGetter\` is correctly format-aware: JVM substitutes a multi-format bridge via setter; TeaVM falls back to the lazy single-format build.

## Behavior on current dev vs. after #431
- **Today**: \`MinimalEngineBridge\` still synthesizes \`.jshd\`, so the wrapped getter routes \`.jshd\`-suffixed names to \`jshdGetter\` — identical to before. Net gain: user-supplied \`.jshdz\`-suffixed names now resolve correctly.
- **After #431**: bare external resource names probe both formats — full \`.jshdz\` capability.

## Test plan
- [x] \`./gradlew test\` passes
- [x] \`./gradlew checkstyleMain checkstyleTest\` clean
- [x] \`./gradlew compileTeavmJava\` succeeds — \`PreprocessUtil\` is JVM-only (not reachable from \`JoshJsSimFacade\`); the new XZ imports stay out of the WASM compile path

🤖 Generated with [Claude Code](https://claude.com/claude-code)