### PR TITLE
Fold demo deploy into deployStatic; restore demo.joshsim.org target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -571,42 +571,21 @@ jobs:
           sshpass -e scp -r -P 22 -o StrictHostKeyChecking=no \
             ./landing-build/* \
             ${{ secrets.SFTPUSER }}@${{ secrets.SFTPHOST }}:${{ env.LANDING_DIRECTORY }}/
-  deployDemo:
-    environment: Deploy
-    runs-on: ubuntu-latest
-    name: Deploy Demo to SFTP
-    needs: [deployStatic]
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Install SSH client and sshpass
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openssh-client sshpass
-      - name: Setup SSH known hosts
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan -H -p 22 ${{ secrets.SFTPHOST }} >> ~/.ssh/known_hosts
       - name: Download demo artifact
+        if: github.ref == 'refs/heads/main'
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: demo
           path: ./demo-build
-      - name: Ensure remote demo directory exists
-        env:
-          SSHPASS: ${{ secrets.SFTPPASSWORD }}
-        run: |
-          # Served under the landing site at joshsim.org/demo until the
-          # demo.joshsim.org subdomain is configured on the host.
-          sshpass -e ssh -p 22 -o StrictHostKeyChecking=no \
-            ${{ secrets.SFTPUSER }}@${{ secrets.SFTPHOST }} \
-            "mkdir -p joshsim.org/demo"
       - name: Upload demo via SCP
+        if: github.ref == 'refs/heads/main'
         env:
           SSHPASS: ${{ secrets.SFTPPASSWORD }}
         run: |
+          # Demo is production-only; the demo.joshsim.org subdomain has no dev directory.
           sshpass -e scp -r -P 22 -o StrictHostKeyChecking=no \
             ./demo-build/* \
-            ${{ secrets.SFTPUSER }}@${{ secrets.SFTPHOST }}:joshsim.org/demo/
+            ${{ secrets.SFTPUSER }}@${{ secrets.SFTPHOST }}:demo.joshsim.org/
   deployCloud:
     name: Deploy to Cloud
     environment: Deploy

--- a/landing/guide.html
+++ b/landing/guide.html
@@ -26,7 +26,7 @@
         <div class="demo-callout-inner">
           <h2>✨ Try Josh right now — no install needed</h2>
           <p>Prefer to learn by doing? Watch a real vegetation simulation get built up line by line, then run and tweak it live in your browser.</p>
-          <a class="demo-callout-button" href="/demo/">Start the interactive intro →</a>
+          <a class="demo-callout-button" href="https://demo.joshsim.org/">Start the interactive intro →</a>
         </div>
       </section>
       <section id="meet">

--- a/landing/index.html
+++ b/landing/index.html
@@ -26,7 +26,7 @@
         <div class="demo-callout-inner">
           <h2>✨ Try Josh right now — no install needed</h2>
           <p>New to Josh? Watch a real vegetation simulation get built up line by line, then run and tweak it live in your browser.</p>
-          <a class="demo-callout-button" href="/demo/">Start the interactive intro →</a>
+          <a class="demo-callout-button" href="https://demo.joshsim.org/">Start the interactive intro →</a>
         </div>
       </section>
       <section id="meet">


### PR DESCRIPTION
`demo.joshsim.org` is live on the host now, so the `joshsim.org/demo` subpath workaround from #459 is no longer needed.

## Changes
- **Removed the separate `deployDemo` job** and moved its demo download + upload steps into the existing **`deployStatic`** ("Deploy to SFTP") job. A single Deploy-environment approval now releases the landing, editor, jar, and demo uploads together — no more demo deploy stalling on its own approval gate (the root cause of the demo never appearing).
- **Restored the `demo.joshsim.org/` target** and pointed the home/guide call-out buttons back to `https://demo.joshsim.org/`.
- Demo upload steps are guarded `if: github.ref == 'refs/heads/main'` (the demo subdomain has no dev directory, so dev deploys skip it — same behavior as the old main-only `deployDemo`).

## Kept from #459
- `landing.css?v=2` cache-buster on the home + guide pages. Reverting it would re-serve the stale cached `/landing.css` that was hiding the `.demo-callout` styling, so it stays.

Effectively reverts #459's deploy-path workaround while keeping the styling fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)