### PR TITLE
Align external data reads with steps.low-based timesteps

### DIFF
--- a/src/main/java/org/joshsim/command/InspectJshdCommand.java
+++ b/src/main/java/org/joshsim/command/InspectJshdCommand.java
@@ -12,7 +12,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.math.BigDecimal;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.joshsim.engine.value.engine.ValueSupportFactory;
 import org.joshsim.engine.value.type.EngineValue;

--- a/src/main/java/org/joshsim/command/PreprocessUtil.java
+++ b/src/main/java/org/joshsim/command/PreprocessUtil.java
@@ -297,12 +297,18 @@ public class PreprocessUtil {
     DataGridLayer grid = StreamToPrecomputedGridUtil.streamToGrid(
         valueFactory,
         (timestepVal) -> {
+          // The data source exposes records 0-based; record i is the i-th step of the run. Map
+          // the absolute grid timestep (steps.low..steps.high) back to that 0-based source index
+          // so a non-zero steps.low - e.g. a calendar start year - lines the source up with the
+          // grid key, meta.year, and the organism-side external read instead of running off the
+          // end of the source. The forced single-timestep path keeps its legacy absolute index.
+          long sourceIndex = forcedTimestep.isPresent() ? timestepVal : timestepVal - startTimestep;
           Stream<Map.Entry<GeoKey, EngineValue>> geoStream;
           try {
             geoStream = mapper.streamVariableTimeStepToPatches(
                 dataFile,
                 variable,
-                (int) timestepVal,
+                (int) sourceIndex,
                 patchSet
             );
           } catch (IOException e) {

--- a/src/main/java/org/joshsim/geo/geometry/EarthGeometry.java
+++ b/src/main/java/org/joshsim/geo/geometry/EarthGeometry.java
@@ -4,7 +4,6 @@ import java.math.BigDecimal;
 import java.util.Objects;
 import org.apache.sis.geometry.Envelope2D;
 import org.apache.sis.util.Utilities;
-import org.joshsim.engine.geometry.EngineGeometry;
 import org.joshsim.engine.geometry.grid.GridShape;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;

--- a/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
@@ -552,6 +552,17 @@ public interface EventHandlerMachine {
   long getStepCount();
 
   /**
+   * Get the current semantic timestep (steps.low-based), used to resolve external data reads.
+   *
+   * <p>This matches how preprocessed external grids are keyed and how {@code meta.year} is
+   * computed, so {@code external X} resolves against the same time origin as the rest of the
+   * engine. It coincides with {@link #getStepCount()} only when {@code steps.low} is zero.</p>
+   *
+   * @return The current timestep, offset by steps.low.
+   */
+  long getCurrentTimestep();
+
+  /**
    * Get a value from an external resource at a given time.
    *
    * @param name The name of the external resource.

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -933,6 +933,11 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
   }
 
   @Override
+  public long getCurrentTimestep() {
+    return bridge.getCurrentTimestep();
+  }
+
+  @Override
   public void pushExternal(String name, long step) {
     push(bridge.getExternal(scope.get("here").getAsEntity().getKey().orElseThrow(), name, step));
   }

--- a/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshExternalVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshExternalVisitor.java
@@ -38,8 +38,11 @@ public class JoshExternalVisitor implements JoshVisitorDelegate {
   public JoshFragment visitExternalValue(JoshLangParser.ExternalValueContext ctx) {
     String name = ctx.name.getText();
     EventHandlerAction action = (machine) -> {
-      long stepCount = machine.getStepCount();
-      machine.pushExternal(name, stepCount);
+      // Resolve against the semantic (steps.low-based) timestep so external data lines up with
+      // how its grid is keyed and with meta.year; getStepCount()'s 0-based value only matches
+      // the grid when steps.low is zero.
+      long step = machine.getCurrentTimestep();
+      machine.pushExternal(name, step);
       return machine;
     };
     return new ActionFragment(action);

--- a/src/test/java/org/joshsim/command/ExternalTimestepAlignmentIntegrationTest.java
+++ b/src/test/java/org/joshsim/command/ExternalTimestepAlignmentIntegrationTest.java
@@ -1,0 +1,231 @@
+/**
+ * Integration tests for external-data timestep alignment under non-zero steps.low.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeSet;
+import org.joshsim.engine.value.engine.ValueSupportFactory;
+import org.joshsim.precompute.BinaryGridSerializationStrategy;
+import org.joshsim.precompute.DataGridLayer;
+import org.joshsim.precompute.DoublePrecomputedGrid;
+import org.joshsim.util.OutputOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+
+/**
+ * End-to-end coverage that the simulation timestep axis is decoupled from the data source's
+ * 0-based record axis, so a calendar {@code steps.low} (e.g. 2024) lines preprocessed external
+ * data up with the grid key, {@code meta.year}, and the organism-side {@code external} read.
+ *
+ * <p>Backed by the committed {@code maxtemp_tulare_annual.nc} fixture (variable
+ * {@code Maximum_air_temperature_at_2m}, {@code calendar_year} 2024..2053). The fixture is read
+ * ordinally (record i = the i-th simulation step), so the same records must surface whether the
+ * run is keyed at 0.. or 2024.. - only the reported year shifts.</p>
+ */
+public class ExternalTimestepAlignmentIntegrationTest {
+
+  private static final String VARIABLE = "Maximum_air_temperature_at_2m";
+
+  @TempDir
+  Path tempDir;
+
+  /** Build a sim that exports meta.year and the external temperature over a steps window. */
+  private Path writeScript(String name, long stepsLow, long stepsHigh, Path csvTarget)
+      throws Exception {
+    String script = """
+        start simulation Test
+          grid.size = 16000 m
+          grid.low = 36.73 degrees latitude, -119.52 degrees longitude
+          grid.high = 35.80 degrees latitude, -117.98 degrees longitude
+          grid.patch = "Default"
+          steps.low = %d count
+          steps.high = %d count
+          exportFiles.patch = "file://%s"
+        end simulation
+
+        start patch Default
+          export.year.step = meta.year
+          export.temperature.step = external temperature
+        end patch
+        """.formatted(stepsLow, stepsHigh, csvTarget.toString());
+    Path scriptFile = tempDir.resolve(name + ".josh");
+    Files.writeString(scriptFile, script);
+    return scriptFile;
+  }
+
+  private Path fixture() throws Exception {
+    return Path.of(getClass().getResource("/netcdf/maxtemp_tulare_annual.nc").toURI());
+  }
+
+  private DoublePrecomputedGrid preprocessGrid(
+      long stepsLow, long stepsHigh, PreprocessUtil.PreprocessOptions options) throws Exception {
+    Path script = writeScript("pre_" + stepsLow, stepsLow, stepsHigh,
+        tempDir.resolve("unused.csv"));
+    Path out = tempDir.resolve("grid_" + stepsLow + ".jshd");
+    PreprocessUtil.preprocess(script.toFile(), "Test", fixture().toString(), VARIABLE, "K",
+        out.toFile(), options, new OutputOptions());
+    try (FileInputStream in = new FileInputStream(out.toFile())) {
+      DataGridLayer layer = new BinaryGridSerializationStrategy(new ValueSupportFactory())
+          .deserialize(in);
+      return (DoublePrecomputedGrid) layer;
+    }
+  }
+
+  private static double sumNonZero(DoublePrecomputedGrid grid, long timestep) {
+    double total = 0;
+    for (long x = grid.getMinX(); x <= grid.getMaxX(); x++) {
+      for (long y = grid.getMinY(); y <= grid.getMaxY(); y++) {
+        total += Math.abs(grid.getAt(x, y, timestep).getAsDouble());
+      }
+    }
+    return total;
+  }
+
+  /**
+   * Preprocessing the same source at steps.low=0 and steps.low=2024 must store the SAME records,
+   * just keyed at different (steps.low-relative) timesteps - record i lands at grid key
+   * steps.low + i in both.
+   */
+  @Test
+  public void preprocessAlignsSourceRecordsToStepsLow() throws Exception {
+    PreprocessUtil.PreprocessOptions opts = new PreprocessUtil.PreprocessOptions();
+    DoublePrecomputedGrid base = preprocessGrid(0, 2, opts);
+    DoublePrecomputedGrid calendar = preprocessGrid(2024, 2026, opts);
+
+    assertEquals(0, base.getMinTimestep(), "baseline grid keyed from 0");
+    assertEquals(2024, calendar.getMinTimestep(), "calendar grid keyed from steps.low");
+    assertEquals(2026, calendar.getMaxTimestep());
+
+    // Sanity: the fixture actually populated data (guards against a bad extent silently passing).
+    assertTrue(sumNonZero(base, 0) > 0, "baseline step 0 should have real data");
+    assertTrue(sumNonZero(calendar, 2024) > 0, "calendar step 2024 should have real data");
+
+    // Record i (0..2) must be identical whether keyed at i or at 2024 + i.
+    for (int i = 0; i <= 2; i++) {
+      for (long x = base.getMinX(); x <= base.getMaxX(); x++) {
+        for (long y = base.getMinY(); y <= base.getMaxY(); y++) {
+          assertEquals(
+              base.getAt(x, y, i).getAsDouble(),
+              calendar.getAt(x, y, 2024 + i).getAsDouble(),
+              1e-9,
+              "record " + i + " at (" + x + "," + y + ") must match across steps.low offsets");
+        }
+      }
+    }
+  }
+
+  /**
+   * A calendar steps.low run reads real external data (not zeros, no crash) and reports calendar
+   * years via meta.year alone - and the temperature values are identical to a steps.low=0 run of
+   * the same records, confirming no data regression while the year column shifts.
+   */
+  @Test
+  public void calendarStepsLowRunReadsRealDataAndShiftsYearOnly() throws Exception {
+    RunResult calendar = runWindow(2024, 2026);
+    RunResult baseline = runWindow(0, 2);
+
+    // New behavior: meta.year alone yields calendar years, and external data is real - the bug
+    // this fixes produced an all-zero grid, so require physical Kelvin values to be present.
+    // (Edge patches outside the fixture's footprint are legitimately zero in both runs.)
+    assertEquals(new TreeSet<>(List.of(2024L, 2025L, 2026L)), calendar.years,
+        "calendar run year column should read 2024..2026 from meta.year directly");
+    assertTrue(calendar.temperatures.stream().anyMatch(t -> t > 250.0),
+        "calendar run external temperatures should include real Kelvin values, not all zeros");
+
+    // No regression: baseline still works and reads the same data, only the year label differs.
+    assertEquals(new TreeSet<>(List.of(0L, 1L, 2L)), baseline.years,
+        "baseline run year column should read 0..2");
+    assertEquals(baseline.temperatures, calendar.temperatures,
+        "the same source records must be read in both runs; only the year column shifts");
+  }
+
+  /**
+   * The forced single-timestep path (--timestep) keeps its legacy absolute index: forcing
+   * timestep 2 reads source record 2, matching the steps.low=0 preprocessing's record 2.
+   */
+  @Test
+  public void forcedTimestepStillReadsAbsoluteSourceIndex() throws Exception {
+    final DoublePrecomputedGrid base = preprocessGrid(0, 2, new PreprocessUtil.PreprocessOptions());
+    PreprocessUtil.PreprocessOptions forced = new PreprocessUtil.PreprocessOptions(
+        "EPSG:4326", "lon", "lat", "calendar_year", "2", null, false, false);
+    DoublePrecomputedGrid forcedGrid = preprocessGrid(2, 2, forced);
+
+    assertEquals(2, forcedGrid.getMinTimestep());
+    assertEquals(2, forcedGrid.getMaxTimestep());
+    assertTrue(sumNonZero(forcedGrid, 2) > 0, "forced timestep should still read real data");
+    for (long x = base.getMinX(); x <= base.getMaxX(); x++) {
+      for (long y = base.getMinY(); y <= base.getMaxY(); y++) {
+        assertEquals(
+            base.getAt(x, y, 2).getAsDouble(),
+            forcedGrid.getAt(x, y, 2).getAsDouble(),
+            1e-9,
+            "forced --timestep 2 must read the same record as record 2 of a 0-based run");
+      }
+    }
+  }
+
+  /** Preprocess + run a window, returning the observed year set and temperature values. */
+  private RunResult runWindow(long stepsLow, long stepsHigh) throws Exception {
+    preprocessGrid(stepsLow, stepsHigh, new PreprocessUtil.PreprocessOptions());
+    Path jshd = tempDir.resolve("grid_" + stepsLow + ".jshd"); // written by preprocessGrid
+    assertTrue(Files.exists(jshd));
+
+    Path outDir = Files.createDirectories(tempDir.resolve("run_" + stepsLow));
+    Path csvTarget = outDir.resolve("results_{replicate}.csv");
+    Path script = writeScript("run_" + stepsLow, stepsLow, stepsHigh, csvTarget);
+
+    RunUtil.RunOptions options = RunUtil.RunOptions.builder(script.toFile(), "Test")
+        .replicates(1)
+        .dataFiles(new String[] {"temperature.jshd=" + jshd})
+        .seed(Optional.of(42L))
+        .build();
+    RunUtil.RunResult result = RunUtil.run(options, new OutputOptions());
+    assertTrue(result.isSuccess(),
+        "run with steps.low=" + stepsLow + " should succeed: " + result.getMessage());
+
+    Path csv = outDir.resolve("results_0.csv");
+    assertTrue(Files.exists(csv), "expected output CSV at " + csv);
+    return parseCsv(csv);
+  }
+
+  private static RunResult parseCsv(Path csv) throws Exception {
+    List<String> lines = Files.readAllLines(csv);
+    String[] header = lines.get(0).split(",", -1);
+    int yearCol = -1;
+    int tempCol = -1;
+    for (int i = 0; i < header.length; i++) {
+      if (header[i].equals("year")) {
+        yearCol = i;
+      } else if (header[i].equals("temperature")) {
+        tempCol = i;
+      }
+    }
+    assertFalse(yearCol < 0 || tempCol < 0, "CSV must have year and temperature columns");
+
+    TreeSet<Long> years = new TreeSet<>();
+    List<Double> temperatures = new ArrayList<>();
+    for (int i = 1; i < lines.size(); i++) {
+      String[] row = lines.get(i).split(",", -1);
+      years.add((long) Double.parseDouble(row[yearCol]));
+      temperatures.add(Double.parseDouble(row[tempCol]));
+    }
+    temperatures.sort(Double::compareTo);
+    return new RunResult(years, temperatures);
+  }
+
+  private record RunResult(TreeSet<Long> years, List<Double> temperatures) {}
+}

--- a/src/test/java/org/joshsim/conformance/JoshConformanceTest.java
+++ b/src/test/java/org/joshsim/conformance/JoshConformanceTest.java
@@ -13,7 +13,6 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;

--- a/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
@@ -32,7 +32,6 @@ import org.joshsim.engine.value.type.EngineValue;
 import org.joshsim.engine.value.type.RealizedDistribution;
 import org.joshsim.lang.bridge.EngineBridge;
 import org.joshsim.lang.interpret.RecursiveValueResolver;
-import org.joshsim.lang.interpret.ValueResolver;
 import org.joshsim.lang.interpret.action.EventHandlerAction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshExternalVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshExternalVisitorTest.java
@@ -50,12 +50,14 @@ class JoshExternalVisitorTest {
     assertNotNull(action);
 
     EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
-    when(mockMachine.getStepCount()).thenReturn(42L);
+    // External reads resolve at the semantic (steps.low-based) timestep so the lookup lines up
+    // with how the data grid is keyed and with meta.year.
+    when(mockMachine.getCurrentTimestep()).thenReturn(42L);
     org.mockito.Mockito.doNothing().when(mockMachine).pushExternal("externalVar", 42L);
 
     action.apply(mockMachine);
 
-    verify(mockMachine).getStepCount();
+    verify(mockMachine).getCurrentTimestep();
     verify(mockMachine).pushExternal("externalVar", 42L);
   }
 

--- a/src/test/java/org/joshsim/mcp/McpStdoutCleanlinessTest.java
+++ b/src/test/java/org/joshsim/mcp/McpStdoutCleanlinessTest.java
@@ -10,14 +10,12 @@
 package org.joshsim.mcp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/joshsim/pipeline/target/KubernetesPollingStrategyTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/KubernetesPollingStrategyTest.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
@@ -10,9 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.fabric8.kubernetes.api.model.Container;


### PR DESCRIPTION
## Problem

`meta.year` is designed as "step shifted by `steps.low`" (`meta.year = steps.low + step`, units `years`), so setting `steps.low` to a calendar start year should make `meta.year` read as a calendar year directly. But that never worked with external data, because **external reads were the one place resolving against the 0-based `absoluteStep`**, while:

- the preprocessed `.jshd` grid is keyed by `steps.low` ([PreprocessUtil](../blob/dev/src/main/java/org/joshsim/command/PreprocessUtil.java) → `getStartTimestep()`),
- `meta.year` is `steps.low`-based,
- and `external X at <time>` is already `steps.low`-aligned.

The mismatch was masked because all four coincide at `steps.low = 0` — the only value real workflows used. At `steps.low ≠ 0` it either crashed (`Timestep out of bounds`) or, once preprocess produced an in-range-but-empty grid, returned **silent zeros**.

This is what made the calendar-year idiom unusable and pushed every LLM-authored cell to `steps.low = 0` + a manual `+ 2024` offset (and the `meta.year`-alone cells to fail the year-column gate). Surfaced by the josh-llm-experiment year-export survey.

## Change (two aligned edits, both no-ops at `steps.low = 0`)

1. **[PreprocessUtil](../blob/dev/src/main/java/org/joshsim/command/PreprocessUtil.java)** maps each grid timestep back to the data source's 0-based record index (`timestep - steps.low`) before reading, so source record `i` lands at grid key `steps.low + i`. The forced single-timestep (`--timestep`) path keeps its legacy absolute index.
2. **[JoshExternalVisitor](../blob/dev/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshExternalVisitor.java)** resolves the plain `external X` read at the semantic timestep (`getCurrentTimestep()`, `steps.low`-based) instead of `getStepCount()`'s 0-based `absoluteStep` — matching the grid keying, `meta.year`, and `external X at <time>`. New `EventHandlerMachine.getCurrentTimestep()`; `getStepCount()` retained (mirrors `meta.stepCount`).

### Result
`steps.low = 2024` + `export.year.step = meta.year` (no offset) now reads external data correctly **and** reports calendar years — the intuitive form. `steps.low = 0` is byte-identical (`currentStep == absoluteStep`, `timestep - 0 == timestep`).

## Why it's safe
At `steps.low = 0` (every existing example, test, and experiment cell) nothing changes. The only path that changes (`steps.low ≠ 0` + external) was broken before — crash or zeros — so nothing can depend on it.

## Tests
`ExternalTimestepAlignmentIntegrationTest` drives `PreprocessUtil` + `RunUtil` against the committed `maxtemp_tulare_annual.nc` fixture (`calendar_year` 2024..2053):
- **preprocess alignment** — same source at `steps.low=0` vs `2024` stores identical records, shifted by `steps.low`.
- **end-to-end** — a `steps.low=2024` run reads real Kelvin values and reports years 2024.., while a `steps.low=0` run reads the **same** data with a 0-based year column (no data regression; only the year label shifts).
- **forced path** — `--timestep` still reads its absolute source record.

`JoshExternalVisitorTest` updated to pin the semantic-timestep read. Full `./gradlew build` green (all tests + conformance + checkstyle + spotless).

## Notes
- Second commit is `spotlessApply` on **pre-existing** formatting violations in unrelated files (`dev` was red on `spotlessCheck`); pure formatting, no behavior change.
- Adopting this in the experiment requires authoring cells with `steps.low = <startYear>` — then `meta.year` alone is the calendar year.

🤖 Generated with [Claude Code](https://claude.com/claude-code)