### PR TITLE
Fail fast on unsupported grid.size units in preprocess

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -583,7 +583,7 @@ steps.high = 10 count
 
 - **`grid.low` / `grid.high`** are corners, not min/max: `grid.low` is the top-left, `grid.high` the bottom-right. In Western Hemisphere geography, `grid.low` carries the more-northern latitude and more-negative longitude.
 - Each corner component must carry the word `latitude` or `longitude` (parser tags, not units); order within the pair is free.
-- **`grid.size`** — patch side length. Units: `m`, `km`, `count`, `degrees`. Meters paired with degrees triggers a Haversine conversion; `here.x` / `here.y` then reference grid space `(0,0)` top-left to `(width, height)` bottom-right.
+- **`grid.size`** — patch side length. Units: `m` (meters), `count`, or `degrees`. When positions are given in degrees, the size must be in meters, which triggers a Haversine conversion; `here.x` / `here.y` then reference grid space `(0,0)` top-left to `(width, height)` bottom-right. Other length units such as `km` are not accepted for grid size — use meters (e.g. `1000 m`, not `1 km`).
 - **`grid.patch`** — patch entity name (default `"Default"`).
 - **`grid.inputCrs` / `grid.targetCrs`** — optional EPSG codes; the CLI `--crs` flag overrides `grid.inputCrs`.
 - **`steps.low` / `steps.high`** — both endpoints inclusive (`0` to `10` runs 11 timesteps; defaults `0`, `10`).

--- a/src/main/java/org/joshsim/command/PreprocessUtil.java
+++ b/src/main/java/org/joshsim/command/PreprocessUtil.java
@@ -235,6 +235,16 @@ public class PreprocessUtil {
     String endStr = extractor.getEndStr();
     EngineValue size = extractor.getSize();
 
+    // Validate grid size units before building the grid. An unsupported unit such as "km"
+    // would otherwise be silently treated as meters by the Earth-space patch builder,
+    // producing a grid orders of magnitude too fine and hanging preprocessing. Fail fast.
+    if (!unitsSupported(size.getUnits().toString())) {
+      throw new IllegalArgumentException(
+          "Unsupported units for grid size: " + size.getUnits()
+          + ". Grid size must be specified in meters (m); for example use \"1000 m\" "
+          + "instead of \"1 km\".");
+    }
+
     // Build bridge
     CoordinateReferenceSystem crs;
     try {
@@ -261,10 +271,7 @@ public class PreprocessUtil {
     GridFromSimFactory gridFactory = new GridFromSimFactory(bridge);
     PatchSet patchSet = gridFactory.build(simEntity, options.getCrsCode());
 
-    // Check and parse grid
-    if (!unitsSupported(size.getUnits().toString())) {
-      throw new IllegalArgumentException("Unsupported units for grid size: " + size.getUnits());
-    }
+    // Parse grid extents.
     PatchBuilderExtents extents = gridFactory.buildExtents(startStr, endStr);
     PatchKeyConverter patchKeyConverter = new PatchKeyConverter(
         extents,

--- a/src/test/java/org/joshsim/command/PreprocessUtilGridSizeUnitsTest.java
+++ b/src/test/java/org/joshsim/command/PreprocessUtilGridSizeUnitsTest.java
@@ -1,0 +1,82 @@
+/**
+ * Tests that preprocessing rejects unsupported grid size units before building the grid.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.command;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.joshsim.command.PreprocessUtil.PreprocessOptions;
+import org.joshsim.util.OutputOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression tests for grid size unit handling in {@link PreprocessUtil}.
+ *
+ * <p>An unsupported unit such as {@code km} used to be silently treated as meters by the
+ * Earth-space patch builder, producing a grid orders of magnitude too fine that hung
+ * preprocessing for hundreds of seconds. The unit guard must reject such units up front,
+ * before any grid is built.</p>
+ */
+public class PreprocessUtilGridSizeUnitsTest {
+
+  private static final String KM_SCRIPT = """
+      start simulation TestSim
+        grid.size = 16 km
+        grid.low = 36.73 degrees latitude, -119.52 degrees longitude
+        grid.high = 35.80 degrees latitude, -117.98 degrees longitude
+        grid.patch = "Default"
+        steps.low = 0 count
+        steps.high = 1 count
+        exportFiles.patch = "file:///tmp/test_out.csv"
+      end simulation
+
+      start patch Default
+        export.count.step = 1 count
+      end patch
+      """;
+
+  @TempDir
+  Path tempDir;
+
+  /**
+   * A grid size in kilometers must be rejected quickly with a clear message rather than
+   * hanging while an enormous grid is materialized.
+   */
+  @Test
+  public void gridSizeInKilometersFailsFast() throws Exception {
+    Path scriptFile = tempDir.resolve("km.josh");
+    Files.writeString(scriptFile, KM_SCRIPT);
+    File dataFile = tempDir.resolve("data.nc").toFile();
+    File outputFile = tempDir.resolve("out.jshd").toFile();
+
+    IllegalArgumentException ex = assertTimeoutPreemptively(Duration.ofSeconds(60), () ->
+        assertThrows(IllegalArgumentException.class, () ->
+            PreprocessUtil.preprocess(
+                scriptFile.toFile(),
+                "TestSim",
+                dataFile.toString(),
+                "data",
+                "K",
+                outputFile,
+                new PreprocessOptions(),
+                new OutputOptions()
+            )
+        )
+    );
+
+    assertTrue(ex.getMessage().contains("Unsupported units for grid size"),
+        "Expected an unsupported-units error, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("km"),
+        "Error should name the offending unit, got: " + ex.getMessage());
+  }
+}


### PR DESCRIPTION
## Problem

`josh preprocess` hangs for the full timeout (observed: >600s) when a simulation uses a non-meter spatial unit for `grid.size`, e.g. `grid.size = 16 km`.

Root cause is an **ordering bug**. In `PreprocessUtil.preprocess`, the `unitsSupported()` guard (which only accepts `m`/`meter`/`meters`) ran *after* `gridFactory.build()`. With `km`, the bare numeric value (`16`) reaches `EarthPatchBuilder`, which interprets `getCellSizeMeters()` literally as meters. So `16 km` is treated as `16 m` — a grid ~1000× too fine per axis, i.e. tens of millions of patches allocated in a nested loop before the guard ever runs. The build hangs (or OOMs) instead of producing the clean "Unsupported units" error that already existed a few lines below.

`validate` passes because validation never builds the grid; the `run` path doesn't hang because it skips the Earth-space branch when the size isn't in meters (a separate silent-fallback quirk, not addressed here).

## Fix

Move the existing `unitsSupported()` check ahead of `gridFactory.build()` so an unsupported unit fails immediately, and make the message actionable (point the user at meters). No unit-system refactor — `km` is still not auto-converted; it now produces an instant, clear error instead of a hang.

## Test

Adds `PreprocessUtilGridSizeUnitsTest`: a `grid.size = 16 km` script must throw `IllegalArgumentException` (naming the offending unit) within a bounded time, guarding against the hang regressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)