### PR TITLE
batchRemote: thread --custom-tag and --replicate-start through dispatch

### DIFF
--- a/.github/workflows/test-k8s.yaml
+++ b/.github/workflows/test-k8s.yaml
@@ -230,6 +230,79 @@ jobs:
             cat /tmp/bad-image-output.txt
           fi
 
+      - name: Run batchRemote with --custom-tag and --replicate-start
+        env:
+          MINIO_ENDPOINT: http://localhost:9000
+          MINIO_ACCESS_KEY: minioadmin
+          MINIO_SECRET_KEY: minioadmin
+          MINIO_BUCKET: josh-test-bucket
+        run: |
+          echo "Staging custom-tag test inputs to MinIO..."
+          java -jar build/libs/joshsim-fat.jar stageToMinio \
+            --input-dir=examples/test/k8s-customtag/ \
+            --prefix=batch-jobs/k8s-customtag/inputs/
+
+          echo "Dispatching with --custom-tag run_hash=ci-test --replicate-start=2 --replicates=2..."
+          # The simulation templates {run_hash} and {replicate} into the export path:
+          #   minio://josh-test-bucket/k8s-customtag-results/{run_hash}/replicate-{replicate}.csv
+          # With --custom-tag run_hash=ci-test the path renders to .../ci-test/...
+          # With --replicate-start=2 --replicates=2 the K8s Job runs indices 2 and 3.
+          java -jar build/libs/joshsim-fat.jar batchRemote K8sCustomTagTest \
+            --target=ci-k8s \
+            --minio-prefix=batch-jobs/k8s-customtag/inputs/ \
+            --require-prestaged \
+            --replicates=2 \
+            --replicate-start=2 \
+            --custom-tag=run_hash=ci-test \
+            --poll-interval=5 \
+            --timeout=300
+
+          echo "batchRemote with custom-tag and replicate-start completed"
+
+      - name: Verify custom-tag and replicate-start results in MinIO
+        run: |
+          MINIO_POD=$(kubectl get pod -l app=minio -o jsonpath='{.items[0].metadata.name}')
+
+          echo "Listing custom-tag results in MinIO..."
+          kubectl exec $MINIO_POD -- /tmp/mc ls --recursive \
+            local/josh-test-bucket/k8s-customtag-results/
+
+          # Verify run_hash interpolated into the path
+          echo "Checking that {run_hash}=ci-test rendered into the export path..."
+          if ! kubectl exec $MINIO_POD -- /tmp/mc ls \
+              local/josh-test-bucket/k8s-customtag-results/ci-test/ >/dev/null 2>&1; then
+            echo "ERROR: expected directory ci-test/ not found under k8s-customtag-results/"
+            kubectl exec $MINIO_POD -- /tmp/mc ls --recursive \
+              local/josh-test-bucket/k8s-customtag-results/
+            exit 1
+          fi
+          echo "  {run_hash} interpolation works"
+
+          # Verify replicate-start shifted absolute indices to 2 and 3
+          echo "Checking replicate indices 2 and 3 exist..."
+          for IDX in 2 3; do
+            SIZE=$(kubectl exec $MINIO_POD -- /tmp/mc stat \
+              local/josh-test-bucket/k8s-customtag-results/ci-test/replicate-$IDX.csv \
+              --json 2>/dev/null | grep -o '"size":[0-9]*' | cut -d':' -f2)
+            if [ -z "$SIZE" ] || [ "$SIZE" -le 0 ]; then
+              echo "ERROR: replicate-$IDX.csv missing or empty"
+              exit 1
+            fi
+            echo "  replicate-$IDX.csv present ($SIZE bytes)"
+          done
+
+          # Verify replicate-start shifted away from 0 (replicate-0.csv should NOT exist)
+          echo "Checking replicate-0.csv is absent (offset shifted away from 0)..."
+          if kubectl exec $MINIO_POD -- /tmp/mc stat \
+              local/josh-test-bucket/k8s-customtag-results/ci-test/replicate-0.csv \
+              --json >/dev/null 2>&1; then
+            echo "ERROR: replicate-0.csv exists; --replicate-start=2 did not shift indices"
+            exit 1
+          fi
+          echo "  replicate-0.csv absent (offset works)"
+
+          echo "Custom-tag and replicate-start integration verified"
+
       - name: Run preprocessBatch end-to-end
         run: |
           echo "Running preprocessBatch with K8s target..."
@@ -293,6 +366,8 @@ jobs:
           echo "  Job completion verification"
           echo "  Results verification in MinIO"
           echo "  Failure detection (bad image)"
+          echo "  batchRemote e2e with --custom-tag and --replicate-start (K8s target)"
+          echo "  Custom-tag template + replicate-offset verification in MinIO"
           echo "  preprocessBatch e2e (K8s target, NetCDF → jshd)"
           echo "  Preprocess job completion verification"
           echo "================================================"

--- a/cloud-img/run-entrypoint.sh
+++ b/cloud-img/run-entrypoint.sh
@@ -54,7 +54,22 @@ if [ -z "$SCRIPT" ]; then
 fi
 
 # JOB_COMPLETION_INDEX is set by K8s for indexed Jobs (0, 1, 2, ...).
-# Each pod runs one replicate at its assigned index so {replicate}
-# template paths resolve to unique filenames.
-REPLICATE_INDEX="${JOB_COMPLETION_INDEX:-0}"
-java -XX:+ExitOnOutOfMemoryError -jar "$JAR" run "$SCRIPT" "$JOSH_SIMULATION" --replicate-index="$REPLICATE_INDEX"
+# JOSH_REPLICATE_OFFSET (default 0) shifts the absolute index for pool/resume
+# workflows where indices need to be stable across re-dispatch.
+REPLICATE_INDEX=$(( ${JOB_COMPLETION_INDEX:-0} + ${JOSH_REPLICATE_OFFSET:-0} ))
+
+# JOSH_CUSTOM_TAGS holds newline-delimited key=value entries. One
+# --custom-tag flag per non-empty line. Newline-delimited (vs JSON)
+# avoids needing jq in the JRE-only batch image.
+TAGS=""
+if [ -n "$JOSH_CUSTOM_TAGS" ]; then
+  while IFS= read -r line; do
+    [ -n "$line" ] && TAGS="$TAGS --custom-tag=$line"
+  done <<EOF
+$JOSH_CUSTOM_TAGS
+EOF
+fi
+
+# shellcheck disable=SC2086
+java -XX:+ExitOnOutOfMemoryError -jar "$JAR" run "$SCRIPT" "$JOSH_SIMULATION" \
+  --replicate-index="$REPLICATE_INDEX" $TAGS

--- a/examples/test/k8s-customtag/k8s_customtag_test.josh
+++ b/examples/test/k8s-customtag/k8s_customtag_test.josh
@@ -1,0 +1,19 @@
+start simulation K8sCustomTagTest
+  grid.size = 100 m
+  grid.low = 0 degrees latitude, 0 degrees longitude
+  grid.high = 0.01 degrees latitude, 0.01 degrees longitude
+  grid.patch = "Default"
+  steps.low = 0 count
+  steps.high = 2 count
+  exportFiles.patch = "minio://josh-test-bucket/k8s-customtag-results/{run_hash}/replicate-{replicate}.csv"
+end simulation
+
+start patch Default
+  Tree.init = create 3 count of Tree
+  export.treeCount.step = count(Tree)
+end patch
+
+start organism Tree
+  age.init = 0 count
+  age.step = prior.age + 1 count
+end organism

--- a/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -39,6 +40,9 @@ import org.joshsim.lang.io.InputOutputLayer;
 import org.joshsim.lang.io.JvmInputOutputLayerBuilder;
 import org.joshsim.lang.io.JvmMappedInputGetter;
 import org.joshsim.lang.parse.ParseResult;
+import org.joshsim.pipeline.job.JoshJob;
+import org.joshsim.pipeline.job.JoshJobBuilder;
+import org.joshsim.pipeline.job.config.TemplateStringRenderer;
 import org.joshsim.util.MinioHandler;
 import org.joshsim.util.MinioOptions;
 import org.joshsim.util.MinioStagingUtil;
@@ -180,8 +184,12 @@ public class JoshSimBatchHandler implements HttpHandler {
     }
 
     int replicates;
