### PR TITLE
Serve demo at joshsim.org/demo; fix landing call-out styling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -591,13 +591,22 @@ jobs:
         with:
           name: demo
           path: ./demo-build
+      - name: Ensure remote demo directory exists
+        env:
+          SSHPASS: ${{ secrets.SFTPPASSWORD }}
+        run: |
+          # Served under the landing site at joshsim.org/demo until the
+          # demo.joshsim.org subdomain is configured on the host.
+          sshpass -e ssh -p 22 -o StrictHostKeyChecking=no \
+            ${{ secrets.SFTPUSER }}@${{ secrets.SFTPHOST }} \
+            "mkdir -p joshsim.org/demo"
       - name: Upload demo via SCP
         env:
           SSHPASS: ${{ secrets.SFTPPASSWORD }}
         run: |
           sshpass -e scp -r -P 22 -o StrictHostKeyChecking=no \
             ./demo-build/* \
-            ${{ secrets.SFTPUSER }}@${{ secrets.SFTPHOST }}:demo.joshsim.org/
+            ${{ secrets.SFTPUSER }}@${{ secrets.SFTPHOST }}:joshsim.org/demo/
   deployCloud:
     name: Deploy to Cloud
     environment: Deploy

--- a/landing/guide.html
+++ b/landing/guide.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Josh Simulation Engine: Guide</title>
-    <link href="/landing.css" rel="stylesheet" type="text/css" />
+    <link href="/landing.css?v=2" rel="stylesheet" type="text/css" />
   </head>
   <body>
     <div class="skip-link">
@@ -26,7 +26,7 @@
         <div class="demo-callout-inner">
           <h2>✨ Try Josh right now — no install needed</h2>
           <p>Prefer to learn by doing? Watch a real vegetation simulation get built up line by line, then run and tweak it live in your browser.</p>
-          <a class="demo-callout-button" href="https://demo.joshsim.org/">Start the interactive intro →</a>
+          <a class="demo-callout-button" href="/demo/">Start the interactive intro →</a>
         </div>
       </section>
       <section id="meet">

--- a/landing/index.html
+++ b/landing/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Josh Simulation Engine</title>
-    <link href="/landing.css" rel="stylesheet" type="text/css" />
+    <link href="/landing.css?v=2" rel="stylesheet" type="text/css" />
   </head>
   <body>
     <div class="skip-link">
@@ -26,7 +26,7 @@
         <div class="demo-callout-inner">
           <h2>✨ Try Josh right now — no install needed</h2>
           <p>New to Josh? Watch a real vegetation simulation get built up line by line, then run and tweak it live in your browser.</p>
-          <a class="demo-callout-button" href="https://demo.joshsim.org/">Start the interactive intro →</a>
+          <a class="demo-callout-button" href="/demo/">Start the interactive intro →</a>
         </div>
       </section>
       <section id="meet">


### PR DESCRIPTION
Two post-merge fixes from testing the deployed site.

## 1. demo.joshsim.org doesn't resolve → serve under `joshsim.org/demo`
The `demo.joshsim.org` subdomain isn't configured on the host yet (DreamHost shows its placeholder). Until it is, the `deployDemo` job uploads the demo into **`joshsim.org/demo`** (main only), creating the remote directory first. All demo asset paths are relative, so it runs unchanged under the subpath. The landing call-out buttons on the home and guide pages now link to `/demo/`.

Follow-up (host config, not code): set up the `demo.joshsim.org` subdomain and a redirect from `/demo`, then flip the deploy target back.

## 2. Call-out styling missing on the live pages
The `.demo-callout` rules are present in `landing.css`, but `/landing.css` has no cache-buster, so browsers were serving a stale stylesheet without them. Bumped to `?v=2` on the two pages that carry the call-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)