### PR TITLE
Give an actionable error when a bare unit name is used as a value

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -602,6 +602,8 @@ Single-line comments use `#` syntax:
 33.7 degrees latitude
 ```
 
+A unit must attach to a number. Write a rate or compound unit as a value-over-value division or a quoted compound — `300 mm / 1 year` or `300 "mm / year"` — not `300 / year` (a bare unit name with no number is treated as an undefined value, not a unit).
+
 **String literals enclosed in double quotes:**
 
 ```

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -130,7 +130,7 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
       }
     }
 
-    throw new IllegalStateException("Unable to get value for " + valueResolver);
+    throw new IllegalStateException(unresolvedValueMessage(path, valueResolver));
   }
 
   @Override
@@ -656,6 +656,29 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
       );
       default -> Optional.empty();
     };
+  }
+
+  /**
+   * Build an actionable message for a value reference that could not be resolved.
+   *
+   * <p>A bare name (no dot) is most often a unit written where a value is expected — e.g.
+   * {@code 300 / year} parses {@code year} as an identifier, not as a unit. Units must attach to
+   * a number, so the hint points at the working forms. Dotted paths are reported as a plain
+   * missing attribute. The resolver text is retained for greppability.</p>
+   *
+   * @param path The reference that failed to resolve.
+   * @param valueResolver The resolver, included for diagnostic continuity.
+   * @return A human-readable explanation with a fix hint where applicable.
+   */
+  private static String unresolvedValueMessage(String path, ValueResolver valueResolver) {
+    String base = "Unable to resolve '" + path + "' as a value: no attribute, variable, or "
+        + "built-in by that name is in scope here (" + valueResolver + ").";
+    if (path.contains(".")) {
+      return base;
+    }
+    return base + " If '" + path + "' is a unit, attach it to a number — e.g. '300 " + path
+        + "', a rate as '300 mm / 1 year', or a quoted compound unit '300 \"mm / year\"'. "
+        + "A bare unit name cannot be used as a value.";
   }
 
   @Override

--- a/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
@@ -7,7 +7,9 @@
 package org.joshsim.lang.interpret.machine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -86,6 +88,24 @@ public class SingleThreadEventHandlerMachineTest {
     // Then
     machine.end();
     assertEquals(mockValue, machine.getResult());
+  }
+
+  @Test
+  void push_unresolvedBareName_givesActionableUnitHint() {
+    // A bare unit name used as a value (e.g. `300 / year`) reaches push() as an unresolvable
+    // resolver. The message must guide the author to attach the unit to a number, not just emit
+    // the opaque resolver text.
+    RecursiveValueResolver resolver = new RecursiveValueResolver(factory, "year");
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> machine.push(resolver));
+
+    String message = ex.getMessage();
+    assertTrue(message.contains("year"), "should name the unresolved symbol: " + message);
+    assertTrue(message.contains("1 year") || message.contains("unit"),
+        "should hint that a bare unit must attach to a number: " + message);
+    assertNotEquals("Unable to get value for RecursiveValueResolver(year)", message,
+        "should not be the bare opaque message");
   }
 
   @Test


### PR DESCRIPTION
## Problem

A patch expression like `testRate.step = 300 / year` — or `300 * year`, or a `mm/year` rate written as `(precipitation - 300 mm/year) / (...)` — crashes at run time with the opaque:

```
java.lang.IllegalStateException: Unable to get value for RecursiveValueResolver(year)
```

`validate_simulation` passes; only `run_simulation` trips it. The cryptic message leads LLM agents to blame the year *export* and strip it (then failing a downstream schema gate). Surfaced by the josh-llm-experiment panel as the single biggest model-quality confounder on the Josh arms.

## Root cause (long-standing; not `meta.year`/#451)

`300 / year` parses as a division whose right operand `year` is a bare `identifierExpression`. At run time the machine resolves it as a *value*; there is no attribute/`meta.`/`here.` named `year`, so [SingleThreadEventHandlerMachine.push](src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java) throws. `300 year` works because that's a single `unitsValue` literal (unit token attached to a number), never value-resolved. Declaring `start unit year` does not help — resolution never consults unit declarations.

**Correct rate syntax already works** (verified): `300 mm / 1 year`, `300 / 1 year`, `300 "mm / year"`, `300 year` all run. Only a *bare* unit name as an operand fails.

## Fix — diagnosability only

Replace the throw with a message that names the unresolved symbol and, for a bare name, points at the working forms:

> Unable to resolve 'year' as a value: no attribute, variable, or built-in by that name is in scope here (RecursiveValueResolver(year)). If 'year' is a unit, attach it to a number — e.g. '300 year', a rate as '300 mm / 1 year', or a quoted compound unit '300 "mm / year"'. A bare unit name cannot be used as a value.

Plus a terse `llms-full.txt` note on rate/compound-unit syntax.

**No semantics change**: `300 / year` still fails, just legibly; all working forms unchanged. Deliberately does **not** silently treat unresolved barewords as units — `Units.of()` accepts any string with no registry, so that would mask typos (e.g. a misspelled attribute becoming `1 <typo>`). Decision confirmed with maintainer.

## Tests
- `SingleThreadEventHandlerMachineTest` — pushing an unresolvable `RecursiveValueResolver("year")` yields a message containing the unit hint and the symbol, and is not the bare opaque text.
- Verified end-to-end on the reported repro (`300 / year`) — now prints the actionable message.
- Full `./gradlew build` green (tests + conformance + checkstyle + spotless).

## Scope
Independent of #451/#452. No grammar or `Units` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)