### PR TITLE
DRY: extract RunUtil so CLI and MCP share one run pipeline

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -365,18 +365,26 @@ Existing CLI commands have execution logic intertwined with picocli
 field state. Extract callable pipeline classes so both the CLI
 command and the MCP backend can drive them without duplication:
 
-- From `command/RunCommand.java` — extract `RunPipeline` that takes
-  an immutable run config (file, simulation, replicates, dataFiles,
-  customTags, outputSteps, etc.), a step callback, and an
-  `OutputOptions`. `RunCommand.call()` becomes a 20-line shim that
-  builds the config from its picocli fields and invokes the pipeline.
+- From `command/RunCommand.java` — extract `RunUtil` (the immutable
+  `RunUtil.RunOptions` carries file, simulation, replicates,
+  replicateStart/Index, dataFiles, customParameters, outputSteps,
+  csvPrecision, exportQueueSize, useFloat64, enableProfiler, seed, and
+  `MinioOptions`). `RunCommand.call()` is now a shim that builds
+  `RunOptions` from its picocli fields, calls `RunUtil.run`, and maps
+  the `RunUtil.RunResult` to an exit code. **Done** — both the CLI and
+  the MCP `LocalBackend.runSimulation` drive `RunUtil`, so there is one
+  in-JVM run pipeline rather than two. `LocalBackend` sets only the
+  five MCP-exposed knobs; everything else falls through to the CLI
+  defaults, with two MCP-specific choices (profiler off; `MinioOptions`
+  resolved from the environment) documented inline.
 - From `command/RunRemoteCommand.java` — same treatment:
-  `RemoteRunPipeline`.
+  `RemoteRunPipeline`. *(Still pending — Phase 2.)*
 - From `command/PreprocessBatchCommand.java` — same:
-  `RemotePreprocessPipeline`.
+  `RemotePreprocessPipeline`. *(Still pending — Phase 2.)*
 
-No behavior change. This is the largest piece of mechanical work in
-the plan and the prerequisite for clean tool handlers.
+No behavior change for the CLI; the MCP run path now matches CLI
+behavior (including Earth-space grid handling that the earlier
+standalone MCP run loop omitted).
 
 ## Critical implementation details
 
@@ -516,7 +524,7 @@ the plan and the prerequisite for clean tool handlers.
 
 **Core files created:**
 - `src/main/java/org/joshsim/mcp/Backend.java` — Interface with four methods and inner result POJOs (`ValidateResult`, `DiscoverConfigResult`, `PreprocessResult`, `RunSimulationResult`) plus `PreprocessOptions`.
-- `src/main/java/org/joshsim/mcp/LocalBackend.java` — In-JVM implementation delegating to `JoshSimCommander.getJoshProgram`, `JoshConfigDiscoveryVisitor`, `PreprocessUtil.preprocess`, and `JoshSimFacadeUtil.runSimulation`.
+- `src/main/java/org/joshsim/mcp/LocalBackend.java` — In-JVM implementation delegating to `JoshSimCommander.getJoshProgram`, `JoshConfigDiscoveryVisitor`, `PreprocessUtil.preprocess`, and `RunUtil.run` (see Post-review refactors).
 - `src/main/java/org/joshsim/mcp/JoshMcpServer.java` — Wires the MCP SDK, loads `McpJsonMapper` via `ServiceLoader<McpJsonMapperSupplier>`, registers all four tools.
 - `src/main/java/org/joshsim/mcp/JoshPaths.java` — Path resolution utility (absolute + normalized).
 - `src/main/java/org/joshsim/mcp/StderrOutputOptions.java` — Routes all diagnostic output to `System.err`, keeping `System.out` clean for JSON-RPC.
@@ -548,7 +556,26 @@ the plan and the prerequisite for clean tool handlers.
 
 ### Known limitations
 
-- `runSimulation` is not tested end-to-end (would require a real simulation run); unit tests cover the result POJOs and backend wiring only.
 - The MCP server sends several `notifications/tools/list_changed` events on startup (one per `addTool` call); this is an SDK behavior and not harmful.
 - opencode MCP server config: https://opencode.ai/docs/mcp-servers/
 - MCP Inspector (testing tool): `npx @modelcontextprotocol/inspector`
+
+### Post-review refactors (PR #440 follow-ups)
+
+Two follow-up changes addressed code-review feedback on the Phase 1 PR:
+
+1. **Schema + handler cleanup.** Each tool's input schema moved from an
+   inline concatenated Java string to a `*.schema.json` resource under
+   `src/main/resources/org/joshsim/mcp/tool/local/`, loaded by
+   `ToolSchemas.load(...)`. Each tool's call-handler body was lifted out
+   of its anonymous lambda into a named `handle(...)` method, and shared
+   `errorResult(...)` / `requireString(...)` helpers moved to
+   `ToolHandlers`. New test: `ToolSchemasTest`.
+
+2. **`RunUtil` extraction (DRY).** `LocalBackend.runSimulation` no longer
+   reimplements the run loop; it builds `RunUtil.RunOptions` and calls
+   `RunUtil.run`, the same pipeline `RunCommand` now uses. This removed
+   the divergence where the MCP run path skipped Earth-space grid setup,
+   metadata/progress, csv-precision, and MinIO. New test: `RunUtilTest`
+   (real end-to-end run, simulation-not-found, init-failure, seed
+   determinism). `runSimulation` is now covered end-to-end.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -576,6 +576,11 @@ Two follow-up changes addressed code-review feedback on the Phase 1 PR:
    reimplements the run loop; it builds `RunUtil.RunOptions` and calls
    `RunUtil.run`, the same pipeline `RunCommand` now uses. This removed
    the divergence where the MCP run path skipped Earth-space grid setup,
-   metadata/progress, csv-precision, and MinIO. New test: `RunUtilTest`
-   (real end-to-end run, simulation-not-found, init-failure, seed
-   determinism). `runSimulation` is now covered end-to-end.
+   metadata/progress, csv-precision, and MinIO. Internally, `RunUtil` is
+   organized into named per-phase helpers (`buildJobs`,
+   `initializeProgram`, `extractSpatialInfo`, `executeJobs`, etc.) with
+   `GridSpatialInfo` / `ExecutionSummary` records grouping the values
+   passed between them, so the top-level `run` reads as a sequence of
+   steps. New test: `RunUtilTest` (real end-to-end run,
+   simulation-not-found, init-failure, seed determinism). `runSimulation`
+   is now covered end-to-end.

--- a/src/main/java/org/joshsim/command/RunCommand.java
+++ b/src/main/java/org/joshsim/command/RunCommand.java
@@ -12,52 +12,16 @@
 package org.joshsim.command;
 
 import java.io.File;
-import java.math.BigDecimal;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import org.joshsim.JoshSimCommander;
-import org.joshsim.JoshSimFacadeUtil;
-import org.joshsim.compat.CompatibilityLayerKeeper;
-import org.joshsim.compat.JvmCompatibilityLayer;
-import org.joshsim.engine.entity.base.MutableEntity;
-import org.joshsim.engine.geometry.EngineGeometryFactory;
-import org.joshsim.engine.geometry.ExtentsUtil;
-import org.joshsim.engine.geometry.PatchBuilderExtentsBuilder;
-import org.joshsim.engine.geometry.grid.GridGeometryFactory;
-import org.joshsim.engine.value.converter.Units;
-import org.joshsim.engine.value.engine.ValueSupportFactory;
-import org.joshsim.engine.value.type.EngineValue;
-import org.joshsim.lang.bridge.GridInfoExtractor;
-import org.joshsim.lang.bridge.ShadowingEntity;
-import org.joshsim.lang.interpret.JoshProgram;
-import org.joshsim.lang.interpret.RecursiveValueResolverFactory;
-import org.joshsim.lang.interpret.TimedRecursiveValueResolverFactory;
-import org.joshsim.lang.interpret.ValueResolverFactory;
-import org.joshsim.lang.io.InputGetterStrategy;
-import org.joshsim.lang.io.InputOutputLayer;
-import org.joshsim.lang.io.JvmInputOutputLayerBuilder;
-import org.joshsim.lang.io.JvmMappedInputGetter;
-import org.joshsim.lang.io.JvmWorkingDirInputGetter;
 import org.joshsim.lang.io.MapSerializeStrategy;
-import org.joshsim.pipeline.job.JoshJob;
-import org.joshsim.pipeline.job.JoshJobBuilder;
-import org.joshsim.pipeline.job.config.JobVariationParser;
-import org.joshsim.pipeline.job.config.TemplateStringRenderer;
-import org.joshsim.precompute.JshdExternalGetter;
-import org.joshsim.precompute.JshdzExternalGetter;
-import org.joshsim.precompute.MultiFormatExternalGetter;
 import org.joshsim.util.MinioOptions;
 import org.joshsim.util.OutputOptions;
 import org.joshsim.util.OutputStepsParser;
-import org.joshsim.util.ProgressCalculator;
-import org.joshsim.util.ProgressUpdate;
-import org.joshsim.util.SharedRandom;
-import org.joshsim.util.SimulationMetadata;
-import org.joshsim.util.SimulationMetadataExtractor;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -69,7 +33,9 @@ import picocli.CommandLine.Parameters;
  *
  * <p>Processes command line arguments to run a specified simulation from a Josh script file.
  * Supports configuration of the coordinate reference system and parallel/serial patch processing.
