### PR TITLE
Resolve bare external names mapped to .jshd without an XZ-format error

### DIFF
--- a/src/main/java/org/joshsim/lang/io/JvmMappedInputGetter.java
+++ b/src/main/java/org/joshsim/lang/io/JvmMappedInputGetter.java
@@ -45,38 +45,70 @@ public class JvmMappedInputGetter extends JvmInputGetter {
 
   @Override
   protected boolean checkNamePathExists(String identifier) {
-    if (fileMapping.containsKey(identifier)) {
-      return true;
+    return resolveMappedPath(identifier) != null;
+  }
+
+  /**
+   * Resolve a requested name to a mapped file path, or null when there is no acceptable mapping.
+   *
+   * <p>An exact key match always wins. Otherwise, when the name carries an extension, the
+   * extension-stripped base is tried too, so a bare mapping key (e.g. {@code editor}) can satisfy
+   * an extension-qualified lookup (e.g. {@code editor.jshc} produced by config resolution).</p>
+   *
+   * <p>The stripped fallback is suppressed when it would cross the {@code .jshd}/{@code .jshdz}
+   * divide. {@link org.joshsim.precompute.MultiFormatExternalGetter} resolves a bare
+   * {@code external} reference by probing {@code name.jshdz} then {@code name.jshd}; without this
+   * guard a key mapped to a plain {@code .jshd} file would satisfy the {@code .jshdz} probe and
+   * hand the XZ reader uncompressed bytes ("Input is not in the XZ format"). Returning null for
+   * the mismatched probe lets the dispatcher fall through to the format that actually matches.</p>
+   *
+   * @param name The requested name.
+   * @return The mapped path, or null if no acceptable mapping exists.
+   */
+  private String resolveMappedPath(String name) {
+    String exact = fileMapping.get(name);
+    if (exact != null) {
+      return exact;
     }
-    // Also try without extension if the identifier has one
-    if (identifier.contains(".")) {
-      String nameWithoutExt = identifier.substring(0, identifier.lastIndexOf('.'));
-      return fileMapping.containsKey(nameWithoutExt);
+    if (name.contains(".")) {
+      String nameWithoutExt = name.substring(0, name.lastIndexOf('.'));
+      String candidate = fileMapping.get(nameWithoutExt);
+      if (candidate != null && stripFallbackAllowed(name, candidate)) {
+        return candidate;
+      }
     }
-    return false;
+    return null;
+  }
+
+  /**
+   * Whether the extension-stripped fallback may bind {@code requested} to {@code mappedPath}.
+   *
+   * <p>Only genuine {@code .jshd}/{@code .jshdz} format conflicts are suppressed; every other
+   * lookup (e.g. config {@code .jshc}, or a bare working file) keeps the permissive behavior.</p>
+   *
+   * @param requested The extension-qualified name being looked up.
+   * @param mappedPath The path the stripped base key points at.
+   * @return True if the fallback may bind, false to force a miss.
+   */
+  private static boolean stripFallbackAllowed(String requested, String mappedPath) {
+    if (requested.endsWith(".jshdz")) {
+      return mappedPath.endsWith(".jshdz");   // XZ reader expects an actually-compressed file
+    }
+    if (requested.endsWith(".jshd")) {
+      return !mappedPath.endsWith(".jshdz");  // raw reader: anything except a compressed file
+    }
+    return true;
   }
 
   /**
    * Load a file from the mapped files.
-   *
-   * <p>This method first tries to find the file using the exact name provided. If not found
-   * and the name contains an extension, it also tries looking up the name without the extension.
-   * This allows flexibility in how files are mapped via the --data flag, particularly for
-   * config files where the .jshc extension is automatically appended during lookup.</p>
    *
    * @param name The name of the file to load from the mapping.
    * @return The input stream for the file at the mapped path.
    * @throws RuntimeException raised if file not found in mapping or error in opening stream.
    */
   private InputStream loadFromMappedFiles(String name) {
-    String actualPath = fileMapping.get(name);
-
-    // If not found and name has extension, also try without extension
-    if (actualPath == null && name.contains(".")) {
-      String nameWithoutExt = name.substring(0, name.lastIndexOf('.'));
-      actualPath = fileMapping.get(nameWithoutExt);
-    }
-
+    String actualPath = resolveMappedPath(name);
     if (actualPath == null) {
       // Surface an unmapped name as a file-not-found so callers that probe multiple candidate
       // names (e.g. MultiFormatExternalGetter trying name.jshdz then name.jshd) can recognize the

--- a/src/test/java/org/joshsim/lang/io/JvmMappedInputGetterTest.java
+++ b/src/test/java/org/joshsim/lang/io/JvmMappedInputGetterTest.java
@@ -213,4 +213,43 @@ class JvmMappedInputGetterTest {
     // Act & Assert - lookup without extension should NOT use fallback
     assertFalse(getter.exists("editor"));
   }
+
+  @Test
+  void testJshdzProbeDoesNotBindToJshdMapping() throws Exception {
+    // A data map keyed by the bare external name (data {"temperature": ".../t.jshd"}) is probed
+    // by MultiFormatExternalGetter as temperature.jshdz THEN temperature.jshd. The .jshdz probe
+    // must MISS so it can fall through to .jshd, rather than handing the XZ reader raw bytes.
+    File jshd = File.createTempFile("mapped-temperature", ".jshd");
+    jshd.deleteOnExit();
+    try (FileWriter writer = new FileWriter(jshd)) {
+      writer.write("raw jshd bytes");
+    }
+    Map<String, String> fileMapping = new HashMap<>();
+    fileMapping.put("temperature", jshd.getAbsolutePath());
+    JvmMappedInputGetter getter = new JvmMappedInputGetter(fileMapping);
+
+    assertFalse(getter.exists("temperature.jshdz"),
+        ".jshdz probe must not bind to a .jshd mapping");
+    assertTrue(getter.exists("temperature.jshd"),
+        ".jshd probe should bind to the .jshd mapping");
+
+    String content = new String(
+        getter.open("temperature.jshd").readAllBytes(), StandardCharsets.UTF_8);
+    assertEquals("raw jshd bytes", content);
+    assertThrows(RuntimeException.class, () -> getter.open("temperature.jshdz"));
+  }
+
+  @Test
+  void testJshdProbeDoesNotBindToJshdzMapping() {
+    // Symmetric guard: a bare key pointing at a compressed .jshdz file must not satisfy a .jshd
+    // probe (which would feed compressed bytes to the raw reader).
+    Map<String, String> fileMapping = new HashMap<>();
+    fileMapping.put("temperature", "/tmp/whatever-temperature.jshdz");
+    JvmMappedInputGetter getter = new JvmMappedInputGetter(fileMapping);
+
+    assertFalse(getter.exists("temperature.jshd"),
+        ".jshd probe must not bind to a .jshdz mapping");
+    assertTrue(getter.exists("temperature.jshdz"),
+        ".jshdz probe should bind to the .jshdz mapping");
+  }
 }

--- a/src/test/java/org/joshsim/precompute/MultiFormatExternalGetterTest.java
+++ b/src/test/java/org/joshsim/precompute/MultiFormatExternalGetterTest.java
@@ -6,6 +6,7 @@
 
 package org.joshsim.precompute;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,12 +15,21 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.FileNotFoundException;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Map;
+import org.joshsim.engine.geometry.PatchBuilderExtentsBuilder;
+import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.ValueSupportFactory;
 import org.joshsim.lang.io.InputGetterStrategy;
+import org.joshsim.lang.io.JvmMappedInputGetter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -147,5 +157,35 @@ class MultiFormatExternalGetterTest {
 
   private static void verifyNoInteractionsWith(InputGetterStrategy strat, String filename) {
     verify(strat, never()).open(filename);
+  }
+
+  @Test
+  void bareName_mappedToJshdFile_resolvesViaJshdFallback(@TempDir Path tempDir) throws Exception {
+    // End-to-end with a real mapped input getter: a data map keyed by the bare external name
+    // (data {"temperature": ".../t.jshd"}) must resolve. The .jshdz probe misses (the mapping
+    // points at a .jshd file) and the dispatcher falls through to .jshd, rather than failing with
+    // "Input is not in the XZ format".
+    ValueSupportFactory factory = new ValueSupportFactory();
+    PatchBuilderExtentsBuilder extentsBuilder = new PatchBuilderExtentsBuilder();
+    extentsBuilder.setTopLeftX(BigDecimal.ZERO);
+    extentsBuilder.setTopLeftY(BigDecimal.ZERO);
+    extentsBuilder.setBottomRightX(BigDecimal.TWO);
+    extentsBuilder.setBottomRightY(BigDecimal.TWO);
+    DoublePrecomputedGrid grid = new DoublePrecomputedGrid(
+        factory, extentsBuilder.build(), 0L, 2L, Units.of("meters"), new double[3][3][3]);
+
+    Path jshd = tempDir.resolve("t.jshd");
+    try (OutputStream out = Files.newOutputStream(jshd)) {
+      new BinaryGridSerializationStrategy(factory).serialize(grid, out);
+    }
+
+    JvmMappedInputGetter mapped =
+        new JvmMappedInputGetter(Map.of("temperature", jshd.toString()));
+    MultiFormatExternalGetter dispatcher = new MultiFormatExternalGetter(
+        new JshdExternalGetter(mapped, factory), new JshdzExternalGetter(mapped, factory));
+
+    DataGridLayer resolved = dispatcher.getResource("temperature");
+    assertEquals(0L, resolved.getMinTimestep());
+    assertEquals(2L, resolved.getMaxTimestep());
   }
 }


### PR DESCRIPTION
## Problem

When external data is supplied under a **bare key** matching the `external` declaration — e.g. `external temperature` with `data: {"temperature": ".../t.jshd"}` (the natural thing to write, matching the in-`.josh` name) — the run fails with:

```
Failed to deserialize grid with XZ decompression: Input is not in the XZ format
```

Keying the data map with the explicit `.jshd` suffix (`"temperature.jshd": ...`) works, so the failure is confusing and arbitrary. Surfaced by the josh-llm-experiment team while verifying #451.

## Root cause

`MultiFormatExternalGetter` resolves a bare external name by probing `name.jshdz` **then** `name.jshd` (falling through only on file-not-found — a deliberate design, asserted by `bareName_nonFileNotFoundError_isRethrownWithoutFallback`).

`JvmMappedInputGetter` has an extension-stripping fallback so a bare mapping key can satisfy an extension-qualified lookup (used by config `.jshc` resolution). That fallback is format-blind: for a bare key `temperature` → `.../t.jshd`, the **`.jshdz` probe** strips the extension, matches `temperature`, and returns the **`.jshd`** bytes. The XZ reader then fails — and because that's not a file-not-found, the dispatcher rethrows instead of falling through to `.jshd`.

## Fix

`JvmMappedInputGetter` now suppresses the stripped fallback only across the `.jshd`/`.jshdz` divide ([JvmMappedInputGetter.java](src/main/java/org/joshsim/lang/io/JvmMappedInputGetter.java)):
- a `.jshdz` lookup binds via the stripped key only to an actually-`.jshdz` path;
- a `.jshd` lookup to anything except a `.jshdz` path;
- every other lookup (config `.jshc`, bare working files) keeps the permissive behavior.

So the `.jshdz` probe now **misses cleanly** (file-not-found) and the dispatcher falls through to the matching `.jshd`. The fix is localized to the mapped getter; `MultiFormatExternalGetter`'s intended fall-through-on-file-not-found behavior is unchanged. Explicit `.jshd`-suffixed keys already worked and are unchanged.

## Tests
- `JvmMappedInputGetterTest` — both directions of the format guard (`.jshdz` probe doesn't bind to a `.jshd` mapping and vice-versa), and the existing config-style extension fallback still passes.
- `MultiFormatExternalGetterTest` — new end-to-end test wires a **real** mapped getter + a serialized `.jshd` under a bare key and confirms `getResource("temperature")` resolves.
- Full `./gradlew build` green (tests + conformance + checkstyle + spotless).

## Scope
Independent of #451 (this is a pre-existing resolution bug). No format/serialization changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)