### PR TITLE
Add grid.top_left / grid.bottom_right corner aliases

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -581,7 +581,7 @@ steps.low  = 0 count
 steps.high = 10 count
 ```
 
-- **`grid.low` / `grid.high`** (geo-canonical aliases: **`grid.top_left`** / **`grid.bottom_right`**) are corners, not min/max: `grid.low` (`grid.top_left`) is the top-left / north-west corner, `grid.high` (`grid.bottom_right`) the bottom-right / south-east. In Western Hemisphere geography, `grid.low` carries the more-northern latitude and more-negative longitude. The canonical and alias names are interchangeable; if both are given, the canonical name wins.
+- **`grid.low`** (alias **`grid.top_left`**) — top-left / north-west grid corner; **`grid.high`** (alias **`grid.bottom_right`**) — bottom-right / south-east grid corner.
 - Each corner component must carry the word `latitude` or `longitude` (parser tags, not units); order within the pair is free.
 - **`grid.size`** — patch side length. Units: `m`, `km`, `count`, `degrees`. Meters paired with degrees triggers a Haversine conversion; `here.x` / `here.y` then reference grid space `(0,0)` top-left to `(width, height)` bottom-right.
 - **`grid.patch`** — patch entity name (default `"Default"`).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -581,7 +581,7 @@ steps.low  = 0 count
 steps.high = 10 count
 ```
 
-- **`grid.low` / `grid.high`** are corners, not min/max: `grid.low` is the top-left, `grid.high` the bottom-right. In Western Hemisphere geography, `grid.low` carries the more-northern latitude and more-negative longitude.
+- **`grid.low` / `grid.high`** (geo-canonical aliases: **`grid.top_left`** / **`grid.bottom_right`**) are corners, not min/max: `grid.low` (`grid.top_left`) is the top-left / north-west corner, `grid.high` (`grid.bottom_right`) the bottom-right / south-east. In Western Hemisphere geography, `grid.low` carries the more-northern latitude and more-negative longitude. The canonical and alias names are interchangeable; if both are given, the canonical name wins.
 - Each corner component must carry the word `latitude` or `longitude` (parser tags, not units); order within the pair is free.
 - **`grid.size`** — patch side length. Units: `m`, `km`, `count`, `degrees`. Meters paired with degrees triggers a Haversine conversion; `here.x` / `here.y` then reference grid space `(0,0)` top-left to `(width, height)` bottom-right.
 - **`grid.patch`** — patch entity name (default `"Default"`).