- * Can optionally save results to Minio storage.</p>
+ * Can optionally save results to Minio storage. The actual run pipeline lives in {@link RunUtil};
+ * this class only translates picocli fields into {@link RunUtil.RunOptions} and maps the
+ * {@link RunUtil.RunResult} to a process exit code.</p>
  */
 @Command(
     name = "run",
@@ -77,20 +43,6 @@ import picocli.CommandLine.Parameters;
 )
 public class RunCommand implements Callable<Integer> {
   private static final int UNKNOWN_ERROR_CODE = 404;
-
-  /**
-   * Builds the appropriate ValueResolverFactory based on whether profiling is enabled.
-   *
-   * @param enableProfiler True to use timed resolution for evalDuration support, false otherwise.
-   * @return A ValueResolverFactory configured for the requested profiling mode.
-   */
-  private static ValueResolverFactory buildValueResolverFactory(boolean enableProfiler) {
-    if (enableProfiler) {
-      return new TimedRecursiveValueResolverFactory();
-    } else {
-      return new RecursiveValueResolverFactory();
-    }
-  }
 
   @Parameters(index = "0", description = "Path to file to validate")
   private File file;
@@ -250,95 +202,30 @@ public class RunCommand implements Callable<Integer> {
       return 1;
     }
 
-    // Initialize shared random with seed for reproducibility
-    if (seed != null) {
-      SharedRandom.initialize(seed);
-      output.printInfo("Using random seed: " + seed);
-
-      // Force serial execution when seeded for deterministic results
-      // Parallel execution would cause non-deterministic random call ordering
-      if (!serialPatches) {
-        output.printInfo(
-            "Note: Forcing serial patch execution for reproducibility with --seed");
-        serialPatches = true;
-      }
-    } else {
-      SharedRandom.initialize(Optional.empty());
-    }
-
-    // Parse output steps early for fail-fast validation
-    final Optional<Set<Integer>> parsedOutputSteps = parseOutputSteps();
-    final EngineGeometryFactory geometryFactory = new GridGeometryFactory();
-
-    // Parse custom parameters from command line
+    // Parse CLI-shaped inputs up front for fail-fast validation.
     Map<String, String> customParameters = parseCustomParameters();
+    Optional<Set<Integer>> parsedOutputSteps = parseOutputSteps();
 
-    // When --replicate-index is set, run exactly one replicate at that index.
-    int effectiveReplicates = replicateIndex != null ? 1 : replicates;
-
-    // Create job configurations using JobVariationParser for grid search
-    JoshJobBuilder templateJobBuilder = new JoshJobBuilder()
-        .setReplicates(effectiveReplicates)
-        .setCustomParameters(customParameters);
-    JobVariationParser parser = new JobVariationParser();
-    List<JoshJobBuilder> jobBuilders = parser.parseDataFiles(templateJobBuilder, dataFiles);
-
-    // Build all job instances
-    List<JoshJob> jobs = jobBuilders.stream()
-        .map(JoshJobBuilder::build)
-        .toList();
-
-    // Report grid search information
-    if (replicateIndex != null) {
-      output.printInfo("Running replicate index " + replicateIndex
-          + " across " + jobs.size() + " job combination(s)");
-    } else {
-      output.printInfo("Grid search will execute " + jobs.size() + " job combination(s) "
-          + "with " + replicates + " replicate(s) each");
-    }
-    output.printInfo("Total simulations to run: " + (jobs.size() * effectiveReplicates));
-
-    // Use first job for initialization (all jobs should have compatible structure)
-    JoshJob firstJob = jobs.get(0);
-
-    // Create appropriate InputGetterStrategy based on first job configuration
-    InputGetterStrategy inputStrategy;
-    if (firstJob.getFilePaths().isEmpty()) {
-      inputStrategy = new JvmWorkingDirInputGetter();
-    } else {
-      inputStrategy = new JvmMappedInputGetter(firstJob.getFilePaths());
-    }
-
-    // Create template renderer for initialization phase (using first job, replicate 0)
-    TemplateStringRenderer initTemplateRenderer = new TemplateStringRenderer(firstJob, 0);
-
-    // Create InputOutputLayer with the chosen strategy (using first replicate for initialization)
-    InputOutputLayer initInputOutputLayer = new JvmInputOutputLayerBuilder()
-        .withReplicate(0)
-        .withInputStrategy(inputStrategy)
-        .withTemplateRenderer(initTemplateRenderer)
-        .withMinioOptions(minioOptions)
-        .withMaxDecimalPlaces(csvPrecision)
+    RunUtil.RunOptions options = RunUtil.RunOptions.builder(file, simulation)
+        .replicates(replicates)
+        .replicateIndex(replicateIndex)
+        .replicateStart(replicateStart)
+        .serialPatches(serialPatches)
+        .seed(Optional.ofNullable(seed))
+        .useFloat64(useFloat64)
+        .enableProfiler(enableProfiler)
+        .csvPrecision(csvPrecision)
+        .exportQueueSize(exportQueueSize)
+        .outputSteps(parsedOutputSteps)
+        .dataFiles(dataFiles)
+        .customParameters(customParameters)
+        .minioOptions(minioOptions)
         .build();
 
-    // Create ValueSupportFactory before interpretation so that the profiler-enabled
-    // resolver factory is used when building ValueResolver instances at compile time.
-    boolean favorBigDecimal = !useFloat64;
-    ValueSupportFactory valueFactory = new ValueSupportFactory(
-        favorBigDecimal,
-        buildValueResolverFactory(enableProfiler)
-    );
+    RunUtil.RunResult result = RunUtil.run(options, output);
 
-    JoshSimCommander.ProgramInitResult initResult = JoshSimCommander.getJoshProgram(
-        valueFactory,
-        geometryFactory,
-        file,
-        output,
-        initInputOutputLayer
-    );
-
-    if (initResult.getFailureStep().isPresent()) {
-      JoshSimCommander.CommanderStepEnum failStep = initResult.getFailureStep().get();
+    if (result.getInitFailureStep().isPresent()) {
+      JoshSimCommander.CommanderStepEnum failStep = result.getInitFailureStep().get();
       return switch (failStep) {
         case LOAD -> 1;
         case READ -> 2;
@@ -346,156 +233,11 @@ public class RunCommand implements Callable<Integer> {
         default -> UNKNOWN_ERROR_CODE;
       };
     }
-
-    output.printInfo("Validated Josh code at " + file);
-
-    JoshProgram program = initResult.getProgram().orElseThrow();
-    if (!program.getSimulations().hasPrototype(simulation)) {
-      output.printError("Could not find simulation: " + simulation);
+    if (result.isSimulationNotFound()) {
       return 4;
     }
 
-    // Extract simulation metadata for progress tracking
-    SimulationMetadata metadata;
-    try {
-      metadata = SimulationMetadataExtractor.extractMetadata(file, simulation);
-    } catch (Exception e) {
-      // Use default metadata if extraction fails
-      metadata = new SimulationMetadata(0, 10, 11);
-      output.printInfo("Using default metadata for progress tracking: " + e.getMessage());
-    }
-
-    ProgressCalculator progressCalculator = new ProgressCalculator(
-        metadata.getTotalSteps(),
-        jobs.size() * replicates // Total simulations = jobs × replicates
-    );
-
-    // Set up JVM compatibility layer
-    JvmCompatibilityLayer compatLayer = new JvmCompatibilityLayer();
-    compatLayer.setExportQueueCapacity(exportQueueSize);
-    CompatibilityLayerKeeper.set(compatLayer);
-
-    // Extract grid information for Earth-space detection (similar to JoshSimFacade)
-    MutableEntity simEntityRaw = program.getSimulations().getProtoype(simulation).build();
-    MutableEntity simEntity = new ShadowingEntity(valueFactory, simEntityRaw, simEntityRaw);
-    GridInfoExtractor extractor = new GridInfoExtractor(simEntity, valueFactory);
-    boolean hasDegrees = extractor.getStartStr().contains("degree");
-
-    EngineValue sizeValueRaw = extractor.getSize();
-    Units sizeUnits = sizeValueRaw.getUnits();
-    String sizeStr = sizeUnits.toString();
-    boolean sizeMeterAbbreviated = sizeStr.equals("m");
-    boolean sizeMetersFull = sizeStr.equals("meter") || sizeStr.equals("meters");
-    boolean sizeMeters = sizeMetersFull || sizeMeterAbbreviated;
-
-    // Execute simulation for each job combination and replicate.
-    // When --replicate-index is set, run exactly one replicate at that index.
-    int totalReplicateCount = 0;
-
-    for (int jobIndex = 0; jobIndex < jobs.size(); jobIndex++) {
-      JoshJob currentJob = jobs.get(jobIndex);
-      output.printInfo("Executing job combination " + (jobIndex + 1) + "/" + jobs.size());
-
-      if (!currentJob.getFilePaths().isEmpty()) {
-        inputStrategy = new JvmMappedInputGetter(currentJob.getFilePaths());
-      }
-
-      int startReplicate = replicateIndex != null ? replicateIndex : replicateStart;
-      int endReplicate = replicateIndex != null
-          ? replicateIndex + 1 : replicateStart + currentJob.getReplicates();
-
-      for (int currentReplicate = startReplicate; currentReplicate < endReplicate;
-           currentReplicate++) {
-        int effectiveReplicate = replicateIndex != null ? replicateIndex : currentReplicate;
-        totalReplicateCount++;
-
-        if (totalReplicateCount > 1) {
-          progressCalculator.resetForNextReplicate(totalReplicateCount);
-        }
-
-        runReplicate(currentJob, effectiveReplicate, totalReplicateCount > 1,
-            valueFactory, geometryFactory, inputStrategy, hasDegrees, sizeMeters,
-            sizeValueRaw, extractor, program, simulation, progressCalculator,
-            parsedOutputSteps);
-
-        ProgressUpdate completion = progressCalculator.updateReplicateCompleted(
-            totalReplicateCount);
-        output.printInfo(completion.getMessage());
-      }
-
-      if (jobIndex < jobs.size() - 1) {
-        output.printInfo("Completed job combination " + (jobIndex + 1) + "/" + jobs.size());
-      }
-    }
-
-    output.printInfo("");
-    output.printInfo("✓ All simulations completed successfully!");
-    output.printInfo("  Total replicates run: " + totalReplicateCount);
-    output.printInfo("  Job combinations: " + jobs.size());
-    output.printInfo("  Replicates per job: " + effectiveReplicates);
-
-    // Clean up shared random
-    SharedRandom.clear();
-
     return 0;
-  }
-
-  private void runReplicate(JoshJob currentJob, int currentReplicate, boolean appendMode,
-      ValueSupportFactory valueFactory, EngineGeometryFactory geometryFactory,
-      InputGetterStrategy inputStrategy, boolean hasDegrees, boolean sizeMeters,
-      EngineValue sizeValueRaw, GridInfoExtractor extractor, JoshProgram program,
-      String simulation, ProgressCalculator progressCalculator,
-      Optional<Set<Integer>> parsedOutputSteps) {
-    TemplateStringRenderer templateRenderer = new TemplateStringRenderer(currentJob,
-        currentReplicate);
-
-    InputOutputLayer inputOutputLayer;
-    if (hasDegrees && sizeMeters) {
-      PatchBuilderExtentsBuilder extentsBuilder = new PatchBuilderExtentsBuilder();
-      ExtentsUtil.addExtents(extentsBuilder, extractor.getStartStr(), true, valueFactory);
-      ExtentsUtil.addExtents(extentsBuilder, extractor.getEndStr(), false, valueFactory);
-      BigDecimal sizeValuePrimitive = sizeValueRaw.getAsDecimal();
-      inputOutputLayer = new JvmInputOutputLayerBuilder()
-          .withReplicate(currentReplicate)
-          .withEarthSpace(extentsBuilder.build(), sizeValuePrimitive)
-          .withInputStrategy(inputStrategy)
-          .withTemplateRenderer(templateRenderer)
-          .withMinioOptions(minioOptions)
-          .withAppendMode(appendMode)
-          .withMaxDecimalPlaces(csvPrecision)
-          .build();
-    } else {
-      inputOutputLayer = new JvmInputOutputLayerBuilder()
-          .withReplicate(currentReplicate)
-          .withInputStrategy(inputStrategy)
-          .withTemplateRenderer(templateRenderer)
-          .withMinioOptions(minioOptions)
-          .withAppendMode(appendMode)
-          .withMaxDecimalPlaces(csvPrecision)
-          .build();
-    }
-
-    MultiFormatExternalGetter externalGetter = new MultiFormatExternalGetter(
-        new JshdExternalGetter(inputStrategy, valueFactory),
-        new JshdzExternalGetter(inputStrategy, valueFactory)
-    );
-
-    JoshSimFacadeUtil.runSimulation(
-        valueFactory,
-        geometryFactory,
-        inputOutputLayer,
-        externalGetter,
-        program,
-        simulation,
-        (step) -> {
-          ProgressUpdate update = progressCalculator.updateStep(step);
-          if (update.shouldReport()) {
-            output.printInfo(update.getMessage());
-          }
-        },
-        serialPatches,
-        parsedOutputSteps
-    );
   }
 
 }

--- a/src/main/java/org/joshsim/command/RunUtil.java
+++ b/src/main/java/org/joshsim/command/RunUtil.java
@@ -1,0 +1,665 @@
+/**
+ * Shared simulation-run logic extracted from {@link RunCommand}.
+ *
+ * <p>Holds the full "run a simulation" pipeline — random-seed setup, grid-search job expansion,
+ * program initialization, Earth-space detection, and the per-replicate execution loop — so that
+ * both the {@code run} CLI command and the MCP {@code run_simulation} tool drive identical logic
+ * rather than maintaining divergent reimplementations.</p>
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.command;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.joshsim.JoshSimCommander;
+import org.joshsim.JoshSimFacadeUtil;
+import org.joshsim.compat.CompatibilityLayerKeeper;
+import org.joshsim.compat.JvmCompatibilityLayer;
+import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.geometry.EngineGeometryFactory;
+import org.joshsim.engine.geometry.ExtentsUtil;
+import org.joshsim.engine.geometry.PatchBuilderExtentsBuilder;
+import org.joshsim.engine.geometry.grid.GridGeometryFactory;
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.engine.ValueSupportFactory;
+import org.joshsim.engine.value.type.EngineValue;
+import org.joshsim.lang.bridge.GridInfoExtractor;
+import org.joshsim.lang.bridge.ShadowingEntity;
+import org.joshsim.lang.interpret.JoshProgram;
+import org.joshsim.lang.interpret.RecursiveValueResolverFactory;
+import org.joshsim.lang.interpret.TimedRecursiveValueResolverFactory;
+import org.joshsim.lang.interpret.ValueResolverFactory;
+import org.joshsim.lang.io.InputGetterStrategy;
+import org.joshsim.lang.io.InputOutputLayer;
+import org.joshsim.lang.io.JvmInputOutputLayerBuilder;
+import org.joshsim.lang.io.JvmMappedInputGetter;
+import org.joshsim.lang.io.JvmWorkingDirInputGetter;
+import org.joshsim.lang.io.MapSerializeStrategy;
+import org.joshsim.pipeline.job.JoshJob;
+import org.joshsim.pipeline.job.JoshJobBuilder;
+import org.joshsim.pipeline.job.config.JobVariationParser;
+import org.joshsim.pipeline.job.config.TemplateStringRenderer;
+import org.joshsim.precompute.JshdExternalGetter;
+import org.joshsim.precompute.JshdzExternalGetter;
+import org.joshsim.precompute.MultiFormatExternalGetter;
+import org.joshsim.util.MinioOptions;
+import org.joshsim.util.OutputOptions;
+import org.joshsim.util.ProgressCalculator;
+import org.joshsim.util.ProgressUpdate;
+import org.joshsim.util.SharedRandom;
+import org.joshsim.util.SimulationMetadata;
+import org.joshsim.util.SimulationMetadataExtractor;
+
+/**
+ * Static utility that runs a Josh simulation end-to-end.
+ *
+ * <p>This is the single source of truth for how a simulation is run in-JVM. {@link RunCommand}
+ * builds a {@link RunOptions} from its picocli fields and maps the {@link RunResult} to a process
+ * exit code; the MCP {@code LocalBackend} builds a {@link RunOptions} and maps the result to an
+ * MCP tool result. Neither reimplements the run loop.</p>
+ */
+public final class RunUtil {
+
+  private RunUtil() {
+    // Static utility class
+  }
+
+  /**
+   * Immutable configuration for a simulation run.
+   *
+   * <p>Mirrors the knobs exposed by the {@code run} CLI command. Construct via
+   * {@link #builder(File, String)}; every field other than the script file and simulation name
+   * has a default matching the CLI's default, so a caller that sets nothing extra behaves exactly
+   * like {@code josh run <script> <simulation>} with no flags.</p>
+   */
+  public static final class RunOptions {
+    private final File scriptFile;
+    private final String simulation;
+    private final int replicates;
+    private final Integer replicateIndex;
+    private final int replicateStart;
+    private final boolean serialPatches;
+    private final Optional<Long> seed;
+    private final boolean useFloat64;
+    private final boolean enableProfiler;
+    private final int csvPrecision;
+    private final int exportQueueSize;
+    private final Optional<Set<Integer>> outputSteps;
+    private final String[] dataFiles;
+    private final Map<String, String> customParameters;
+    private final MinioOptions minioOptions;
+
+    private RunOptions(Builder builder) {
+      this.scriptFile = builder.scriptFile;
+      this.simulation = builder.simulation;
+      this.replicates = builder.replicates;
+      this.replicateIndex = builder.replicateIndex;
+      this.replicateStart = builder.replicateStart;
+      this.serialPatches = builder.serialPatches;
+      this.seed = builder.seed;
+      this.useFloat64 = builder.useFloat64;
+      this.enableProfiler = builder.enableProfiler;
+      this.csvPrecision = builder.csvPrecision;
+      this.exportQueueSize = builder.exportQueueSize;
+      this.outputSteps = builder.outputSteps;
+      this.dataFiles = builder.dataFiles;
+      this.customParameters = builder.customParameters;
+      this.minioOptions = builder.minioOptions;
+    }
+
+    /**
+     * Creates a builder for the required script file and simulation name.
+     *
+     * @param scriptFile the {@code .josh} script file to run
+     * @param simulation the name of the simulation block to run
+     * @return a new builder seeded with CLI-matching defaults
+     */
+    public static Builder builder(File scriptFile, String simulation) {
+      return new Builder(scriptFile, simulation);
+    }
+
+    /**
+     * Builder for {@link RunOptions}. Defaults match the {@code run} CLI command's option defaults.
+     */
+    public static final class Builder {
+      private final File scriptFile;
+      private final String simulation;
+      private int replicates = 1;
+      private Integer replicateIndex = null;
+      private int replicateStart = 0;
+      private boolean serialPatches = false;
+      private Optional<Long> seed = Optional.empty();
+      private boolean useFloat64 = false;
+      private boolean enableProfiler = false;
+      private int csvPrecision = MapSerializeStrategy.DEFAULT_MAX_DECIMAL_PLACES;
+      private int exportQueueSize = 1000000;
+      private Optional<Set<Integer>> outputSteps = Optional.empty();
+      private String[] dataFiles = new String[0];
+      private Map<String, String> customParameters = new HashMap<>();
+      private MinioOptions minioOptions = new MinioOptions();
+
+      private Builder(File scriptFile, String simulation) {
+        this.scriptFile = scriptFile;
+        this.simulation = simulation;
+      }
+
+      /**
+       * Sets the number of replicates to run (default 1).
+       *
+       * @param value replicate count
+       * @return this builder
+       */
+      public Builder replicates(int value) {
+        this.replicates = value;
+        return this;
+      }
+
+      /**
+       * Sets a single replicate index to run, or {@code null} to run the full range (default null).
+       *
+       * @param value replicate index, or null
+       * @return this builder
+       */
+      public Builder replicateIndex(Integer value) {
+        this.replicateIndex = value;
+        return this;
+      }
+
+      /**
+       * Sets the starting replicate index for the half-open range {@code [start, start+count)}
+       * (default 0).
+       *
+       * @param value starting replicate index
+       * @return this builder
+       */
+      public Builder replicateStart(int value) {
+        this.replicateStart = value;
+        return this;
+      }
+
+      /**
+       * Sets whether to process patches serially rather than in parallel (default false). A
+       * present {@code seed} forces serial processing regardless of this value.
+       *
+       * @param value true to process patches serially
+       * @return this builder
+       */
+      public Builder serialPatches(boolean value) {
+        this.serialPatches = value;
+        return this;
+      }
+
+      /**
+       * Sets the random seed for reproducible runs (default empty).
+       *
+       * @param value the seed, or empty for a non-deterministic run
+       * @return this builder
+       */
+      public Builder seed(Optional<Long> value) {
+        this.seed = value;
+        return this;
+      }
+
+      /**
+       * Sets whether to use {@code double} instead of {@code BigDecimal} for decimals
+       * (default false).
+       *
+       * @param value true to favor double precision
+       * @return this builder
+       */
+      public Builder useFloat64(boolean value) {
+        this.useFloat64 = value;
+        return this;
+      }
+
+      /**
+       * Sets whether to enable evalDuration profiling (default false).
+       *
+       * @param value true to enable the profiler
+       * @return this builder
+       */
+      public Builder enableProfiler(boolean value) {
+        this.enableProfiler = value;
+        return this;
+      }
+
+      /**
+       * Sets the maximum decimal places for numeric CSV output, or -1 for unlimited
+       * (default {@link MapSerializeStrategy#DEFAULT_MAX_DECIMAL_PLACES}).
+       *
+       * @param value maximum decimal places
+       * @return this builder
+       */
+      public Builder csvPrecision(int value) {
+        this.csvPrecision = value;
+        return this;
+      }
+
+      /**
+       * Sets the export queue capacity before backpressure is applied (default 1000000).
+       *
+       * @param value queue capacity
+       * @return this builder
+       */
+      public Builder exportQueueSize(int value) {
+        this.exportQueueSize = value;
+        return this;
+      }
+
+      /**
+       * Sets the specific time steps to export, or empty to export all steps (default empty).
+       *
+       * @param value set of steps to export, or empty
+       * @return this builder
+       */
+      public Builder outputSteps(Optional<Set<Integer>> value) {
+        this.outputSteps = value;
+        return this;
+      }
+
+      /**
+       * Sets the external data file specifications for grid search (default none).
+       *
+       * @param value data file specifications in {@code name=path} form
+       * @return this builder
+       */
+      public Builder dataFiles(String[] value) {
+        this.dataFiles = value;
+        return this;
+      }
+
+      /**
+       * Sets custom template parameters applied to each job (default none).
+       *
+       * @param value map of custom parameter names to values
+       * @return this builder
+       */
+      public Builder customParameters(Map<String, String> value) {
+        this.customParameters = value;
+        return this;
+      }
+
+      /**
+       * Sets the MinIO options used to build the input/output layer (default a fresh instance,
+       * which resolves credentials from CLI flags, config file, then environment).
+       *
+       * @param value the MinIO options
+       * @return this builder
+       */
+      public Builder minioOptions(MinioOptions value) {
+        this.minioOptions = value;
+        return this;
+      }
+
+      /**
+       * Builds the immutable {@link RunOptions}.
+       *
+       * @return a new {@link RunOptions}
+       */
+      public RunOptions build() {
+        return new RunOptions(this);
+      }
+    }
+  }
+
+  /**
+   * Outcome of a simulation run.
+   *
+   * <p>Carries enough structured detail for the CLI to derive an exit code and for the MCP tool to
+   * build a result message, without either caller needing to interpret run internals.</p>
+   */
+  public static final class RunResult {
+    private final boolean success;
+    private final String message;
+    private final long lastStep;
+    private final int totalReplicatesRun;
+    private final Optional<JoshSimCommander.CommanderStepEnum> initFailureStep;
+    private final boolean simulationNotFound;
+
+    private RunResult(boolean success, String message, long lastStep, int totalReplicatesRun,
+        Optional<JoshSimCommander.CommanderStepEnum> initFailureStep, boolean simulationNotFound) {
+      this.success = success;
+      this.message = message;
+      this.lastStep = lastStep;
+      this.totalReplicatesRun = totalReplicatesRun;
+      this.initFailureStep = initFailureStep;
+      this.simulationNotFound = simulationNotFound;
+    }
+
+    private static RunResult success(String message, long lastStep, int totalReplicatesRun) {
+      return new RunResult(true, message, lastStep, totalReplicatesRun, Optional.empty(), false);
+    }
+
+    private static RunResult initFailure(JoshSimCommander.CommanderStepEnum step) {
+      return new RunResult(false, "Script validation failed at step: " + step, 0, 0,
+          Optional.of(step), false);
+    }
+
+    private static RunResult simulationNotFound(String simulation) {
+      return new RunResult(false, "Could not find simulation: " + simulation, 0, 0,
+          Optional.empty(), true);
+    }
+
+    public boolean isSuccess() {
+      return success;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public long getLastStep() {
+      return lastStep;
+    }
+
+    public int getTotalReplicatesRun() {
+      return totalReplicatesRun;
+    }
+
+    /**
+     * Returns the program-initialization step that failed, if initialization failed.
+     *
+     * @return the failing {@link JoshSimCommander.CommanderStepEnum}, or empty if init succeeded
+     */
+    public Optional<JoshSimCommander.CommanderStepEnum> getInitFailureStep() {
+      return initFailureStep;
+    }
+
+    /**
+     * Indicates whether the run failed because the named simulation was not found in the script.
+     *
+     * @return true if the simulation name did not match any prototype in the program
+     */
+    public boolean isSimulationNotFound() {
+      return simulationNotFound;
+    }
+  }
+
+  /**
+   * Runs a simulation end-to-end according to the given options.
+   *
+   * <p>Diagnostic and progress messages are written via {@code output}; the caller controls where
+   * they land (the CLI routes them to stdout, the MCP server to stderr). The returned
+   * {@link RunResult} reports success/failure structurally. Genuinely unexpected exceptions from
+   * the simulation engine are allowed to propagate; the random-number generator state is always
+   * cleared on exit.</p>
+   *
+   * @param opts   the run configuration
+   * @param output the output sink for diagnostic and progress messages
+   * @return a {@link RunResult} describing the outcome
+   */
+  public static RunResult run(RunOptions opts, OutputOptions output) {
+    boolean serialPatches = opts.serialPatches;
+
+    // Initialize shared random with seed for reproducibility.
+    if (opts.seed.isPresent()) {
+      SharedRandom.initialize(opts.seed.get());
+      output.printInfo("Using random seed: " + opts.seed.get());
+
+      // Force serial execution when seeded for deterministic results. Parallel execution would
+      // cause non-deterministic random call ordering.
+      if (!serialPatches) {
+        output.printInfo("Note: Forcing serial patch execution for reproducibility with --seed");
+        serialPatches = true;
+      }
+    } else {
+      SharedRandom.initialize(Optional.empty());
+    }
+
+    try {
+      return runInternal(opts, output, serialPatches);
+    } finally {
+      // Clean up shared random regardless of how the run terminated.
+      SharedRandom.clear();
+    }
+  }
+
+  private static RunResult runInternal(RunOptions opts, OutputOptions output,
+      boolean serialPatches) {
+    final EngineGeometryFactory geometryFactory = new GridGeometryFactory();
+
+    // When --replicate-index is set, run exactly one replicate at that index.
+    int effectiveReplicates = opts.replicateIndex != null ? 1 : opts.replicates;
+
+    // Create job configurations using JobVariationParser for grid search.
+    JoshJobBuilder templateJobBuilder = new JoshJobBuilder()
+        .setReplicates(effectiveReplicates)
+        .setCustomParameters(opts.customParameters);
+    JobVariationParser parser = new JobVariationParser();
+    List<JoshJobBuilder> jobBuilders = parser.parseDataFiles(templateJobBuilder, opts.dataFiles);
+
+    // Build all job instances.
+    List<JoshJob> jobs = jobBuilders.stream()
+        .map(JoshJobBuilder::build)
+        .toList();
+
+    // Report grid search information.
+    if (opts.replicateIndex != null) {
+      output.printInfo("Running replicate index " + opts.replicateIndex
+          + " across " + jobs.size() + " job combination(s)");
+    } else {
+      output.printInfo("Grid search will execute " + jobs.size() + " job combination(s) "
+          + "with " + opts.replicates + " replicate(s) each");
+    }
+    output.printInfo("Total simulations to run: " + (jobs.size() * effectiveReplicates));
+
+    // Use first job for initialization (all jobs should have compatible structure).
+    JoshJob firstJob = jobs.get(0);
+
+    // Create appropriate InputGetterStrategy based on first job configuration.
+    InputGetterStrategy inputStrategy;
+    if (firstJob.getFilePaths().isEmpty()) {
+      inputStrategy = new JvmWorkingDirInputGetter();
+    } else {
+      inputStrategy = new JvmMappedInputGetter(firstJob.getFilePaths());
+    }
+
+    // Create template renderer for initialization phase (using first job, replicate 0).
+    TemplateStringRenderer initTemplateRenderer = new TemplateStringRenderer(firstJob, 0);
+
+    // Create InputOutputLayer with the chosen strategy (using first replicate for initialization).
+    InputOutputLayer initInputOutputLayer = new JvmInputOutputLayerBuilder()
+        .withReplicate(0)
+        .withInputStrategy(inputStrategy)
+        .withTemplateRenderer(initTemplateRenderer)
+        .withMinioOptions(opts.minioOptions)
+        .withMaxDecimalPlaces(opts.csvPrecision)
+        .build();
+
+    // Create ValueSupportFactory before interpretation so that the profiler-enabled resolver
+    // factory is used when building ValueResolver instances at compile time.
+    boolean favorBigDecimal = !opts.useFloat64;
+    ValueSupportFactory valueFactory = new ValueSupportFactory(
+        favorBigDecimal,
+        buildValueResolverFactory(opts.enableProfiler)
+    );
+
+    JoshSimCommander.ProgramInitResult initResult = JoshSimCommander.getJoshProgram(
+        valueFactory,
+        geometryFactory,
+        opts.scriptFile,
+        output,
+        initInputOutputLayer
+    );
+
+    if (initResult.getFailureStep().isPresent()) {
+      return RunResult.initFailure(initResult.getFailureStep().get());
+    }
+
+    output.printInfo("Validated Josh code at " + opts.scriptFile);
+
+    JoshProgram program = initResult.getProgram().orElseThrow();
+    if (!program.getSimulations().hasPrototype(opts.simulation)) {
+      output.printError("Could not find simulation: " + opts.simulation);
+      return RunResult.simulationNotFound(opts.simulation);
+    }
+
+    // Extract simulation metadata for progress tracking.
+    SimulationMetadata metadata;
+    try {
+      metadata = SimulationMetadataExtractor.extractMetadata(opts.scriptFile, opts.simulation);
+    } catch (Exception e) {
+      // Use default metadata if extraction fails.
+      metadata = new SimulationMetadata(0, 10, 11);
+      output.printInfo("Using default metadata for progress tracking: " + e.getMessage());
+    }
+
+    ProgressCalculator progressCalculator = new ProgressCalculator(
+        metadata.getTotalSteps(),
+        jobs.size() * opts.replicates // Total simulations = jobs × replicates
+    );
+
+    // Set up JVM compatibility layer.
+    JvmCompatibilityLayer compatLayer = new JvmCompatibilityLayer();
+    compatLayer.setExportQueueCapacity(opts.exportQueueSize);
+    CompatibilityLayerKeeper.set(compatLayer);
+
+    // Extract grid information for Earth-space detection (similar to JoshSimFacade).
+    MutableEntity simEntityRaw = program.getSimulations().getProtoype(opts.simulation).build();
+    MutableEntity simEntity = new ShadowingEntity(valueFactory, simEntityRaw, simEntityRaw);
+    GridInfoExtractor extractor = new GridInfoExtractor(simEntity, valueFactory);
+    boolean hasDegrees = extractor.getStartStr().contains("degree");
+
+    EngineValue sizeValueRaw = extractor.getSize();
+    Units sizeUnits = sizeValueRaw.getUnits();
+    String sizeStr = sizeUnits.toString();
+    boolean sizeMeterAbbreviated = sizeStr.equals("m");
+    boolean sizeMetersFull = sizeStr.equals("meter") || sizeStr.equals("meters");
+    boolean sizeMeters = sizeMetersFull || sizeMeterAbbreviated;
+
+    // Execute simulation for each job combination and replicate.
+    // When --replicate-index is set, run exactly one replicate at that index.
+    int totalReplicateCount = 0;
+    long[] lastStep = {0};
+
+    for (int jobIndex = 0; jobIndex < jobs.size(); jobIndex++) {
+      JoshJob currentJob = jobs.get(jobIndex);
+      output.printInfo("Executing job combination " + (jobIndex + 1) + "/" + jobs.size());
+
+      if (!currentJob.getFilePaths().isEmpty()) {
+        inputStrategy = new JvmMappedInputGetter(currentJob.getFilePaths());
+      }
+
+      int startReplicate = opts.replicateIndex != null ? opts.replicateIndex : opts.replicateStart;
+      int endReplicate = opts.replicateIndex != null
+          ? opts.replicateIndex + 1 : opts.replicateStart + currentJob.getReplicates();
+
+      for (int currentReplicate = startReplicate; currentReplicate < endReplicate;
+           currentReplicate++) {
+        int effectiveReplicate = opts.replicateIndex != null ? opts.replicateIndex
+            : currentReplicate;
+        totalReplicateCount++;
+
+        if (totalReplicateCount > 1) {
+          progressCalculator.resetForNextReplicate(totalReplicateCount);
+        }
+
+        runReplicate(currentJob, effectiveReplicate, totalReplicateCount > 1,
+            valueFactory, geometryFactory, inputStrategy, hasDegrees, sizeMeters,
+            sizeValueRaw, extractor, program, opts.simulation, progressCalculator,
+            opts.outputSteps, serialPatches, opts.minioOptions, opts.csvPrecision, output,
+            lastStep);
+
+        ProgressUpdate completion = progressCalculator.updateReplicateCompleted(
+            totalReplicateCount);
+        output.printInfo(completion.getMessage());
+      }
+
+      if (jobIndex < jobs.size() - 1) {
+        output.printInfo("Completed job combination " + (jobIndex + 1) + "/" + jobs.size());
+      }
+    }
+
+    output.printInfo("");
+    output.printInfo("✓ All simulations completed successfully!");
+    output.printInfo("  Total replicates run: " + totalReplicateCount);
+    output.printInfo("  Job combinations: " + jobs.size());
+    output.printInfo("  Replicates per job: " + effectiveReplicates);
+
+    String summary = "Simulation '" + opts.simulation + "' completed: "
+        + totalReplicateCount + " replicate(s), last step " + lastStep[0];
+    return RunResult.success(summary, lastStep[0], totalReplicateCount);
+  }
+
+  /**
+   * Builds the appropriate ValueResolverFactory based on whether profiling is enabled.
+   *
+   * @param enableProfiler True to use timed resolution for evalDuration support, false otherwise.
+   * @return A ValueResolverFactory configured for the requested profiling mode.
+   */
+  private static ValueResolverFactory buildValueResolverFactory(boolean enableProfiler) {
+    if (enableProfiler) {
+      return new TimedRecursiveValueResolverFactory();
+    } else {
+      return new RecursiveValueResolverFactory();
+    }
+  }
+
+  private static void runReplicate(JoshJob currentJob, int currentReplicate, boolean appendMode,
+      ValueSupportFactory valueFactory, EngineGeometryFactory geometryFactory,
+      InputGetterStrategy inputStrategy, boolean hasDegrees, boolean sizeMeters,
+      EngineValue sizeValueRaw, GridInfoExtractor extractor, JoshProgram program,
+      String simulation, ProgressCalculator progressCalculator,
+      Optional<Set<Integer>> parsedOutputSteps, boolean serialPatches, MinioOptions minioOptions,
+      int csvPrecision, OutputOptions output, long[] lastStep) {
+    TemplateStringRenderer templateRenderer = new TemplateStringRenderer(currentJob,
+        currentReplicate);
+
+    InputOutputLayer inputOutputLayer;
+    if (hasDegrees && sizeMeters) {
+      PatchBuilderExtentsBuilder extentsBuilder = new PatchBuilderExtentsBuilder();
+      ExtentsUtil.addExtents(extentsBuilder, extractor.getStartStr(), true, valueFactory);
+      ExtentsUtil.addExtents(extentsBuilder, extractor.getEndStr(), false, valueFactory);
+      BigDecimal sizeValuePrimitive = sizeValueRaw.getAsDecimal();
+      inputOutputLayer = new JvmInputOutputLayerBuilder()
+          .withReplicate(currentReplicate)
+          .withEarthSpace(extentsBuilder.build(), sizeValuePrimitive)
+          .withInputStrategy(inputStrategy)
+          .withTemplateRenderer(templateRenderer)
+          .withMinioOptions(minioOptions)
+          .withAppendMode(appendMode)
+          .withMaxDecimalPlaces(csvPrecision)
+          .build();
+    } else {
+      inputOutputLayer = new JvmInputOutputLayerBuilder()
+          .withReplicate(currentReplicate)
+          .withInputStrategy(inputStrategy)
+          .withTemplateRenderer(templateRenderer)
+          .withMinioOptions(minioOptions)
+          .withAppendMode(appendMode)
+          .withMaxDecimalPlaces(csvPrecision)
+          .build();
+    }
+
+    MultiFormatExternalGetter externalGetter = new MultiFormatExternalGetter(
+        new JshdExternalGetter(inputStrategy, valueFactory),
+        new JshdzExternalGetter(inputStrategy, valueFactory)
+    );
+
+    JoshSimFacadeUtil.runSimulation(
+        valueFactory,
+        geometryFactory,
+        inputOutputLayer,
+        externalGetter,
+        program,
+        simulation,
+        (step) -> {
+          lastStep[0] = step;
+          ProgressUpdate update = progressCalculator.updateStep(step);
+          if (update.shouldReport()) {
+            output.printInfo(update.getMessage());
+          }
+        },
+        serialPatches,
+        parsedOutputSteps
+    );
+  }
+
+}

--- a/src/main/java/org/joshsim/command/RunUtil.java
+++ b/src/main/java/org/joshsim/command/RunUtil.java
@@ -12,7 +12,6 @@
 package org.joshsim.command;
 
 import java.io.File;
-import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +26,6 @@ import org.joshsim.engine.geometry.EngineGeometryFactory;
 import org.joshsim.engine.geometry.ExtentsUtil;
 import org.joshsim.engine.geometry.PatchBuilderExtentsBuilder;
 import org.joshsim.engine.geometry.grid.GridGeometryFactory;
-import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.ValueSupportFactory;
 import org.joshsim.engine.value.type.EngineValue;
 import org.joshsim.lang.bridge.GridInfoExtractor;
@@ -428,71 +426,16 @@ public final class RunUtil {
     // When --replicate-index is set, run exactly one replicate at that index.
     int effectiveReplicates = opts.replicateIndex != null ? 1 : opts.replicates;
 
-    // Create job configurations using JobVariationParser for grid search.
-    JoshJobBuilder templateJobBuilder = new JoshJobBuilder()
-        .setReplicates(effectiveReplicates)
-        .setCustomParameters(opts.customParameters);
-    JobVariationParser parser = new JobVariationParser();
-    List<JoshJobBuilder> jobBuilders = parser.parseDataFiles(templateJobBuilder, opts.dataFiles);
+    List<JoshJob> jobs = buildJobs(opts, effectiveReplicates);
+    reportPlannedRun(opts, jobs, effectiveReplicates, output);
 
-    // Build all job instances.
-    List<JoshJob> jobs = jobBuilders.stream()
-        .map(JoshJobBuilder::build)
-        .toList();
-
-    // Report grid search information.
-    if (opts.replicateIndex != null) {
-      output.printInfo("Running replicate index " + opts.replicateIndex
-          + " across " + jobs.size() + " job combination(s)");
-    } else {
-      output.printInfo("Grid search will execute " + jobs.size() + " job combination(s) "
-          + "with " + opts.replicates + " replicate(s) each");
-    }
-    output.printInfo("Total simulations to run: " + (jobs.size() * effectiveReplicates));
-
-    // Use first job for initialization (all jobs should have compatible structure).
-    JoshJob firstJob = jobs.get(0);
-
-    // Create appropriate InputGetterStrategy based on first job configuration.
-    InputGetterStrategy inputStrategy;
-    if (firstJob.getFilePaths().isEmpty()) {
-      inputStrategy = new JvmWorkingDirInputGetter();
-    } else {
-      inputStrategy = new JvmMappedInputGetter(firstJob.getFilePaths());
-    }
-
-    // Create template renderer for initialization phase (using first job, replicate 0).
-    TemplateStringRenderer initTemplateRenderer = new TemplateStringRenderer(firstJob, 0);
-
-    // Create InputOutputLayer with the chosen strategy (using first replicate for initialization).
-    InputOutputLayer initInputOutputLayer = new JvmInputOutputLayerBuilder()
-        .withReplicate(0)
-        .withInputStrategy(inputStrategy)
-        .withTemplateRenderer(initTemplateRenderer)
-        .withMinioOptions(opts.minioOptions)
-        .withMaxDecimalPlaces(opts.csvPrecision)
-        .build();
-
-    // Create ValueSupportFactory before interpretation so that the profiler-enabled resolver
-    // factory is used when building ValueResolver instances at compile time.
-    boolean favorBigDecimal = !opts.useFloat64;
-    ValueSupportFactory valueFactory = new ValueSupportFactory(
-        favorBigDecimal,
-        buildValueResolverFactory(opts.enableProfiler)
-    );
-
-    JoshSimCommander.ProgramInitResult initResult = JoshSimCommander.getJoshProgram(
-        valueFactory,
-        geometryFactory,
-        opts.scriptFile,
-        output,
-        initInputOutputLayer
-    );
-
+    // Initialize the program once (using the first job) to validate it before running.
+    ValueSupportFactory valueFactory = createValueFactory(opts);
+    JoshSimCommander.ProgramInitResult initResult =
+        initializeProgram(opts, valueFactory, geometryFactory, jobs.get(0), output);
     if (initResult.getFailureStep().isPresent()) {
       return RunResult.initFailure(initResult.getFailureStep().get());
     }
-
     output.printInfo("Validated Josh code at " + opts.scriptFile);
 
     JoshProgram program = initResult.getProgram().orElseThrow();
@@ -501,7 +444,108 @@ public final class RunUtil {
       return RunResult.simulationNotFound(opts.simulation);
     }
 
-    // Extract simulation metadata for progress tracking.
+    configureCompatibilityLayer(opts);
+    ProgressCalculator progressCalculator = createProgressCalculator(opts, jobs, output);
+    GridSpatialInfo spatialInfo = extractSpatialInfo(program, opts.simulation, valueFactory);
+
+    ExecutionSummary summary = executeJobs(opts, jobs, valueFactory, geometryFactory, program,
+        spatialInfo, progressCalculator, serialPatches, output);
+
+    reportRunCompletion(jobs, effectiveReplicates, summary, output);
+
+    String message = "Simulation '" + opts.simulation + "' completed: "
+        + summary.totalReplicates() + " replicate(s), last step " + summary.lastStep();
+    return RunResult.success(message, summary.lastStep(), summary.totalReplicates());
+  }
+
+  /**
+   * Expands the run into one job per grid-search combination of data files.
+   */
+  private static List<JoshJob> buildJobs(RunOptions opts, int effectiveReplicates) {
+    JoshJobBuilder templateJobBuilder = new JoshJobBuilder()
+        .setReplicates(effectiveReplicates)
+        .setCustomParameters(opts.customParameters);
+    JobVariationParser parser = new JobVariationParser();
+    List<JoshJobBuilder> jobBuilders = parser.parseDataFiles(templateJobBuilder, opts.dataFiles);
+    return jobBuilders.stream()
+        .map(JoshJobBuilder::build)
+        .toList();
+  }
+
+  /**
+   * Prints what the run is about to do (grid-search shape and total simulation count).
+   */
+  private static void reportPlannedRun(RunOptions opts, List<JoshJob> jobs,
+      int effectiveReplicates, OutputOptions output) {
+    if (opts.replicateIndex != null) {
+      output.printInfo("Running replicate index " + opts.replicateIndex
+          + " across " + jobs.size() + " job combination(s)");
+    } else {
+      output.printInfo("Grid search will execute " + jobs.size() + " job combination(s) "
+          + "with " + opts.replicates + " replicate(s) each");
+    }
+    output.printInfo("Total simulations to run: " + (jobs.size() * effectiveReplicates));
+  }
+
+  /**
+   * Creates the value factory, wiring in the profiler-enabled resolver factory when requested.
+   */
+  private static ValueSupportFactory createValueFactory(RunOptions opts) {
+    boolean favorBigDecimal = !opts.useFloat64;
+    return new ValueSupportFactory(favorBigDecimal, buildValueResolverFactory(opts.enableProfiler));
+  }
+
+  /**
+   * Chooses the input strategy for a job: working-directory lookup, or a mapped getter when the
+   * job supplies explicit file paths.
+   */
+  private static InputGetterStrategy createInputStrategy(JoshJob job) {
+    if (job.getFilePaths().isEmpty()) {
+      return new JvmWorkingDirInputGetter();
+    }
+    return new JvmMappedInputGetter(job.getFilePaths());
+  }
+
+  /**
+   * Parses and validates the program using the first job's configuration for the initial
+   * input/output layer.
+   */
+  private static JoshSimCommander.ProgramInitResult initializeProgram(RunOptions opts,
+      ValueSupportFactory valueFactory, EngineGeometryFactory geometryFactory, JoshJob firstJob,
+      OutputOptions output) {
+    InputGetterStrategy inputStrategy = createInputStrategy(firstJob);
+    TemplateStringRenderer initTemplateRenderer = new TemplateStringRenderer(firstJob, 0);
+    InputOutputLayer initInputOutputLayer = new JvmInputOutputLayerBuilder()
+        .withReplicate(0)
+        .withInputStrategy(inputStrategy)
+        .withTemplateRenderer(initTemplateRenderer)
+        .withMinioOptions(opts.minioOptions)
+        .withMaxDecimalPlaces(opts.csvPrecision)
+        .build();
+
+    return JoshSimCommander.getJoshProgram(
+        valueFactory,
+        geometryFactory,
+        opts.scriptFile,
+        output,
+        initInputOutputLayer
+    );
+  }
+
+  /**
+   * Installs the JVM compatibility layer with the configured export queue capacity.
+   */
+  private static void configureCompatibilityLayer(RunOptions opts) {
+    JvmCompatibilityLayer compatLayer = new JvmCompatibilityLayer();
+    compatLayer.setExportQueueCapacity(opts.exportQueueSize);
+    CompatibilityLayerKeeper.set(compatLayer);
+  }
+
+  /**
+   * Builds the progress calculator, falling back to default metadata if extraction fails.
+   */
+  private static ProgressCalculator createProgressCalculator(RunOptions opts, List<JoshJob> jobs,
+      OutputOptions output) {
     SimulationMetadata metadata;
     try {
       metadata = SimulationMetadataExtractor.extractMetadata(opts.scriptFile, opts.simulation);
@@ -510,34 +554,38 @@ public final class RunUtil {
       metadata = new SimulationMetadata(0, 10, 11);
       output.printInfo("Using default metadata for progress tracking: " + e.getMessage());
     }
-
-    ProgressCalculator progressCalculator = new ProgressCalculator(
+    return new ProgressCalculator(
         metadata.getTotalSteps(),
         jobs.size() * opts.replicates // Total simulations = jobs × replicates
     );
+  }
 
-    // Set up JVM compatibility layer.
-    JvmCompatibilityLayer compatLayer = new JvmCompatibilityLayer();
-    compatLayer.setExportQueueCapacity(opts.exportQueueSize);
-    CompatibilityLayerKeeper.set(compatLayer);
-
-    // Extract grid information for Earth-space detection (similar to JoshSimFacade).
-    MutableEntity simEntityRaw = program.getSimulations().getProtoype(opts.simulation).build();
+  /**
+   * Extracts grid information needed to detect Earth-space simulations (degrees + metric size).
+   */
+  private static GridSpatialInfo extractSpatialInfo(JoshProgram program, String simulation,
+      ValueSupportFactory valueFactory) {
+    MutableEntity simEntityRaw = program.getSimulations().getProtoype(simulation).build();
     MutableEntity simEntity = new ShadowingEntity(valueFactory, simEntityRaw, simEntityRaw);
     GridInfoExtractor extractor = new GridInfoExtractor(simEntity, valueFactory);
     boolean hasDegrees = extractor.getStartStr().contains("degree");
 
     EngineValue sizeValueRaw = extractor.getSize();
-    Units sizeUnits = sizeValueRaw.getUnits();
-    String sizeStr = sizeUnits.toString();
-    boolean sizeMeterAbbreviated = sizeStr.equals("m");
-    boolean sizeMetersFull = sizeStr.equals("meter") || sizeStr.equals("meters");
-    boolean sizeMeters = sizeMetersFull || sizeMeterAbbreviated;
+    String sizeStr = sizeValueRaw.getUnits().toString();
+    boolean sizeMeters = sizeStr.equals("m") || sizeStr.equals("meter") || sizeStr.equals("meters");
+    return new GridSpatialInfo(hasDegrees, sizeMeters, sizeValueRaw, extractor);
+  }
 
-    // Execute simulation for each job combination and replicate.
-    // When --replicate-index is set, run exactly one replicate at that index.
+  /**
+   * Runs every replicate of every job, reporting progress, and returns the aggregate outcome.
+   */
+  private static ExecutionSummary executeJobs(RunOptions opts, List<JoshJob> jobs,
+      ValueSupportFactory valueFactory, EngineGeometryFactory geometryFactory, JoshProgram program,
+      GridSpatialInfo spatialInfo, ProgressCalculator progressCalculator, boolean serialPatches,
+      OutputOptions output) {
     int totalReplicateCount = 0;
     long[] lastStep = {0};
+    InputGetterStrategy inputStrategy = createInputStrategy(jobs.get(0));
 
     for (int jobIndex = 0; jobIndex < jobs.size(); jobIndex++) {
       JoshJob currentJob = jobs.get(jobIndex);
@@ -562,10 +610,9 @@ public final class RunUtil {
         }
 
         runReplicate(currentJob, effectiveReplicate, totalReplicateCount > 1,
-            valueFactory, geometryFactory, inputStrategy, hasDegrees, sizeMeters,
-            sizeValueRaw, extractor, program, opts.simulation, progressCalculator,
-            opts.outputSteps, serialPatches, opts.minioOptions, opts.csvPrecision, output,
-            lastStep);
+            valueFactory, geometryFactory, inputStrategy, spatialInfo, program, opts.simulation,
+            progressCalculator, opts.outputSteps, serialPatches, opts.minioOptions,
+            opts.csvPrecision, output, lastStep);
 
         ProgressUpdate completion = progressCalculator.updateReplicateCompleted(
             totalReplicateCount);
@@ -577,15 +624,19 @@ public final class RunUtil {
       }
     }
 
+    return new ExecutionSummary(totalReplicateCount, lastStep[0]);
+  }
+
+  /**
+   * Prints the final success summary.
+   */
+  private static void reportRunCompletion(List<JoshJob> jobs, int effectiveReplicates,
+      ExecutionSummary summary, OutputOptions output) {
     output.printInfo("");
     output.printInfo("✓ All simulations completed successfully!");
-    output.printInfo("  Total replicates run: " + totalReplicateCount);
+    output.printInfo("  Total replicates run: " + summary.totalReplicates());
     output.printInfo("  Job combinations: " + jobs.size());
     output.printInfo("  Replicates per job: " + effectiveReplicates);
-
-    String summary = "Simulation '" + opts.simulation + "' completed: "
-        + totalReplicateCount + " replicate(s), last step " + lastStep[0];
-    return RunResult.success(summary, lastStep[0], totalReplicateCount);
   }
 
   /**
@@ -604,39 +655,15 @@ public final class RunUtil {
 
   private static void runReplicate(JoshJob currentJob, int currentReplicate, boolean appendMode,
       ValueSupportFactory valueFactory, EngineGeometryFactory geometryFactory,
-      InputGetterStrategy inputStrategy, boolean hasDegrees, boolean sizeMeters,
-      EngineValue sizeValueRaw, GridInfoExtractor extractor, JoshProgram program,
+      InputGetterStrategy inputStrategy, GridSpatialInfo spatialInfo, JoshProgram program,
       String simulation, ProgressCalculator progressCalculator,
       Optional<Set<Integer>> parsedOutputSteps, boolean serialPatches, MinioOptions minioOptions,
       int csvPrecision, OutputOptions output, long[] lastStep) {
     TemplateStringRenderer templateRenderer = new TemplateStringRenderer(currentJob,
         currentReplicate);
 
-    InputOutputLayer inputOutputLayer;
-    if (hasDegrees && sizeMeters) {
-      PatchBuilderExtentsBuilder extentsBuilder = new PatchBuilderExtentsBuilder();
-      ExtentsUtil.addExtents(extentsBuilder, extractor.getStartStr(), true, valueFactory);
-      ExtentsUtil.addExtents(extentsBuilder, extractor.getEndStr(), false, valueFactory);
-      BigDecimal sizeValuePrimitive = sizeValueRaw.getAsDecimal();
-      inputOutputLayer = new JvmInputOutputLayerBuilder()
-          .withReplicate(currentReplicate)
-          .withEarthSpace(extentsBuilder.build(), sizeValuePrimitive)
-          .withInputStrategy(inputStrategy)
-          .withTemplateRenderer(templateRenderer)
-          .withMinioOptions(minioOptions)
-          .withAppendMode(appendMode)
-          .withMaxDecimalPlaces(csvPrecision)
-          .build();
-    } else {
-      inputOutputLayer = new JvmInputOutputLayerBuilder()
-          .withReplicate(currentReplicate)
-          .withInputStrategy(inputStrategy)
-          .withTemplateRenderer(templateRenderer)
-          .withMinioOptions(minioOptions)
-          .withAppendMode(appendMode)
-          .withMaxDecimalPlaces(csvPrecision)
-          .build();
-    }
+    InputOutputLayer inputOutputLayer = buildReplicateLayer(currentReplicate, appendMode,
+        valueFactory, inputStrategy, spatialInfo, templateRenderer, minioOptions, csvPrecision);
 
     MultiFormatExternalGetter externalGetter = new MultiFormatExternalGetter(
         new JshdExternalGetter(inputStrategy, valueFactory),
@@ -661,5 +688,51 @@ public final class RunUtil {
         parsedOutputSteps
     );
   }
+
+  /**
+   * Builds the input/output layer for a single replicate, adding Earth-space extents when the
+   * simulation grid is defined in degrees with a metric cell size.
+   */
+  private static InputOutputLayer buildReplicateLayer(int currentReplicate, boolean appendMode,
+      ValueSupportFactory valueFactory, InputGetterStrategy inputStrategy,
+      GridSpatialInfo spatialInfo, TemplateStringRenderer templateRenderer,
+      MinioOptions minioOptions, int csvPrecision) {
+    JvmInputOutputLayerBuilder builder = new JvmInputOutputLayerBuilder()
+        .withReplicate(currentReplicate)
+        .withInputStrategy(inputStrategy)
+        .withTemplateRenderer(templateRenderer)
+        .withMinioOptions(minioOptions)
+        .withAppendMode(appendMode)
+        .withMaxDecimalPlaces(csvPrecision);
+
+    if (spatialInfo.hasDegrees() && spatialInfo.sizeMeters()) {
+      GridInfoExtractor extractor = spatialInfo.extractor();
+      PatchBuilderExtentsBuilder extentsBuilder = new PatchBuilderExtentsBuilder();
+      ExtentsUtil.addExtents(extentsBuilder, extractor.getStartStr(), true, valueFactory);
+      ExtentsUtil.addExtents(extentsBuilder, extractor.getEndStr(), false, valueFactory);
+      builder.withEarthSpace(extentsBuilder.build(), spatialInfo.sizeValueRaw().getAsDecimal());
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Grid information used to decide whether a simulation runs in Earth space.
+   *
+   * @param hasDegrees   whether the grid is defined in degrees
+   * @param sizeMeters   whether the grid cell size is expressed in meters
+   * @param sizeValueRaw the raw grid cell size value
+   * @param extractor    the extractor providing grid start/end strings
+   */
+  private record GridSpatialInfo(boolean hasDegrees, boolean sizeMeters, EngineValue sizeValueRaw,
+      GridInfoExtractor extractor) {}
+
+  /**
+   * Aggregate outcome of executing all jobs and replicates.
+   *
+   * @param totalReplicates the number of replicates actually run
+   * @param lastStep        the last completed step of the final replicate
+   */
+  private record ExecutionSummary(int totalReplicates, long lastStep) {}
 
 }

--- a/src/main/java/org/joshsim/mcp/LocalBackend.java
+++ b/src/main/java/org/joshsim/mcp/LocalBackend.java
@@ -20,27 +20,15 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.joshsim.JoshSimCommander;
-import org.joshsim.JoshSimFacadeUtil;
 import org.joshsim.command.PreprocessUtil;
-import org.joshsim.compat.CompatibilityLayerKeeper;
-import org.joshsim.compat.JvmCompatibilityLayer;
+import org.joshsim.command.RunUtil;
 import org.joshsim.engine.config.ConfigDiscoverabilityOutputFormatter;
 import org.joshsim.engine.config.DiscoveredConfigVar;
 import org.joshsim.engine.geometry.grid.GridGeometryFactory;
-import org.joshsim.engine.value.engine.ValueSupportFactory;
 import org.joshsim.lang.antlr.JoshLangLexer;
 import org.joshsim.lang.antlr.JoshLangParser;
-import org.joshsim.lang.interpret.JoshProgram;
 import org.joshsim.lang.interpret.visitor.JoshConfigDiscoveryVisitor;
-import org.joshsim.lang.io.InputGetterStrategy;
-import org.joshsim.lang.io.InputOutputLayer;
-import org.joshsim.lang.io.JvmInputOutputLayerBuilder;
-import org.joshsim.lang.io.JvmWorkingDirInputGetter;
-import org.joshsim.precompute.JshdExternalGetter;
-import org.joshsim.precompute.JshdzExternalGetter;
-import org.joshsim.precompute.MultiFormatExternalGetter;
 import org.joshsim.util.OutputOptions;
-import org.joshsim.util.SharedRandom;
 
 
 /**
@@ -172,90 +160,32 @@ public class LocalBackend implements Backend {
       boolean serialPatches,
       Optional<Long> seed
   ) {
-    File file = script.toFile();
-
-    // Initialize shared random per-call (per forward-compatibility discipline)
-    if (seed.isPresent()) {
-      SharedRandom.initialize(seed.get());
-    } else {
-      SharedRandom.initialize(Optional.empty());
-    }
-
-    // Set up JVM compatibility layer
-    JvmCompatibilityLayer compatLayer = new JvmCompatibilityLayer();
-    CompatibilityLayerKeeper.set(compatLayer);
-
-    ValueSupportFactory valueFactory = new ValueSupportFactory();
-    GridGeometryFactory geometryFactory = new GridGeometryFactory();
-
-    InputGetterStrategy inputStrategy = new JvmWorkingDirInputGetter();
-    InputOutputLayer inputOutputLayer = new JvmInputOutputLayerBuilder()
-        .withReplicate(0)
-        .withInputStrategy(inputStrategy)
+    // Build the minimal RunOptions the MCP run_simulation tool exposes today. Every other
+    // RunCommand knob (replicateStart, csvPrecision, exportQueueSize, useFloat64, outputSteps,
+    // dataFiles, customParameters) falls through to its CLI default inside RunUtil, so an
+    // MCP-driven run behaves identically to `josh run <script> <simulation>` with the matching
+    // flags — no divergent run logic lives here.
+    //
+    // Two MCP-specific defaults, deliberately not exposed as tool arguments:
+    //   - Profiling stays disabled: evalDuration profiling is a developer feature with no MCP
+    //     surface in v1.
+    //   - MinIO uses a default MinioOptions instance, which resolves credentials from the
+    //     environment (and config file) exactly as the CLI does when no --minio-* flags are
+    //     passed. This keeps secrets out of tool arguments (and therefore out of LLM chat
+    //     history) while still letting models that export to MinIO work over MCP.
+    RunUtil.RunOptions options = RunUtil.RunOptions.builder(script.toFile(), simulation)
+        .replicates(replicates)
+        .serialPatches(serialPatches)
+        .seed(seed)
         .build();
 
-    JoshSimCommander.ProgramInitResult initResult = JoshSimCommander.getJoshProgram(
-        valueFactory,
-        geometryFactory,
-        file,
-        output,
-        inputOutputLayer
-    );
-
-    if (initResult.getFailureStep().isPresent()) {
-      SharedRandom.clear();
-      return new RunSimulationResult(false,
-          "Script validation failed at step: " + initResult.getFailureStep().get(), 0);
-    }
-
-    JoshProgram program = initResult.getProgram().orElseThrow();
-    if (!program.getSimulations().hasPrototype(simulation)) {
-      SharedRandom.clear();
-      return new RunSimulationResult(false,
-          "Could not find simulation: " + simulation, 0);
-    }
-
-    // Force serial execution when seeded for determinism
-    boolean effectiveSerial = serialPatches || seed.isPresent();
-
-    long[] stepCounter = {0};
-
     try {
-      for (int rep = 0; rep < replicates; rep++) {
-        InputOutputLayer repLayer = new JvmInputOutputLayerBuilder()
-            .withReplicate(rep)
-            .withInputStrategy(inputStrategy)
-            .withAppendMode(rep > 0)
-            .build();
-
-        MultiFormatExternalGetter externalGetter = new MultiFormatExternalGetter(
-            new JshdExternalGetter(inputStrategy, valueFactory),
-            new JshdzExternalGetter(inputStrategy, valueFactory)
-        );
-
-        JoshSimFacadeUtil.runSimulation(
-            valueFactory,
-            geometryFactory,
-            repLayer,
-            externalGetter,
-            program,
-            simulation,
-            (step) -> stepCounter[0] = step,
-            effectiveSerial,
-            Optional.empty()
-        );
-      }
+      RunUtil.RunResult result = RunUtil.run(options, output);
+      return new RunSimulationResult(
+          result.isSuccess(), result.getMessage(), result.getLastStep());
     } catch (Exception e) {
-      SharedRandom.clear();
-      return new RunSimulationResult(false,
-          "Simulation failed: " + e.getMessage(), stepCounter[0]);
+      return new RunSimulationResult(false, "Simulation failed: " + e.getMessage(), 0);
     }
-
-    SharedRandom.clear();
-    return new RunSimulationResult(true,
-        "Simulation '" + simulation + "' completed: "
-            + replicates + " replicate(s), last step " + stepCounter[0],
-        stepCounter[0]);
   }
 
 }

--- a/src/test/java/org/joshsim/command/RunUtilTest.java
+++ b/src/test/java/org/joshsim/command/RunUtilTest.java
@@ -1,0 +1,126 @@
+/**
+ * Tests for the RunUtil shared run pipeline.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import org.joshsim.JoshSimCommander;
+import org.joshsim.util.JoshTestFixtures;
+import org.joshsim.util.OutputOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for {@link RunUtil}.
+ *
+ * <p>Exercises the shared run pipeline that both the {@code run} CLI command and the MCP
+ * {@code run_simulation} tool delegate to: a real end-to-end run, the simulation-not-found path,
+ * the program-init-failure path, and seed determinism.</p>
+ */
+class RunUtilTest {
+
+  @TempDir
+  Path tempDir;
+
+  /**
+   * A real run of a minimal simulation succeeds, writes its export, and reports progress.
+   */
+  @Test
+  void runSucceedsAndWritesOutput() throws Exception {
+    Path joshFile = tempDir.resolve("test.josh");
+    Path outputFile = tempDir.resolve("output.csv");
+    Files.writeString(joshFile,
+        JoshTestFixtures.minimalSimulationWithExport(outputFile.toString()));
+
+    RunUtil.RunOptions options = RunUtil.RunOptions.builder(joshFile.toFile(), "TestSim").build();
+    RunUtil.RunResult result = RunUtil.run(options, new OutputOptions());
+
+    assertTrue(result.isSuccess(), "Run should succeed: " + result.getMessage());
+    assertEquals(1, result.getTotalReplicatesRun());
+    assertTrue(result.getLastStep() > 0, "Last step should advance past zero");
+    assertTrue(Files.exists(outputFile), "Export CSV should be written");
+    assertTrue(Files.readString(outputFile).contains("treeCount"),
+        "Export CSV should contain the treeCount column");
+  }
+
+  /**
+   * Requesting a simulation name that does not exist reports a structured not-found result.
+   */
+  @Test
+  void runReportsSimulationNotFound() throws Exception {
+    Path joshFile = tempDir.resolve("test.josh");
+    Files.writeString(joshFile, JoshTestFixtures.MINIMAL_SIMULATION_NO_EXPORT);
+
+    RunUtil.RunOptions options = RunUtil.RunOptions.builder(joshFile.toFile(), "DoesNotExist")
+        .build();
+    RunUtil.RunResult result = RunUtil.run(options, new OutputOptions());
+
+    assertFalse(result.isSuccess());
+    assertTrue(result.isSimulationNotFound());
+    assertTrue(result.getMessage().contains("DoesNotExist"));
+  }
+
+  /**
+   * A missing script file surfaces a program-init failure with a step the CLI can map to an
+   * exit code.
+   */
+  @Test
+  void runReportsInitFailureForMissingFile() {
+    Path missing = tempDir.resolve("nope.josh");
+
+    RunUtil.RunOptions options = RunUtil.RunOptions.builder(missing.toFile(), "TestSim").build();
+    RunUtil.RunResult result = RunUtil.run(options, new OutputOptions());
+
+    assertFalse(result.isSuccess());
+    assertTrue(result.getInitFailureStep().isPresent(),
+        "A missing file should fail at a program-init step");
+  }
+
+  /**
+   * Two runs with the same seed produce the same output content, confirming the seed is plumbed
+   * through and serial execution is forced for determinism. Compared as an order-independent set
+   * of rows, since patch export row ordering is not itself guaranteed.
+   */
+  @Test
+  void seededRunsAreDeterministic() throws Exception {
+    Path joshFile = tempDir.resolve("test.josh");
+    Path outA = tempDir.resolve("a.csv");
+    Path outB = tempDir.resolve("b.csv");
+
+    Files.writeString(joshFile, JoshTestFixtures.minimalSimulationWithExport(outA.toString()));
+    RunUtil.run(RunUtil.RunOptions.builder(joshFile.toFile(), "TestSim")
+        .seed(Optional.of(42L)).build(), new OutputOptions());
+
+    Files.writeString(joshFile, JoshTestFixtures.minimalSimulationWithExport(outB.toString()));
+    RunUtil.run(RunUtil.RunOptions.builder(joshFile.toFile(), "TestSim")
+        .seed(Optional.of(42L)).build(), new OutputOptions());
+
+    List<String> rowsA = Files.readAllLines(outA).stream().sorted().toList();
+    List<String> rowsB = Files.readAllLines(outB).stream().sorted().toList();
+    assertEquals(rowsA, rowsB,
+        "Runs with the same seed should produce the same set of output rows");
+  }
+
+  /**
+   * The init-failure step is exposed so callers (the CLI) can derive a distinct exit code.
+   */
+  @Test
+  void initFailureStepIsTypedForExitCodeMapping() {
+    Path missing = tempDir.resolve("nope.josh");
+    RunUtil.RunResult result = RunUtil.run(
+        RunUtil.RunOptions.builder(missing.toFile(), "TestSim").build(), new OutputOptions());
+
+    Optional<JoshSimCommander.CommanderStepEnum> step = result.getInitFailureStep();
+    assertTrue(step.isPresent());
+  }
+}


### PR DESCRIPTION
Stacked on the Phase 1 MCP branch (`claude/eloquent-dirac-hmmCi`, PR #440). Targets that branch rather than `dev` because it modifies `LocalBackend`, which only exists on the Phase 1 branch. Merge after / together with #440.

## Why

PR #440 review [comment 4](https://github.com/SchmidtDSE/josh/pull/440#discussion_r3305837284): *"factor out the basic logic into a `runUtil` just like the above `preprocessUtil`. These MCP implementations should be very, very thin and shouldn't touch application logic AT ALL."*

The MCP `LocalBackend.runSimulation` had reimplemented the run loop, duplicating `RunCommand` — and **diverging** from it. The standalone MCP loop skipped Earth-space grid setup, progress metadata, csv precision, and MinIO. Per the guiding rule that *the MCP server should not behave differently from the jar unless a default is hardcoded and clearly justified*, both now drive the same pipeline.

## What

- **New `command/RunUtil.java`** — the single in-JVM run pipeline. `RunUtil.run(RunOptions, OutputOptions)` holds seed setup, grid-search job expansion, program init, Earth-space detection, and the per-replicate loop. `RunOptions` is an immutable builder whose defaults match the `run` CLI command's option defaults. `RunResult` carries success/last-step plus a typed init-failure step and a simulation-not-found flag so each caller derives its own outcome (exit code vs MCP result).
- **`RunCommand.call()` → thin shim** — validate flags, build `RunOptions`, call `RunUtil.run`, map `RunResult` to an exit code. No CLI behavior change.
- **`LocalBackend.runSimulation` → thin shim** — builds the five MCP-exposed knobs (`script`, `simulation`, `replicates`, `serialPatches`, `seed`); everything else falls through to CLI defaults.

### Hardcoded MCP defaults (documented inline in `LocalBackend`)

| Knob | MCP behavior | Why |
|------|--------------|-----|
| `enableProfiler` | off | developer feature, no MCP surface in v1 |
| `MinioOptions` | default instance | `MinioOptions` already resolves CLI flags → config file → **environment**, so models that export to MinIO work over MCP, with creds coming from env rather than tool arguments (keeps secrets out of LLM chat history) |

Every other knob (`replicateStart`, `csvPrecision`, `exportQueueSize`, `useFloat64`, `outputSteps`, `dataFiles`, `customParameters`) uses the same default as the CLI. Phase-2 MCP params (`dataFiles`/`customParameters`/`outputSteps`) are already supported by `RunOptions`; only their MCP tool-schema exposure is deferred.

## Tests & verification

- New `RunUtilTest`: real end-to-end run (asserts CSV written), simulation-not-found, program-init failure, seed determinism. `runSimulation` is now covered end-to-end (was a known gap).
- Existing `RunCommand*` tests pass unchanged — CLI regression net.
- `./gradlew test checkstyleMain checkstyleTest` — clean.
- Manual: `josh run min.josh TestSim --replicates 2` and the MCP `run_simulation` tool both produce identical CSV output through `RunUtil`; the MCP run's diagnostics route to stderr (stdout stays JSON-RPC-only) and the tool returns `Simulation 'TestSim' completed: 1 replicate(s), last step 3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)