+    int replicateStart;
+    Map<String, String> customTags;
     try {
       replicates = parseReplicates(formData);
+      replicateStart = parseReplicateStart(formData);
+      customTags = parseCustomTags(formData);
     } catch (IllegalArgumentException e) {
       sendJsonError(exchange, 400, jobId, e.getMessage());
       return Optional.of(apiKey);
@@ -197,7 +205,8 @@ public class JoshSimBatchHandler implements HttpHandler {
     // deployed with --no-cpu-throttling. See BATCH_EXECUTOR above, #418, #421.
     CompletableFuture.runAsync(() -> {
       runBatchWithStatus(
-          statusMinio, jobId, simulation, workDir, replicates, statusPath, capturedApiKey
+          statusMinio, jobId, simulation, workDir, replicates,
+          replicateStart, customTags, statusPath, capturedApiKey
       );
     }, BATCH_EXECUTOR);
 
@@ -288,14 +297,67 @@ public class JoshSimBatchHandler implements HttpHandler {
     return value;
   }
 
+  /**
+   * Parses the optional {@code replicateStart} form field. Returns 0 if not present.
+   * Throws IllegalArgumentException if present but invalid.
+   */
+  private int parseReplicateStart(FormData formData) {
+    if (!formData.contains("replicateStart")) {
+      return 0;
+    }
+    String raw = formData.getFirst("replicateStart").getValue();
+    int value;
+    try {
+      value = Integer.parseInt(raw);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid replicateStart value: " + raw);
+    }
+    if (value < 0) {
+      throw new IllegalArgumentException("replicateStart must be >= 0, got: " + value);
+    }
+    return value;
+  }
+
+  /**
+   * Parses the optional {@code customTags} form field (newline-delimited
+   * {@code key=value} entries). Returns an empty map if not present.
+   */
+  private Map<String, String> parseCustomTags(FormData formData) {
+    Map<String, String> parsed = new HashMap<>();
+    if (!formData.contains("customTags")) {
+      return parsed;
+    }
+    String raw = formData.getFirst("customTags").getValue();
+    for (String line : raw.split("\n")) {
+      String trimmed = line.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      int equalsIndex = trimmed.indexOf('=');
+      if (equalsIndex <= 0 || equalsIndex == trimmed.length() - 1) {
+        throw new IllegalArgumentException("Invalid customTags entry: " + trimmed
+            + ". Expected format: name=value");
+      }
+      String name = trimmed.substring(0, equalsIndex).trim();
+      String value = trimmed.substring(equalsIndex + 1);
+      if ("replicate".equals(name) || "step".equals(name) || "variable".equals(name)) {
+        throw new IllegalArgumentException("Custom parameter name '" + name
+            + "' conflicts with reserved template variable");
+      }
+      parsed.put(name, value);
+    }
+    return parsed;
+  }
+
   private void runBatchWithStatus(MinioHandler statusMinio, String jobId,
-      String simulation, File workDir, int replicates, String statusPath, String apiKey) {
+      String simulation, File workDir, int replicates, int replicateStart,
+      Map<String, String> customTags, String statusPath, String apiKey) {
     writeStatus(statusMinio, statusPath, buildStatusJson(
         "running", jobId, "startedAt", Instant.now().toString()
     ));
 
     try {
-      executeBatchJob(jobId, simulation, workDir, replicates);
+      executeBatchJob(jobId, simulation, workDir, replicates, replicateStart, customTags);
 
       writeStatus(statusMinio, statusPath, buildStatusJson(
           "complete", jobId, "completedAt", Instant.now().toString()
@@ -329,7 +391,7 @@ public class JoshSimBatchHandler implements HttpHandler {
   }
 
   private void executeBatchJob(String jobId, String simulation, File workDir,
-      int replicates) throws Exception {
+      int replicates, int replicateStart, Map<String, String> customTags) throws Exception {
     // Ensure JVM threading for parallel patch export
     CompatibilityLayerKeeper.set(new JvmCompatibilityLayer());
 
@@ -349,10 +411,19 @@ public class JoshSimBatchHandler implements HttpHandler {
     ValueSupportFactory valueFactory = new ValueSupportFactory();
     GridGeometryFactory geometryFactory = new GridGeometryFactory();
 
+    // JoshJob carries customParameters into TemplateStringRenderer; the renderer is what
+    // makes {key} placeholders in exportFiles paths resolve to dispatched values. Without
+    // this, custom-tag template resolution silently no-ops on the batch HTTP path.
+    JoshJob job = new JoshJobBuilder()
+        .setReplicates(replicates)
+        .setCustomParameters(customTags)
+        .build();
+
     // Interpret once — the program doesn't change between replicates.
     // Only the InputOutputLayer changes (replicate index, append mode).
     InputOutputLayer initialLayer = new JvmInputOutputLayerBuilder()
         .withInputStrategy(new JvmMappedInputGetter(fileMapping))
+        .withTemplateRenderer(new TemplateStringRenderer(job, replicateStart))
         .withMinioOptions(minioOptions)
         .build();
 
@@ -364,12 +435,13 @@ public class JoshSimBatchHandler implements HttpHandler {
       throw new IllegalArgumentException("Simulation not found: " + simulation);
     }
 
-    for (int replicate = 0; replicate < replicates; replicate++) {
+    for (int replicate = replicateStart; replicate < replicateStart + replicates; replicate++) {
       InputOutputLayer replicateLayer = new JvmInputOutputLayerBuilder()
           .withReplicate(replicate)
           .withInputStrategy(new JvmMappedInputGetter(fileMapping))
+          .withTemplateRenderer(new TemplateStringRenderer(job, replicate))
           .withMinioOptions(minioOptions)
-          .withAppendMode(replicate > 0)
+          .withAppendMode(replicate > replicateStart)
           .build();
 
       JoshSimFacadeUtil.runSimulation(

--- a/src/main/java/org/joshsim/cloud/JoshSimLeaderHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimLeaderHandler.java
@@ -162,6 +162,20 @@ public class JoshSimLeaderHandler implements HttpHandler {
     String outputStepsStr = formData.contains("outputSteps")
         ? formData.getFirst("outputSteps").getValue() : "";
 
+    int replicateStart = 0;
+    if (formData.contains("replicateStart")) {
+      try {
+        replicateStart = Integer.parseInt(formData.getFirst("replicateStart").getValue());
+      } catch (NumberFormatException e) {
+        httpServerExchange.setStatusCode(400);
+        return Optional.of(apiKey);
+      }
+      if (replicateStart < 0) {
+        httpServerExchange.setStatusCode(400);
+        return Optional.of(apiKey);
+      }
+    }
+
     // Prepare tasks for parallel execution
     List<WorkerTask> tasks = new ArrayList<>();
     for (int i = 0; i < replicates; i++) {
@@ -171,7 +185,7 @@ public class JoshSimLeaderHandler implements HttpHandler {
           apiKey,
           externalData,
           favorBigDecimal,
-          i,
+          replicateStart + i,
           outputStepsStr,
           false
       );

--- a/src/main/java/org/joshsim/command/BatchRemoteCommand.java
+++ b/src/main/java/org/joshsim/command/BatchRemoteCommand.java
@@ -9,6 +9,8 @@ package org.joshsim.command;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.joshsim.pipeline.target.BatchJobStrategy;
@@ -90,6 +92,22 @@ public class BatchRemoteCommand implements Callable<Integer> {
   private int replicates = 1;
 
   @Option(
+      names = "--replicate-start",
+      description = "Starting replicate index (default: 0). Combined with --replicates this "
+          + "selects the half-open range [start, start+count). Used for pool/resume "
+          + "workflows where indices need to be stable across re-dispatch.",
+      defaultValue = "0"
+  )
+  private int replicateStart = 0;
+
+  @Option(
+      names = "--custom-tag",
+      description = "Custom template parameters (format: name=value). Can be specified "
+          + "multiple times. Resolvable as {name} in exportFiles paths."
+  )
+  private String[] customTags = new String[0];
+
+  @Option(
       names = "--no-wait",
       description = "Dispatch and exit without polling for completion",
       defaultValue = "false"
@@ -116,6 +134,12 @@ public class BatchRemoteCommand implements Callable<Integer> {
   @Override
   public Integer call() {
     try {
+      if (replicateStart < 0) {
+        output.printError("--replicate-start must be >= 0");
+        return DISPATCH_ERROR_CODE;
+      }
+      final Map<String, String> parsedCustomTags = parseCustomTags();
+
       output.printInfo("Loading target profile: " + targetName);
       TargetProfileLoader loader = new TargetProfileLoader();
       TargetProfile profile = loader.load(targetName);
@@ -153,7 +177,9 @@ public class BatchRemoteCommand implements Callable<Integer> {
       );
 
       if (noWait) {
-        String jobId = strategy.executeNoWait(normalizedPrefix, simulation, replicates);
+        String jobId = strategy.executeNoWait(
+            normalizedPrefix, simulation, replicates, parsedCustomTags, replicateStart
+        );
         ObjectNode node = MAPPER.createObjectNode();
         node.put("jobId", jobId);
         node.put("target", targetName);
@@ -162,7 +188,9 @@ public class BatchRemoteCommand implements Callable<Integer> {
         return 0;
       }
 
-      JobStatus finalStatus = strategy.execute(normalizedPrefix, simulation, replicates);
+      JobStatus finalStatus = strategy.execute(
+          normalizedPrefix, simulation, replicates, parsedCustomTags, replicateStart
+      );
 
       if (finalStatus.getState() == JobStatus.State.COMPLETE) {
         output.printInfo("Batch job completed successfully.");
@@ -226,6 +254,34 @@ public class BatchRemoteCommand implements Callable<Integer> {
 
   private static String describeMessage(StagedStatus status) {
     return status.message() != null ? ": " + status.message() : ".";
+  }
+
+  /**
+   * Parses {@code --custom-tag name=value} options into a map.
+   *
+   * <p>Mirrors {@code RunCommand.parseCustomParameters} so the same {@code .josh} script
+   * resolves the same template variables on either run path. Reserved names ({@code replicate},
+   * {@code step}, {@code variable}) are rejected.</p>
+   */
+  private Map<String, String> parseCustomTags() {
+    Map<String, String> parsed = new HashMap<>();
+    for (String customTag : customTags) {
+      int equalsIndex = customTag.indexOf('=');
+      if (equalsIndex <= 0 || equalsIndex == customTag.length() - 1) {
+        throw new IllegalArgumentException("Invalid custom-tag format: " + customTag
+            + ". Expected format: name=value");
+      }
+      String name = customTag.substring(0, equalsIndex).trim();
+      String value = customTag.substring(equalsIndex + 1);
+
+      if ("replicate".equals(name) || "step".equals(name) || "variable".equals(name)) {
+        throw new IllegalArgumentException("Custom parameter name '" + name
+            + "' conflicts with reserved template variable");
+      }
+
+      parsed.put(name, value);
+    }
+    return parsed;
   }
 
   private HttpBatchTarget buildHttpTarget(TargetProfile profile) {

--- a/src/main/java/org/joshsim/command/RunCommand.java
+++ b/src/main/java/org/joshsim/command/RunCommand.java
@@ -109,6 +109,15 @@ public class RunCommand implements Callable<Integer> {
   private Integer replicateIndex;
 
   @Option(
+      names = "--replicate-start",
+      description = "Starting replicate index (default: 0). Combined with --replicates this "
+          + "selects the half-open range [start, start+count). Mutually exclusive with "
+          + "--replicate-index.",
+      defaultValue = "0"
+  )
+  private int replicateStart = 0;
+
+  @Option(
       names = "--use-float-64",
       description = "Use double instead of BigDecimal, offering speed but lower precision.",
       defaultValue = "false"
@@ -226,6 +235,14 @@ public class RunCommand implements Callable<Integer> {
     }
     if (replicateIndex != null && replicateIndex < 0) {
       output.printError("--replicate-index must be >= 0");
+      return 1;
+    }
+    if (replicateIndex != null && replicateStart != 0) {
+      output.printError("--replicate-index and --replicate-start are mutually exclusive");
+      return 1;
+    }
+    if (replicateStart < 0) {
+      output.printError("--replicate-start must be >= 0");
       return 1;
     }
     if (replicates < 1) {
@@ -383,9 +400,9 @@ public class RunCommand implements Callable<Integer> {
         inputStrategy = new JvmMappedInputGetter(currentJob.getFilePaths());
       }
 
-      int startReplicate = replicateIndex != null ? replicateIndex : 0;
+      int startReplicate = replicateIndex != null ? replicateIndex : replicateStart;
       int endReplicate = replicateIndex != null
-          ? replicateIndex + 1 : currentJob.getReplicates();
+          ? replicateIndex + 1 : replicateStart + currentJob.getReplicates();
 
       for (int currentReplicate = startReplicate; currentReplicate < endReplicate;
            currentReplicate++) {

--- a/src/main/java/org/joshsim/command/RunRemoteCommand.java
+++ b/src/main/java/org/joshsim/command/RunRemoteCommand.java
@@ -148,6 +148,15 @@ public class RunRemoteCommand implements Callable<Integer> {
   )
   private int replicates = 1;
 
+  @Option(
+      names = "--replicate-start",
+      description = "Starting replicate index (default: 0). Combined with --replicates this "
+          + "selects the half-open range [start, start+count). Used for pool/resume "
+          + "workflows where indices need to be stable across re-dispatch.",
+      defaultValue = "0"
+  )
+  private int replicateStart = 0;
+
   /**
    * Parses custom parameter command-line options.
    *
@@ -181,6 +190,10 @@ public class RunRemoteCommand implements Callable<Integer> {
     // Validate replicates parameter
     if (replicates < 1) {
       output.printError("Number of replicates must be at least 1");
+      return SERIALIZATION_ERROR_CODE;
+    }
+    if (replicateStart < 0) {
+      output.printError("--replicate-start must be >= 0");
       return SERIALIZATION_ERROR_CODE;
     }
     try {
@@ -338,6 +351,7 @@ public class RunRemoteCommand implements Callable<Integer> {
           .withOutputOptions(output)
           .withMinioOptions(minioOptions)
           .withMaxConcurrentWorkers(concurrentWorkers)
+          .withReplicateNumber(replicateStart)
           .withEnableProfiler(enableProfiler)
           .build();
 

--- a/src/main/java/org/joshsim/pipeline/remote/RunRemoteOffloadLeaderStrategy.java
+++ b/src/main/java/org/joshsim/pipeline/remote/RunRemoteOffloadLeaderStrategy.java
@@ -120,6 +120,9 @@ public class RunRemoteOffloadLeaderStrategy implements RunRemoteStrategy {
     formData.put("externalData", context.getExternalDataSerialized());
     formData.put("favorBigDecimal", String.valueOf(!context.isUseFloat64()));
     formData.put("enableProfiler", String.valueOf(context.isEnableProfiler()));
+    if (context.getReplicateNumber() != 0) {
+      formData.put("replicateStart", String.valueOf(context.getReplicateNumber()));
+    }
 
     // URL encode the form data
     StringBuilder formBody = new StringBuilder();

--- a/src/main/java/org/joshsim/pipeline/target/BatchArgUtil.java
+++ b/src/main/java/org/joshsim/pipeline/target/BatchArgUtil.java
@@ -1,0 +1,47 @@
+/**
+ * Shared encoders for batch dispatch arguments.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.pipeline.target;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+/**
+ * Encoders for arguments shared between {@link KubernetesTarget} and {@link HttpBatchTarget}.
+ *
+ * <p>The encoding format is part of the contract between the dispatcher and the
+ * pod-side {@code run-entrypoint.sh}, so it lives in one place rather than being
+ * duplicated per target.</p>
+ */
+public final class BatchArgUtil {
+
+  private BatchArgUtil() {
+    // utility
+  }
+
+  /**
+   * Encodes custom tags as a newline-delimited {@code key=value} string.
+   *
+   * <p>Used both as a K8s env var ({@code JOSH_CUSTOM_TAGS}) and as an HTTP form field
+   * ({@code customTags}). The pod-side {@code run-entrypoint.sh} reads the env var and
+   * emits one {@code --custom-tag=key=value} flag per non-empty line; the server-side
+   * {@link org.joshsim.cloud.JoshSimBatchHandler} splits the form value the same way.
+   * Newline delimiting matches {@code RunCommand}'s {@code String[] customTags} shape
+   * and avoids needing a JSON parser ({@code jq}) in the JRE-only batch image.</p>
+   *
+   * <p>Insertion order is preserved when the input is a {@link java.util.LinkedHashMap},
+   * which both call sites use. Empty input produces the empty string.</p>
+   *
+   * @param customTags Tag map; may be empty but must not be null.
+   * @return Newline-delimited {@code key=value} entries, or empty string if the map is empty.
+   */
+  public static String encodeCustomTags(Map<String, String> customTags) {
+    return customTags.entrySet().stream()
+        .map(e -> e.getKey() + "=" + e.getValue())
+        .collect(Collectors.joining("\n"));
+  }
+}

--- a/src/main/java/org/joshsim/pipeline/target/BatchJobStrategy.java
+++ b/src/main/java/org/joshsim/pipeline/target/BatchJobStrategy.java
@@ -6,6 +6,7 @@
 
 package org.joshsim.pipeline.target;
 
+import java.util.Map;
 import java.util.UUID;
 import org.joshsim.util.MinioHandler;
 import org.joshsim.util.OutputOptions;
@@ -67,17 +68,21 @@ public class BatchJobStrategy {
    * @param minioPrefix The MinIO object prefix where inputs are already staged.
    * @param simulation Name of the simulation to run.
    * @param replicates Number of replicates to execute.
+   * @param customTags Custom template parameters resolvable as {@code {key}} placeholders
+   *     in {@code exportFiles} paths. Empty map means none.
+   * @param replicateStart Starting replicate index for the half-open range
+   *     {@code [start, start+replicates)}. {@code 0} preserves prior behavior.
    * @return The final job status.
    * @throws Exception If dispatch or polling fails.
    */
-  public JobStatus execute(String minioPrefix, String simulation, int replicates)
-      throws Exception {
+  public JobStatus execute(String minioPrefix, String simulation, int replicates,
+      Map<String, String> customTags, int replicateStart) throws Exception {
     String jobId = UUID.randomUUID().toString();
     String prefix = MinioHandler.normalizePrefix(minioPrefix);
 
     output.printInfo("Dispatching to target (" + replicates + " replicates) against "
         + prefix + "...");
-    target.dispatch(jobId, prefix, simulation, replicates);
+    target.dispatch(jobId, prefix, simulation, replicates, customTags, replicateStart);
     output.printInfo("Dispatched. Polling for completion...");
 
     return pollUntilTerminal(jobId);
@@ -89,17 +94,19 @@ public class BatchJobStrategy {
    * @param minioPrefix The MinIO object prefix where inputs are already staged.
    * @param simulation Name of the simulation to run.
    * @param replicates Number of replicates to execute.
+   * @param customTags Custom template parameters; same semantics as {@link #execute}.
+   * @param replicateStart Starting replicate index; same semantics as {@link #execute}.
    * @return The jobId for manual status tracking.
    * @throws Exception If dispatch fails.
    */
-  public String executeNoWait(String minioPrefix, String simulation, int replicates)
-      throws Exception {
+  public String executeNoWait(String minioPrefix, String simulation, int replicates,
+      Map<String, String> customTags, int replicateStart) throws Exception {
     String jobId = UUID.randomUUID().toString();
     String prefix = MinioHandler.normalizePrefix(minioPrefix);
 
     output.printInfo("Dispatching to target (" + replicates + " replicates) against "
         + prefix + "...");
-    target.dispatch(jobId, prefix, simulation, replicates);
+    target.dispatch(jobId, prefix, simulation, replicates, customTags, replicateStart);
     output.printInfo("Dispatched. Status path: batch-status/" + jobId + "/status.json");
 
     return jobId;

--- a/src/main/java/org/joshsim/pipeline/target/HttpBatchTarget.java
+++ b/src/main/java/org/joshsim/pipeline/target/HttpBatchTarget.java
@@ -73,8 +73,8 @@ public class HttpBatchTarget implements RemoteBatchTarget {
   }
 
   @Override
-  public void dispatch(String jobId, String minioPrefix, String simulation, int replicates)
-      throws Exception {
+  public void dispatch(String jobId, String minioPrefix, String simulation, int replicates,
+      Map<String, String> customTags, int replicateStart) throws Exception {
     Map<String, String> formFields = new LinkedHashMap<>();
     formFields.put("apiKey", apiKey);
     formFields.put("jobId", jobId);
@@ -83,6 +83,12 @@ public class HttpBatchTarget implements RemoteBatchTarget {
     formFields.put("workDir", "/tmp/batch-" + jobId);
     formFields.put("stageFromMinio", "true");
     formFields.put("minioPrefix", minioPrefix);
+    if (customTags != null && !customTags.isEmpty()) {
+      formFields.put("customTags", encodeCustomTags(customTags));
+    }
+    if (replicateStart != 0) {
+      formFields.put("replicateStart", String.valueOf(replicateStart));
+    }
 
     String formBody = formFields.entrySet().stream()
         .map(e -> URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8)
@@ -103,5 +109,26 @@ public class HttpBatchTarget implements RemoteBatchTarget {
           "Dispatch failed (HTTP " + response.statusCode() + "): " + response.body()
       );
     }
+  }
+
+  /**
+   * Encodes custom tags as a newline-delimited {@code key=value} string for the server.
+   *
+   * <p>The server-side {@link org.joshsim.cloud.JoshSimBatchHandler} splits this back
+   * into individual entries when constructing the {@link
+   * org.joshsim.pipeline.job.JoshJob}. Newline delimiting matches {@code RunCommand}'s
+   * {@code String[] customTags} shape.</p>
+   */
+  private static String encodeCustomTags(Map<String, String> customTags) {
+    StringBuilder sb = new StringBuilder();
+    boolean first = true;
+    for (Map.Entry<String, String> entry : customTags.entrySet()) {
+      if (!first) {
+        sb.append('\n');
+      }
+      first = false;
+      sb.append(entry.getKey()).append('=').append(entry.getValue());
+    }
+    return sb.toString();
   }
 }

--- a/src/main/java/org/joshsim/pipeline/target/HttpBatchTarget.java
+++ b/src/main/java/org/joshsim/pipeline/target/HttpBatchTarget.java
@@ -84,7 +84,7 @@ public class HttpBatchTarget implements RemoteBatchTarget {
     formFields.put("stageFromMinio", "true");
     formFields.put("minioPrefix", minioPrefix);
     if (customTags != null && !customTags.isEmpty()) {
-      formFields.put("customTags", encodeCustomTags(customTags));
+      formFields.put("customTags", BatchArgUtil.encodeCustomTags(customTags));
     }
     if (replicateStart != 0) {
       formFields.put("replicateStart", String.valueOf(replicateStart));
@@ -109,26 +109,5 @@ public class HttpBatchTarget implements RemoteBatchTarget {
           "Dispatch failed (HTTP " + response.statusCode() + "): " + response.body()
       );
     }
-  }
-
-  /**
-   * Encodes custom tags as a newline-delimited {@code key=value} string for the server.
-   *
-   * <p>The server-side {@link org.joshsim.cloud.JoshSimBatchHandler} splits this back
-   * into individual entries when constructing the {@link
-   * org.joshsim.pipeline.job.JoshJob}. Newline delimiting matches {@code RunCommand}'s
-   * {@code String[] customTags} shape.</p>
-   */
-  private static String encodeCustomTags(Map<String, String> customTags) {
-    StringBuilder sb = new StringBuilder();
-    boolean first = true;
-    for (Map.Entry<String, String> entry : customTags.entrySet()) {
-      if (!first) {
-        sb.append('\n');
-      }
-      first = false;
-      sb.append(entry.getKey()).append('=').append(entry.getValue());
-    }
-    return sb.toString();
   }
 }

--- a/src/main/java/org/joshsim/pipeline/target/KubernetesTarget.java
+++ b/src/main/java/org/joshsim/pipeline/target/KubernetesTarget.java
@@ -91,7 +91,9 @@ public class KubernetesTarget implements RemoteBatchTarget {
       String jobId,
       String minioPrefix,
       String simulation,
-      int replicates
+      int replicates,
+      Map<String, String> customTags,
+      int replicateStart
   ) throws Exception {
     String secretName = SECRET_NAME_PREFIX + jobId;
 
@@ -128,7 +130,8 @@ public class KubernetesTarget implements RemoteBatchTarget {
                         )
                         .withEnv(buildEnvVars(
                             secretName, jobId,
-                            minioPrefix, simulation
+                            minioPrefix, simulation,
+                            customTags, replicateStart
                         ))
                         .withCommand(
                             ENTRYPOINT,
@@ -209,7 +212,9 @@ public class KubernetesTarget implements RemoteBatchTarget {
       String secretName,
       String jobId,
       String minioPrefix,
-      String simulation
+      String simulation,
+      Map<String, String> customTags,
+      int replicateStart
   ) {
     List<EnvVar> envVars = new ArrayList<>();
     envVars.add(secretEnvVar(
@@ -227,7 +232,38 @@ public class KubernetesTarget implements RemoteBatchTarget {
     envVars.add(plainEnvVar("JOSH_JOB_ID", jobId));
     envVars.add(plainEnvVar("JOSH_MINIO_PREFIX", minioPrefix));
     envVars.add(plainEnvVar("JOSH_SIMULATION", simulation));
+    if (customTags != null && !customTags.isEmpty()) {
+      envVars.add(plainEnvVar(
+          "JOSH_CUSTOM_TAGS", encodeCustomTags(customTags)
+      ));
+    }
+    if (replicateStart != 0) {
+      envVars.add(plainEnvVar(
+          "JOSH_REPLICATE_OFFSET", String.valueOf(replicateStart)
+      ));
+    }
     return envVars;
+  }
+
+  /**
+   * Encodes custom tags as a newline-delimited {@code key=value} string for the pod entrypoint.
+   *
+   * <p>The pod-side {@code run-entrypoint.sh} reads this env var and emits one
+   * {@code --custom-tag=key=value} flag per line. Newline delimiting matches
+   * {@code RunCommand}'s {@code String[] customTags} shape exactly and avoids
+   * needing a JSON parser ({@code jq}) in the JRE-only batch image.</p>
+   */
+  private static String encodeCustomTags(Map<String, String> customTags) {
+    StringBuilder sb = new StringBuilder();
+    boolean first = true;
+    for (Map.Entry<String, String> entry : customTags.entrySet()) {
+      if (!first) {
+        sb.append('\n');
+      }
+      first = false;
+      sb.append(entry.getKey()).append('=').append(entry.getValue());
+    }
+    return sb.toString();
   }
 
   private static EnvVar secretEnvVar(

--- a/src/main/java/org/joshsim/pipeline/target/KubernetesTarget.java
+++ b/src/main/java/org/joshsim/pipeline/target/KubernetesTarget.java
@@ -234,7 +234,7 @@ public class KubernetesTarget implements RemoteBatchTarget {
     envVars.add(plainEnvVar("JOSH_SIMULATION", simulation));
     if (customTags != null && !customTags.isEmpty()) {
       envVars.add(plainEnvVar(
-          "JOSH_CUSTOM_TAGS", encodeCustomTags(customTags)
+          "JOSH_CUSTOM_TAGS", BatchArgUtil.encodeCustomTags(customTags)
       ));
     }
     if (replicateStart != 0) {
@@ -243,27 +243,6 @@ public class KubernetesTarget implements RemoteBatchTarget {
       ));
     }
     return envVars;
-  }
-
-  /**
-   * Encodes custom tags as a newline-delimited {@code key=value} string for the pod entrypoint.
-   *
-   * <p>The pod-side {@code run-entrypoint.sh} reads this env var and emits one
-   * {@code --custom-tag=key=value} flag per line. Newline delimiting matches
-   * {@code RunCommand}'s {@code String[] customTags} shape exactly and avoids
-   * needing a JSON parser ({@code jq}) in the JRE-only batch image.</p>
-   */
-  private static String encodeCustomTags(Map<String, String> customTags) {
-    StringBuilder sb = new StringBuilder();
-    boolean first = true;
-    for (Map.Entry<String, String> entry : customTags.entrySet()) {
-      if (!first) {
-        sb.append('\n');
-      }
-      first = false;
-      sb.append(entry.getKey()).append('=').append(entry.getValue());
-    }
-    return sb.toString();
   }
 
   private static EnvVar secretEnvVar(

--- a/src/main/java/org/joshsim/pipeline/target/RemoteBatchTarget.java
+++ b/src/main/java/org/joshsim/pipeline/target/RemoteBatchTarget.java
@@ -6,6 +6,8 @@
 
 package org.joshsim.pipeline.target;
 
+import java.util.Map;
+
 
 /**
  * Dispatch interface for remote batch execution targets.
@@ -39,8 +41,15 @@ public interface RemoteBatchTarget {
    *     (e.g., {@code batch-jobs/abc123/inputs/}).
    * @param simulation The name of the simulation to run.
    * @param replicates The number of replicates to execute.
+   * @param customTags Custom template parameters resolvable as {@code {key}} placeholders
+   *     in {@code exportFiles} paths. Empty map means none. Same semantics as
+   *     {@code RunCommand --custom-tag}.
+   * @param replicateStart Starting replicate index for the half-open range
+   *     {@code [start, start+replicates)}. Used for pool/resume workflows where
+   *     indices need to be stable across re-dispatch. {@code 0} preserves prior
+   *     behavior.
    * @throws Exception If the dispatch fails (e.g., network error, auth failure).
    */
-  void dispatch(String jobId, String minioPrefix, String simulation, int replicates)
-      throws Exception;
+  void dispatch(String jobId, String minioPrefix, String simulation, int replicates,
+      Map<String, String> customTags, int replicateStart) throws Exception;
 }

--- a/src/test/java/org/joshsim/cloud/JoshSimBatchHandlerTest.java
+++ b/src/test/java/org/joshsim/cloud/JoshSimBatchHandlerTest.java
@@ -214,6 +214,86 @@ class JoshSimBatchHandlerTest {
   }
 
   @Test
+  void whenReplicateStartIsNegative_shouldReturn400() throws IOException {
+    setupValidApiKey();
+    File joshScript = new File(tempDir, "test.josh");
+    Files.writeString(joshScript.toPath(), "start simulation Test end simulation");
+    setupRequiredFields("job-rs", "Test", tempDir.getAbsolutePath());
+    when(formData.contains("stageFromMinio")).thenReturn(false);
+
+    FormData.FormValue rsVal = mock(FormData.FormValue.class);
+    when(formData.contains("replicateStart")).thenReturn(true);
+    when(formData.getFirst("replicateStart")).thenReturn(rsVal);
+    when(rsVal.getValue()).thenReturn("-3");
+
+    handler.processFormData(exchange, formData);
+
+    verify(exchange).setStatusCode(400);
+    assertTrue(responseBody.toString().contains("replicateStart"),
+        "body: " + responseBody.toString());
+  }
+
+  @Test
+  void whenReplicateStartIsNotNumeric_shouldReturn400() throws IOException {
+    setupValidApiKey();
+    File joshScript = new File(tempDir, "test.josh");
+    Files.writeString(joshScript.toPath(), "start simulation Test end simulation");
+    setupRequiredFields("job-rs2", "Test", tempDir.getAbsolutePath());
+    when(formData.contains("stageFromMinio")).thenReturn(false);
+
+    FormData.FormValue rsVal = mock(FormData.FormValue.class);
+    when(formData.contains("replicateStart")).thenReturn(true);
+    when(formData.getFirst("replicateStart")).thenReturn(rsVal);
+    when(rsVal.getValue()).thenReturn("abc");
+
+    handler.processFormData(exchange, formData);
+
+    verify(exchange).setStatusCode(400);
+    assertTrue(responseBody.toString().contains("Invalid replicateStart"),
+        "body: " + responseBody.toString());
+  }
+
+  @Test
+  void whenCustomTagsHasReservedName_shouldReturn400() throws IOException {
+    setupValidApiKey();
+    File joshScript = new File(tempDir, "test.josh");
+    Files.writeString(joshScript.toPath(), "start simulation Test end simulation");
+    setupRequiredFields("job-ct", "Test", tempDir.getAbsolutePath());
+    when(formData.contains("stageFromMinio")).thenReturn(false);
+
+    FormData.FormValue ctVal = mock(FormData.FormValue.class);
+    when(formData.contains("customTags")).thenReturn(true);
+    when(formData.getFirst("customTags")).thenReturn(ctVal);
+    when(ctVal.getValue()).thenReturn("replicate=42");
+
+    handler.processFormData(exchange, formData);
+
+    verify(exchange).setStatusCode(400);
+    assertTrue(responseBody.toString().contains("reserved template variable"),
+        "body: " + responseBody.toString());
+  }
+
+  @Test
+  void whenCustomTagsMalformed_shouldReturn400() throws IOException {
+    setupValidApiKey();
+    File joshScript = new File(tempDir, "test.josh");
+    Files.writeString(joshScript.toPath(), "start simulation Test end simulation");
+    setupRequiredFields("job-ct2", "Test", tempDir.getAbsolutePath());
+    when(formData.contains("stageFromMinio")).thenReturn(false);
+
+    FormData.FormValue ctVal = mock(FormData.FormValue.class);
+    when(formData.contains("customTags")).thenReturn(true);
+    when(formData.getFirst("customTags")).thenReturn(ctVal);
+    when(ctVal.getValue()).thenReturn("no_equals_sign");
+
+    handler.processFormData(exchange, formData);
+
+    verify(exchange).setStatusCode(400);
+    assertTrue(responseBody.toString().contains("Invalid customTags"),
+        "body: " + responseBody.toString());
+  }
+
+  @Test
   void processFormDataReturnsApiKeyOnSuccess() {
     setupValidApiKey();
     setupRequiredFields("job-1", "TestSim", "/nonexistent");

--- a/src/test/java/org/joshsim/command/BatchRemoteCommandTest.java
+++ b/src/test/java/org/joshsim/command/BatchRemoteCommandTest.java
@@ -61,4 +61,78 @@ public class BatchRemoteCommandTest {
     }
   }
 
+  @Test
+  void customTag_shouldBeStringArrayOption() throws Exception {
+    var field = BatchRemoteCommand.class.getDeclaredField("customTags");
+    var option = field.getAnnotation(CommandLine.Option.class);
+    assertEquals(false, option.required());
+    assertEquals(String[].class, field.getType());
+    assertTrue(java.util.Arrays.asList(option.names()).contains("--custom-tag"));
+  }
+
+  @Test
+  void replicateStart_shouldBeIntOptionWithDefaultZero() throws Exception {
+    var field = BatchRemoteCommand.class.getDeclaredField("replicateStart");
+    var option = field.getAnnotation(CommandLine.Option.class);
+    assertEquals(false, option.required());
+    assertEquals(int.class, field.getType());
+    assertTrue(java.util.Arrays.asList(option.names()).contains("--replicate-start"));
+    assertEquals("0", option.defaultValue());
+  }
+
+  @Test
+  void parseCustomTags_shouldRejectReservedNames() throws Exception {
+    BatchRemoteCommand cmd = new BatchRemoteCommand();
+    setCustomTags(cmd, new String[]{"replicate=42"});
+    Exception ex = assertThrows("replicate", cmd);
+    assertTrue(ex.getMessage().contains("reserved"),
+        "expected 'reserved' in message: " + ex.getMessage());
+  }
+
+  @Test
+  void parseCustomTags_shouldRejectMalformed() throws Exception {
+    BatchRemoteCommand cmd = new BatchRemoteCommand();
+    setCustomTags(cmd, new String[]{"no_equals_sign"});
+    Exception ex = assertThrows("no_equals", cmd);
+    assertTrue(ex.getMessage().contains("Invalid custom-tag"),
+        "expected 'Invalid custom-tag' in message: " + ex.getMessage());
+  }
+
+  @Test
+  void parseCustomTags_shouldParseValidPairsIntoMap() throws Exception {
+    BatchRemoteCommand cmd = new BatchRemoteCommand();
+    setCustomTags(cmd, new String[]{"run_hash=abc", "region=west"});
+    var method = BatchRemoteCommand.class.getDeclaredMethod("parseCustomTags");
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    var parsed = (java.util.Map<String, String>) method.invoke(cmd);
+    assertEquals(2, parsed.size());
+    assertEquals("abc", parsed.get("run_hash"));
+    assertEquals("west", parsed.get("region"));
+  }
+
+  private static void setCustomTags(BatchRemoteCommand cmd, String[] tags) throws Exception {
+    java.lang.reflect.Field f = BatchRemoteCommand.class.getDeclaredField("customTags");
+    f.setAccessible(true);
+    f.set(cmd, tags);
+  }
+
+  private static Exception assertThrows(String description, BatchRemoteCommand cmd) {
+    try {
+      var method = BatchRemoteCommand.class.getDeclaredMethod("parseCustomTags");
+      method.setAccessible(true);
+      method.invoke(cmd);
+    } catch (java.lang.reflect.InvocationTargetException ite) {
+      Throwable cause = ite.getCause();
+      if (cause instanceof IllegalArgumentException iae) {
+        return iae;
+      }
+      throw new AssertionError(
+          "Expected IllegalArgumentException for " + description + ", got: " + cause);
+    } catch (Exception e) {
+      throw new AssertionError("Reflection failure: " + e);
+    }
+    throw new AssertionError("Expected exception for " + description + " was not thrown");
+  }
+
 }

--- a/src/test/java/org/joshsim/command/RunCommandReplicatesTest.java
+++ b/src/test/java/org/joshsim/command/RunCommandReplicatesTest.java
@@ -218,6 +218,72 @@ class RunCommandReplicatesTest {
   }
 
   @Test
+  void testReplicateStartValidationNegative(@TempDir Path tempDir) throws Exception {
+    Path joshFile = tempDir.resolve("test.josh");
+    Files.writeString(joshFile, JoshTestFixtures.MINIMAL_SIMULATION_NO_EXPORT);
+
+    setupBasicFields(runCommand, joshFile);
+    setFieldValue(runCommand, "simulation", "TestSim");
+    setFieldValue(runCommand, "replicateStart", -1);
+
+    Integer result = runCommand.call();
+
+    assertEquals(1, result, "Negative replicate-start should fail validation");
+  }
+
+  @Test
+  void testReplicateStartIndexMutex(@TempDir Path tempDir) throws Exception {
+    Path joshFile = tempDir.resolve("test.josh");
+    Files.writeString(joshFile, JoshTestFixtures.MINIMAL_SIMULATION_NO_EXPORT);
+
+    setupBasicFields(runCommand, joshFile);
+    setFieldValue(runCommand, "simulation", "TestSim");
+    setFieldValue(runCommand, "replicateStart", 5);
+    setFieldValue(runCommand, "replicateIndex", Integer.valueOf(2));
+
+    Integer result = runCommand.call();
+
+    assertEquals(1, result, "--replicate-start with --replicate-index should fail validation");
+  }
+
+  @Test
+  void testReplicateStartShiftsAbsoluteIndices(@TempDir Path tempDir) throws Exception {
+    Path joshFile = tempDir.resolve("test.josh");
+    Path outputFile = tempDir.resolve("output.csv");
+    Files.writeString(joshFile,
+        JoshTestFixtures.minimalSimulationWithExport(outputFile.toString()));
+
+    setupBasicFields(runCommand, joshFile);
+    setFieldValue(runCommand, "simulation", "TestSim");
+    setFieldValue(runCommand, "replicates", 2);
+    setFieldValue(runCommand, "replicateStart", 5);
+
+    Integer result = runCommand.call();
+
+    assertEquals(0, result, "Replicate-start with replicates should succeed");
+    assertTrue(Files.exists(outputFile), "Output CSV file should be created");
+
+    String csvContent = Files.readString(outputFile);
+    // Replicate column is the last CSV column. Inspect the parsed last column of each
+    // data row directly to avoid line-ending ambiguity.
+    java.util.Set<String> replicateValues = csvContent.lines()
+        .skip(1)
+        .filter(line -> !line.isBlank())
+        .map(line -> {
+          int lastComma = line.lastIndexOf(',');
+          return lastComma >= 0 ? line.substring(lastComma + 1).trim() : "";
+        })
+        .collect(java.util.stream.Collectors.toSet());
+    assertTrue(replicateValues.contains("5"),
+        "CSV replicate column should contain 5; values were: " + replicateValues);
+    assertTrue(replicateValues.contains("6"),
+        "CSV replicate column should contain 6; values were: " + replicateValues);
+    assertTrue(!replicateValues.contains("0"),
+        "CSV replicate column should NOT contain 0 when start=5; values were: "
+            + replicateValues);
+  }
+
+  @Test
   void testSimulationNotFound(@TempDir Path tempDir) throws Exception {
     // Arrange - create real Josh file but request nonexistent simulation
     Path joshFile = tempDir.resolve("test.josh");

--- a/src/test/java/org/joshsim/pipeline/target/BatchArgUtilTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/BatchArgUtilTest.java
@@ -1,0 +1,55 @@
+/**
+ * Tests for BatchArgUtil.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.pipeline.target;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * Unit tests for {@link BatchArgUtil}.
+ */
+class BatchArgUtilTest {
+
+  @Test
+  void encodeCustomTags_emptyMap_returnsEmptyString() {
+    assertEquals("", BatchArgUtil.encodeCustomTags(Map.of()));
+  }
+
+  @Test
+  void encodeCustomTags_singleEntry_returnsKeyEqualsValue() {
+    assertEquals("run_hash=abc123",
+        BatchArgUtil.encodeCustomTags(Map.of("run_hash", "abc123")));
+  }
+
+  @Test
+  void encodeCustomTags_multipleEntries_areNewlineDelimited() {
+    Map<String, String> tags = new LinkedHashMap<>();
+    tags.put("run_hash", "abc123");
+    tags.put("region", "west");
+    assertEquals("run_hash=abc123\nregion=west", BatchArgUtil.encodeCustomTags(tags));
+  }
+
+  @Test
+  void encodeCustomTags_preservesLinkedHashMapInsertionOrder() {
+    Map<String, String> tags = new LinkedHashMap<>();
+    tags.put("z", "1");
+    tags.put("a", "2");
+    tags.put("m", "3");
+    assertEquals("z=1\na=2\nm=3", BatchArgUtil.encodeCustomTags(tags));
+  }
+
+  @Test
+  void encodeCustomTags_valueWithEqualsSign_isPreservedVerbatim() {
+    // Decoder splits on the first '=' so values may contain '='
+    assertEquals("expr=a=b+c",
+        BatchArgUtil.encodeCustomTags(Map.of("expr", "a=b+c")));
+  }
+}

--- a/src/test/java/org/joshsim/pipeline/target/BatchJobStrategyTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/BatchJobStrategyTest.java
@@ -9,6 +9,8 @@ package org.joshsim.pipeline.target;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -17,6 +19,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import org.joshsim.util.OutputOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,10 +50,12 @@ class BatchJobStrategyTest {
 
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    JobStatus result = strategy.execute("batch-jobs/foo/inputs/", "Test", 1);
+    JobStatus result = strategy.execute(
+        "batch-jobs/foo/inputs/", "Test", 1, Map.of(), 0);
 
     assertEquals(JobStatus.State.COMPLETE, result.getState());
-    verify(target).dispatch(anyString(), eq("batch-jobs/foo/inputs/"), eq("Test"), eq(1));
+    verify(target).dispatch(
+        anyString(), eq("batch-jobs/foo/inputs/"), eq("Test"), eq(1), anyMap(), eq(0));
   }
 
   @Test
@@ -59,10 +64,11 @@ class BatchJobStrategyTest {
 
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    strategy.execute("batch-jobs/foo/inputs", "Test", 1);
+    strategy.execute("batch-jobs/foo/inputs", "Test", 1, Map.of(), 0);
 
     ArgumentCaptor<String> prefixCaptor = ArgumentCaptor.forClass(String.class);
-    verify(target).dispatch(anyString(), prefixCaptor.capture(), eq("Test"), eq(1));
+    verify(target).dispatch(
+        anyString(), prefixCaptor.capture(), eq("Test"), eq(1), anyMap(), eq(0));
     assertEquals("batch-jobs/foo/inputs/", prefixCaptor.getValue());
   }
 
@@ -73,9 +79,10 @@ class BatchJobStrategyTest {
 
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    strategy.execute("batch-jobs/foo/inputs/", "Main", 10);
+    strategy.execute("batch-jobs/foo/inputs/", "Main", 10, Map.of(), 0);
 
-    verify(target).dispatch(anyString(), anyString(), eq("Main"), eq(10));
+    verify(target).dispatch(
+        anyString(), anyString(), eq("Main"), eq(10), anyMap(), eq(0));
   }
 
   @Test
@@ -85,7 +92,8 @@ class BatchJobStrategyTest {
 
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    JobStatus result = strategy.execute("batch-jobs/foo/inputs/", "BadSim", 1);
+    JobStatus result = strategy.execute(
+        "batch-jobs/foo/inputs/", "BadSim", 1, Map.of(), 0);
 
     assertEquals(JobStatus.State.ERROR, result.getState());
     assertEquals("Simulation not found", result.getMessage().get());
@@ -97,7 +105,8 @@ class BatchJobStrategyTest {
 
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 50);
 
-    JobStatus result = strategy.execute("batch-jobs/foo/inputs/", "SlowSim", 1);
+    JobStatus result = strategy.execute(
+        "batch-jobs/foo/inputs/", "SlowSim", 1, Map.of(), 0);
 
     assertEquals(JobStatus.State.ERROR, result.getState());
     assertTrue(result.getMessage().get().contains("timed out"));
@@ -107,21 +116,24 @@ class BatchJobStrategyTest {
   void executeNoWaitSkipsPolling() throws Exception {
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    String jobId = strategy.executeNoWait("batch-jobs/foo/inputs/", "Test", 5);
+    String jobId = strategy.executeNoWait(
+        "batch-jobs/foo/inputs/", "Test", 5, Map.of(), 0);
 
     assertTrue(jobId != null && !jobId.isEmpty());
-    verify(target).dispatch(anyString(), eq("batch-jobs/foo/inputs/"), eq("Test"), eq(5));
+    verify(target).dispatch(
+        anyString(), eq("batch-jobs/foo/inputs/"), eq("Test"), eq(5), anyMap(), eq(0));
     verify(poller, never()).poll(anyString());
   }
 
   @Test
   void executeThrowsOnDispatchFailure() throws Exception {
     doThrow(new RuntimeException("Connection refused"))
-        .when(target).dispatch(anyString(), anyString(), anyString(), eq(1));
+        .when(target).dispatch(
+            anyString(), anyString(), anyString(), eq(1), anyMap(), anyInt());
 
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
     assertThrows(RuntimeException.class,
-        () -> strategy.execute("batch-jobs/foo/inputs/", "Test", 1));
+        () -> strategy.execute("batch-jobs/foo/inputs/", "Test", 1, Map.of(), 0));
   }
 }

--- a/src/test/java/org/joshsim/pipeline/target/HttpBatchTargetTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/HttpBatchTargetTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 
@@ -40,7 +41,8 @@ class HttpBatchTargetTest {
 
     HttpBatchTarget target = new HttpBatchTarget("https://example.com", "test-key", mockClient);
 
-    assertDoesNotThrow(() -> target.dispatch("job-1", "batch-jobs/job-1/inputs/", "Main", 1));
+    assertDoesNotThrow(() -> target.dispatch(
+        "job-1", "batch-jobs/job-1/inputs/", "Main", 1, Map.of(), 0));
     verify(mockClient).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
   }
 
@@ -59,7 +61,7 @@ class HttpBatchTargetTest {
     HttpBatchTarget target = new HttpBatchTarget("https://example.com", "test-key", mockClient);
 
     RuntimeException ex = assertThrows(RuntimeException.class,
-        () -> target.dispatch("job-bad", "prefix/", "Main", 1));
+        () -> target.dispatch("job-bad", "prefix/", "Main", 1, Map.of(), 0));
     assertTrue(ex.getMessage().contains("HTTP 400"));
     assertTrue(ex.getMessage().contains("missing-fields"));
   }
@@ -77,7 +79,7 @@ class HttpBatchTargetTest {
     HttpBatchTarget target = new HttpBatchTarget("https://example.com", "test-key", mockClient);
 
     RuntimeException ex = assertThrows(RuntimeException.class,
-        () -> target.dispatch("job-err", "prefix/", "Main", 5));
+        () -> target.dispatch("job-err", "prefix/", "Main", 5, Map.of(), 0));
     assertTrue(ex.getMessage().contains("HTTP 500"));
   }
 
@@ -92,7 +94,7 @@ class HttpBatchTargetTest {
         .thenReturn(mockResponse);
 
     HttpBatchTarget target = new HttpBatchTarget("https://example.com", "key", mockClient);
-    target.dispatch("job-rep", "prefix/", "Main", 10);
+    target.dispatch("job-rep", "prefix/", "Main", 10, Map.of(), 0);
 
     // Verify the request was made (form body contains replicates, verified via mock interaction)
     verify(mockClient).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
@@ -104,6 +106,99 @@ class HttpBatchTargetTest {
     HttpBatchTarget target = new HttpBatchTarget(config);
     // Should not throw — construction is lazy (no HTTP call)
     assertDoesNotThrow(() -> {});
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void dispatchOmitsCustomTagsAndStartWhenDefault() throws Exception {
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpResponse<String> mockResponse = mock(HttpResponse.class);
+    when(mockResponse.statusCode()).thenReturn(202);
+    when(mockResponse.body()).thenReturn("{}");
+    when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(mockResponse);
+
+    final org.mockito.ArgumentCaptor<HttpRequest> reqCaptor =
+        org.mockito.ArgumentCaptor.forClass(HttpRequest.class);
+    HttpBatchTarget target = new HttpBatchTarget("https://example.com", "key", mockClient);
+
+    target.dispatch("job-1", "prefix/", "Main", 1, Map.of(), 0);
+
+    verify(mockClient).send(reqCaptor.capture(), any(HttpResponse.BodyHandler.class));
+    String body = drainBody(reqCaptor.getValue());
+    assertTrue(!body.contains("customTags"),
+        "default empty tags should not be in form body: " + body);
+    assertTrue(!body.contains("replicateStart"),
+        "default zero start should not be in form body: " + body);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void dispatchIncludesCustomTagsAndReplicateStart() throws Exception {
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpResponse<String> mockResponse = mock(HttpResponse.class);
+    when(mockResponse.statusCode()).thenReturn(202);
+    when(mockResponse.body()).thenReturn("{}");
+    when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(mockResponse);
+
+    final org.mockito.ArgumentCaptor<HttpRequest> reqCaptor =
+        org.mockito.ArgumentCaptor.forClass(HttpRequest.class);
+    HttpBatchTarget target = new HttpBatchTarget("https://example.com", "key", mockClient);
+
+    Map<String, String> tags = new java.util.LinkedHashMap<>();
+    tags.put("run_hash", "abc123");
+    tags.put("region", "west");
+    target.dispatch("job-1", "prefix/", "Main", 3, tags, 5);
+
+    verify(mockClient).send(reqCaptor.capture(), any(HttpResponse.BodyHandler.class));
+    String body = drainBody(reqCaptor.getValue());
+    String decoded = java.net.URLDecoder.decode(
+        body, java.nio.charset.StandardCharsets.UTF_8);
+    assertTrue(decoded.contains("customTags=run_hash=abc123\nregion=west"),
+        "expected tag pairs in body: " + decoded);
+    assertTrue(decoded.contains("replicateStart=5"),
+        "expected replicateStart in body: " + decoded);
+  }
+
+  /**
+   * Extracts the form body from an outgoing HttpRequest.
+   *
+   * <p>HttpRequest.BodyPublisher exposes the bytes via subscribe(); easiest path is to
+   * resubscribe a tiny in-memory collector and concatenate.</p>
+   */
+  private static String drainBody(HttpRequest request) {
+    java.util.List<java.nio.ByteBuffer> chunks = new java.util.ArrayList<>();
+    request.bodyPublisher().get().subscribe(new java.util.concurrent.Flow.Subscriber<>() {
+      @Override
+      public void onSubscribe(java.util.concurrent.Flow.Subscription s) {
+        s.request(Long.MAX_VALUE);
+      }
+
+      @Override
+      public void onNext(java.nio.ByteBuffer item) {
+        chunks.add(item);
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        throw new RuntimeException(t);
+      }
+
+      @Override
+      public void onComplete() {
+        // no-op
+      }
+    });
+    int total = chunks.stream().mapToInt(java.nio.ByteBuffer::remaining).sum();
+    byte[] all = new byte[total];
+    int offset = 0;
+    for (java.nio.ByteBuffer chunk : chunks) {
+      int len = chunk.remaining();
+      chunk.get(all, offset, len);
+      offset += len;
+    }
+    return new String(all, java.nio.charset.StandardCharsets.UTF_8);
   }
 
   @Test
@@ -118,6 +213,6 @@ class HttpBatchTargetTest {
         .thenReturn(mockResponse);
 
     HttpBatchTarget target = new HttpBatchTarget("https://example.com/", "key", mockClient);
-    assertDoesNotThrow(() -> target.dispatch("job-1", "prefix/", "Main", 1));
+    assertDoesNotThrow(() -> target.dispatch("job-1", "prefix/", "Main", 1, Map.of(), 0));
   }
 }

--- a/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
@@ -110,7 +110,7 @@ class KubernetesTargetTest {
       throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 5);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 5, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     assertNotNull(job);
@@ -127,7 +127,7 @@ class KubernetesTargetTest {
   void dispatchSetsContainerImage() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     Container container = getContainer(job);
@@ -138,7 +138,7 @@ class KubernetesTargetTest {
   void dispatchCreatesSecretWithMinioCreds() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Secret secret = secretCaptor.getValue();
     assertNotNull(secret);
@@ -163,7 +163,7 @@ class KubernetesTargetTest {
   void dispatchSetsSecretRefEnvVars() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     List<EnvVar> envVars = getContainer(job).getEnv();
@@ -187,13 +187,57 @@ class KubernetesTargetTest {
   void dispatchSetsPlainJobEnvVars() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     List<EnvVar> envVars = getContainer(job).getEnv();
     assertPlainEnvVar(envVars, "JOSH_JOB_ID", JOB_ID);
     assertPlainEnvVar(envVars, "JOSH_MINIO_PREFIX", PREFIX);
     assertPlainEnvVar(envVars, "JOSH_SIMULATION", SIMULATION);
+  }
+
+  @Test
+  void dispatchOmitsCustomTagsAndOffsetWhenDefault() throws Exception {
+    KubernetesTarget target = buildTarget(config);
+
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+
+    Job job = jobCaptor.getValue();
+    List<EnvVar> envVars = getContainer(job).getEnv();
+    assertNull(findEnvVar(envVars, "JOSH_CUSTOM_TAGS"));
+    assertNull(findEnvVar(envVars, "JOSH_REPLICATE_OFFSET"));
+  }
+
+  @Test
+  void dispatchSerializesCustomTagsAsNewlineDelimitedPairs() throws Exception {
+    KubernetesTarget target = buildTarget(config);
+
+    Map<String, String> tags = new java.util.LinkedHashMap<>();
+    tags.put("run_hash", "abc123");
+    tags.put("region", "west");
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, tags, 0);
+
+    Job job = jobCaptor.getValue();
+    List<EnvVar> envVars = getContainer(job).getEnv();
+    EnvVar tagsVar = findEnvVar(envVars, "JOSH_CUSTOM_TAGS");
+    assertNotNull(tagsVar);
+    String value = tagsVar.getValue();
+    assertTrue(value.contains("run_hash=abc123"));
+    assertTrue(value.contains("region=west"));
+    assertTrue(value.contains("\n"));
+  }
+
+  @Test
+  void dispatchEmitsReplicateOffsetWhenNonZero() throws Exception {
+    KubernetesTarget target = buildTarget(config);
+
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 3, Map.of(), 5);
+
+    Job job = jobCaptor.getValue();
+    List<EnvVar> envVars = getContainer(job).getEnv();
+    EnvVar offsetVar = findEnvVar(envVars, "JOSH_REPLICATE_OFFSET");
+    assertNotNull(offsetVar);
+    assertEquals("5", offsetVar.getValue());
   }
 
   @Test
@@ -208,7 +252,7 @@ class KubernetesTargetTest {
     config = buildConfig(10, 3600, resources);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     ResourceRequirements reqs =
@@ -230,7 +274,7 @@ class KubernetesTargetTest {
     config = buildConfig(10, 3600, null);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     ResourceRequirements reqs =
@@ -243,7 +287,7 @@ class KubernetesTargetTest {
     config = buildConfig(10, 3600, null);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 3);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 3, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     assertEquals(3, job.getSpec().getParallelism());
@@ -254,7 +298,7 @@ class KubernetesTargetTest {
   void dispatchJobNameFormat() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     assertEquals(
@@ -278,7 +322,7 @@ class KubernetesTargetTest {
     setField(config, "spot", true);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     Map<String, String> nodeSelector =
@@ -303,7 +347,7 @@ class KubernetesTargetTest {
     config = buildConfig(10, 3600, null);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     Map<String, String> nodeSelector =
@@ -321,7 +365,7 @@ class KubernetesTargetTest {
     setField(config, "ttlSecondsAfterFinished", 600);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     assertEquals(
@@ -334,7 +378,7 @@ class KubernetesTargetTest {
   void dispatchUsesEntrypointScript() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     Container container = getContainer(job);
@@ -429,5 +473,12 @@ class KubernetesTargetTest {
         .orElse(null);
     assertNotNull(found, "Missing env var: " + name);
     assertEquals(value, found.getValue());
+  }
+
+  private EnvVar findEnvVar(List<EnvVar> envVars, String name) {
+    return envVars.stream()
+        .filter(e -> name.equals(e.getName()))
+        .findFirst()
+        .orElse(null);
   }
 }


### PR DESCRIPTION
## Summary

Restores `--custom-tag` parity on `batchRemote` (lost in #423) and adds `--replicate-start` for pool/resume sweep workflows. Both flags also land on `run` and `runRemote` so the same `.josh` file works on every run mode.

After this PR, joshpy ([joshpy#39](https://github.com/SchmidtDSE/joshpy/pull/39)) can:
- Inject `run_hash` (or any custom tag) into `exportFiles` paths without pre-interpolating tokens in `sim.josh` before upload.
- Implement `pool`/`replace`/`skip`/`fail` collision policies for re-dispatch by computing replicate offsets pre-dispatch.

## Changes

### CLI
- `RunCommand` — adds `--replicate-start` (default `0`), mutex with `--replicate-index`.
- `RunRemoteCommand` — same flag, threaded via `RunRemoteContextBuilder.withReplicateNumber()` (consumed by `RunRemoteLocalLeaderStrategy.createWorkerTasks` for the local-leader path); also sent as a `replicateStart` form field on the offload-leader path.
- `BatchRemoteCommand` — adds `--custom-tag` and `--replicate-start`. `parseCustomTags()` mirrors `RunCommand.parseCustomParameters()` (rejects reserved names `replicate`/`step`/`variable`).

### Dispatch chain
- `RemoteBatchTarget.dispatch()` — extended signature: `(jobId, prefix, simulation, replicates, customTags, replicateStart)`.
- `KubernetesTarget` — emits `JOSH_CUSTOM_TAGS` (newline-delimited `key=value` lines) and `JOSH_REPLICATE_OFFSET` env vars on the Job spec.
- `HttpBatchTarget` — propagates as `customTags` and `replicateStart` form fields.
- Both new env vars / form fields are emitted **only when non-default**, so existing dispatches produce byte-identical Job specs and form bodies.

### Server-side
- `JoshSimBatchHandler` — parses both new form fields, **wires `TemplateStringRenderer` through `JvmInputOutputLayerBuilder` for the first time** on this code path (it was never wired before, so `{run_hash}` and other custom tags silently no-op'd on the HTTP batch path even prior to this PR — fixing this is partly a bug fix), and offsets the replicate loop by `replicateStart`. Validates negative/non-numeric `replicateStart` and reserved/malformed `customTags`.
- `JoshSimLeaderHandler` — accepts the new `replicateStart` form field and offsets `WorkerTask` replicate numbering for the offload-leader path.

### Pod entrypoint
- `cloud-img/run-entrypoint.sh` — reads `JOSH_CUSTOM_TAGS` via POSIX `while IFS= read -r line` (no `jq` dep — keeps `Dockerfile.batch` JRE-only), emits one `--custom-tag=key=value` flag per non-empty line. Computes `REPLICATE_INDEX = JOB_COMPLETION_INDEX + JOSH_REPLICATE_OFFSET`. `preprocess-entrypoint.sh` is unchanged — preprocessing is tag-free by design.

## Encoding decisions

- **Newline-delimited `key=value` for tags**: matches `RunCommand`'s existing `String[] customTags` shape exactly, parseable in pure POSIX shell, no new image deps. Newlines in tag values are not supported (joshpy's typical tag values are alphanumeric in practice).
- **Defaults are no-ops**: empty tag map and `replicateStart=0` produce byte-identical specs to before this PR.

## Tests

### Unit (~12 new)
- `RunCommandReplicatesTest` — `--replicate-start=5 --replicates=2` produces CSV rows with replicate column = 5 and 6, none = 0; mutex with `--replicate-index`; rejects negative.
- `BatchRemoteCommandTest` — schema (`--custom-tag` is `String[]`, `--replicate-start` is `int` with default `"0"`); `parseCustomTags` rejects reserved names + malformed entries.
- `KubernetesTargetTest` — env vars omitted at default; newline-joined value when tags present; offset emitted iff non-zero.
- `HttpBatchTargetTest` — form fields omitted at default; URL-encoded round-trip of newlines verified by capturing the outgoing `HttpRequest` body.
- `JoshSimBatchHandlerTest` — rejects malformed `customTags`, reserved-name `customTags`, negative `replicateStart`, non-numeric `replicateStart`.
- Existing `BatchJobStrategyTest`, `HttpBatchTargetTest`, `KubernetesTargetTest` updated to the new signature with `Map.of(), 0`.

### Integration (`.github/workflows/test-k8s.yaml`)

New step inside the existing Kind CI workflow dispatches:

```sh
java -jar build/libs/joshsim-fat.jar batchRemote K8sCustomTagTest \
  --target=ci-k8s \
  --minio-prefix=batch-jobs/k8s-customtag/inputs/ \
  --require-prestaged \
  --replicates=2 \
  --replicate-start=2 \
  --custom-tag=run_hash=ci-test
```

The `.josh` script templates both `{run_hash}` and `{replicate}` into the export path:
```
minio://josh-test-bucket/k8s-customtag-results/{run_hash}/replicate-{replicate}.csv
```

The verification step asserts:
- `ci-test/` directory exists under `k8s-customtag-results/` (proves `{run_hash}` flows through K8s env var → entrypoint → `--custom-tag` flag → `TemplateStringRenderer`)
- `replicate-2.csv` and `replicate-3.csv` are present and non-empty (proves the offset reaches the pod via `JOSH_REPLICATE_OFFSET + JOB_COMPLETION_INDEX`)
- `replicate-0.csv` is absent (proves the pods didn't fall back to `JOB_COMPLETION_INDEX` alone)

All three assertions would fail before this PR.

### Local smoke
`joshsim run --replicates=2 --replicate-start=5 --custom-tag=run_hash=local-test` produces exactly `local-test/replicate-5.csv` and `local-test/replicate-6.csv` (no `replicate-0.csv`) — same logic the pod entrypoint executes.

## Test plan
- [x] \`./gradlew test checkstyleMain checkstyleTest\` — all pass
- [x] \`./gradlew fatJar\` — builds clean
- [x] \`--help\` on \`run\`, \`runRemote\`, \`batchRemote\` shows the new flags
- [x] Local end-to-end smoke via \`run\` — output paths verified
- [ ] CI: existing K8s integration tests still pass (verifies backward-compat)
- [ ] CI: new K8s integration step verifies the new flags end-to-end against Kind

🤖 Generated with [Claude Code](https://claude.com/claude-code)