### PR TITLE
Fix KubernetesTargetTest compile error after #433 + #434 merge

### DIFF
--- a/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
@@ -366,7 +366,7 @@ class KubernetesTargetTest {
     ));
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     Map<String, String> selector = job.getSpec()
@@ -386,7 +386,7 @@ class KubernetesTargetTest {
     ));
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     Map<String, String> selector = job.getSpec()
@@ -404,7 +404,7 @@ class KubernetesTargetTest {
     config = buildConfig(10, 3600, null);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
 
     Job job = jobCaptor.getValue();
     Map<String, String> selector = job.getSpec()


### PR DESCRIPTION
## What broke

PR #433 changed \`RemoteBatchTarget.dispatch()\` from 4 args to 6 (added \`customTags\` and \`replicateStart\`). PR #434 added three new tests for the \`nodeSelector\` feature. Both were open at the same time; #434 branched before #433 landed, so its three new test calls used the old 4-arg form.

Both got merged before CI on the rebase had a chance to flag it, so \`dev\` is currently broken — \`compileTestJava\` fails on:

\`\`\`
src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java:369:
  required: String,String,String,int,Map<String,String>,int
  found:    String,String,String,int
\`\`\`

(Same error at lines 389 and 407.)

## Fix

Three-line patch — match the existing convention in this file: every other test calls \`target.dispatch(JOB_ID, PREFIX, SIMULATION, N, Map.of(), 0)\`. The three new \`nodeSelector\` tests now do the same.

## Test plan
- [x] \`./gradlew compileTestJava\` — clean
- [x] \`./gradlew test --tests KubernetesTargetTest\` — passes
- [x] All three nodeSelector tests still exercise what they did before (\`dispatchAppliesNodeSelector\`, \`dispatchMergesNodeSelectorWithSpotSelector\`, \`dispatchOmitsNodeSelectorWhenAbsent\`). The \`Map.of(), 0\` arguments are no-op defaults that don't affect the nodeSelector assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)