--- a/src/main/java/org/joshsim/lang/bridge/GridInfoExtractor.java
+++ b/src/main/java/org/joshsim/lang/bridge/GridInfoExtractor.java
@@ -44,8 +44,8 @@ public class GridInfoExtractor {
 
     inputCrsMaybe = simulation.getAttributeValue("grid.inputCrs");
     targetCrsMaybe = simulation.getAttributeValue("grid.targetCrs");
-    startStrMaybe = simulation.getAttributeValue("grid.low");
-    endStrMaybe = simulation.getAttributeValue("grid.high");
+    startStrMaybe = getFirstPresent(simulation, "grid.low", "grid.top_left");
+    endStrMaybe = getFirstPresent(simulation, "grid.high", "grid.bottom_right");
     patchNameMaybe = simulation.getAttributeValue("grid.patch");
     sizeMaybe = simulation.getAttributeValue("grid.size");
     stepsLowMaybe = simulation.getAttributeValue("steps.low");
@@ -213,6 +213,28 @@ public class GridInfoExtractor {
     long highValue = Math.round(stepsHigh.getAsDouble());
 
     return highValue - lowValue + 1;
+  }
+
+  /**
+   * Reads the first attribute that is present among the provided names.
+   *
+   * <p>Supports geo-canonical aliases for the grid corners: {@code grid.top_left} aliases
+   * {@code grid.low} (the north-west corner) and {@code grid.bottom_right} aliases
+   * {@code grid.high} (the south-east corner). The canonical name takes precedence when both
+   * are present.</p>
+   *
+   * @param simulation the simulation entity to read attributes from
+   * @param names attribute names to try, in order of precedence
+   * @return the value of the first present attribute, or empty if none are set
+   */
+  private static Optional<EngineValue> getFirstPresent(MutableEntity simulation, String... names) {
+    for (String name : names) {
+      Optional<EngineValue> value = simulation.getAttributeValue(name);
+      if (value.isPresent()) {
+        return value;
+      }
+    }
+    return Optional.empty();
   }
 
   /**

--- a/src/test/java/org/joshsim/lang/bridge/GridInfoExtractorTest.java
+++ b/src/test/java/org/joshsim/lang/bridge/GridInfoExtractorTest.java
@@ -1,0 +1,83 @@
+/**
+ * Tests for GridInfoExtractor, including geo-canonical grid corner aliases.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.lang.bridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.value.converter.Units;
+import org.joshsim.engine.value.engine.ValueSupportFactory;
+import org.joshsim.engine.value.type.EngineValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests that GridInfoExtractor reads grid corners, including the {@code grid.top_left} /
+ * {@code grid.bottom_right} aliases for {@code grid.low} / {@code grid.high}.
+ */
+@ExtendWith(MockitoExtension.class)
+class GridInfoExtractorTest {
+
+  private static final String TOP_LEFT = "36.73 degrees latitude, -119.52 degrees longitude";
+  private static final String BOTTOM_RIGHT = "35.80 degrees latitude, -117.98 degrees longitude";
+
+  @Mock(lenient = true) private MutableEntity mockSimulation;
+
+  private ValueSupportFactory valueFactory;
+
+  /**
+   * Sets up the test environment before each test.
+   */
+  @BeforeEach
+  void setUp() {
+    valueFactory = new ValueSupportFactory();
+  }
+
+  private EngineValue str(String value) {
+    return valueFactory.build(value, Units.EMPTY);
+  }
+
+  /**
+   * The top_left / bottom_right aliases resolve to the same start / end corners as low / high.
+   */
+  @Test
+  void readsTopLeftAndBottomRightAliases() {
+    when(mockSimulation.getAttributeValue("grid.low")).thenReturn(Optional.empty());
+    when(mockSimulation.getAttributeValue("grid.high")).thenReturn(Optional.empty());
+    when(mockSimulation.getAttributeValue("grid.top_left")).thenReturn(Optional.of(str(TOP_LEFT)));
+    when(mockSimulation.getAttributeValue("grid.bottom_right"))
+        .thenReturn(Optional.of(str(BOTTOM_RIGHT)));
+
+    GridInfoExtractor extractor = new GridInfoExtractor(mockSimulation, valueFactory);
+
+    assertEquals(TOP_LEFT, extractor.getStartStr());
+    assertEquals(BOTTOM_RIGHT, extractor.getEndStr());
+  }
+
+  /**
+   * When both the canonical and alias names are present, the canonical name wins.
+   */
+  @Test
+  void canonicalNamesTakePrecedenceOverAliases() {
+    when(mockSimulation.getAttributeValue("grid.low")).thenReturn(Optional.of(str(TOP_LEFT)));
+    when(mockSimulation.getAttributeValue("grid.high")).thenReturn(Optional.of(str(BOTTOM_RIGHT)));
+    when(mockSimulation.getAttributeValue("grid.top_left"))
+        .thenReturn(Optional.of(str("0 degrees latitude, 0 degrees longitude")));
+    when(mockSimulation.getAttributeValue("grid.bottom_right"))
+        .thenReturn(Optional.of(str("0 degrees latitude, 0 degrees longitude")));
+
+    GridInfoExtractor extractor = new GridInfoExtractor(mockSimulation, valueFactory);
+
+    assertEquals(TOP_LEFT, extractor.getStartStr());
+    assertEquals(BOTTOM_RIGHT, extractor.getEndStr());
+  }
+}


### PR DESCRIPTION
## Summary

`grid.low` and `grid.high` are geographic corners, not min/max: `grid.low` is the **top-left / north-west** corner (more-northern latitude, more-negative longitude) and `grid.high` is the **bottom-right / south-east** corner. The grid is built going south+east from `grid.low`, so this orientation is load-bearing.

This adds geo-canonical aliases that name those corners explicitly:

- `grid.top_left` → `grid.low`
- `grid.bottom_right` → `grid.high`

The alias names were chosen to match josh's actual corner semantics (the NW/SE diagonal the engine uses), so they're unambiguous rather than misleading.

## Implementation

Resolved in `GridInfoExtractor`, the single consumer of these attributes (used by both the `run` and `preprocess` paths), via a small `getFirstPresent(...)` helper. Underscored identifiers are already legal in the grammar, so no parser changes are needed. The canonical name takes precedence if both are supplied. Fully backward compatible — existing `grid.low`/`grid.high` scripts are unaffected.

## Docs & tests

- `llms-full.txt`: documents the aliases on the spatial-configuration bullet.
- `GridInfoExtractorTest`: verifies the aliases resolve to the same corners and that the canonical name wins when both are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)