### PR TITLE
Add --replicate-indices for non-contiguous replicate backfill across all routes

### DIFF
--- a/cloud-img/run-entrypoint.sh
+++ b/cloud-img/run-entrypoint.sh
@@ -54,9 +54,35 @@ if [ -z "$SCRIPT" ]; then
 fi
 
 # JOB_COMPLETION_INDEX is set by K8s for indexed Jobs (0, 1, 2, ...).
-# JOSH_REPLICATE_OFFSET (default 0) shifts the absolute index for pool/resume
-# workflows where indices need to be stable across re-dispatch.
-REPLICATE_INDEX=$(( ${JOB_COMPLETION_INDEX:-0} + ${JOSH_REPLICATE_OFFSET:-0} ))
+# Two ways to map a pod's completion index to an absolute replicate index:
+#   - JOSH_REPLICATE_INDICES (comma-separated, e.g. "3,7,8"): pick the
+#     JOB_COMPLETION_INDEX-th entry. Used to backfill a specific, possibly
+#     non-contiguous set of replicates.
+#   - JOSH_REPLICATE_OFFSET (default 0): shift the completion index by a fixed
+#     offset for contiguous pool/resume ranges.
+# JOSH_REPLICATE_INDICES takes precedence when set.
+if [ -n "${JOSH_REPLICATE_INDICES:-}" ]; then
+  target_pos=${JOB_COMPLETION_INDEX:-0}
+  pos=0
+  REPLICATE_INDEX=""
+  OLD_IFS=$IFS
+  IFS=,
+  for idx in $JOSH_REPLICATE_INDICES; do
+    if [ "$pos" -eq "$target_pos" ]; then
+      REPLICATE_INDEX=$idx
+      break
+    fi
+    pos=$((pos + 1))
+  done
+  IFS=$OLD_IFS
+  if [ -z "$REPLICATE_INDEX" ]; then
+    echo "ERROR: JOB_COMPLETION_INDEX $target_pos out of range for" \
+      "JOSH_REPLICATE_INDICES=$JOSH_REPLICATE_INDICES" >&2
+    exit 1
+  fi
+else
+  REPLICATE_INDEX=$(( ${JOB_COMPLETION_INDEX:-0} + ${JOSH_REPLICATE_OFFSET:-0} ))
+fi
 
 # JOSH_CUSTOM_TAGS holds newline-delimited key=value entries. One
 # --custom-tag flag per non-empty line. Newline-delimited (vs JSON)

--- a/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -47,6 +48,7 @@ import org.joshsim.util.MinioHandler;
 import org.joshsim.util.MinioOptions;
 import org.joshsim.util.MinioStagingUtil;
 import org.joshsim.util.OutputOptions;
+import org.joshsim.util.ReplicateSelection;
 
 
 /**
@@ -183,12 +185,17 @@ public class JoshSimBatchHandler implements HttpHandler {
       return Optional.of(apiKey);
     }
 
-    int replicates;
-    int replicateStart;
+    List<Integer> replicateIndices;
     Map<String, String> customTags;
     try {
-      replicates = parseReplicates(formData);
-      replicateStart = parseReplicateStart(formData);
+      int replicates = parseReplicates(formData);
+      int replicateStart = parseReplicateStart(formData);
+      // An explicit replicateIndices list supersedes start/count; absent it, the [start,
+      // start+count) range is used. Resolved here via the shared helper so every route agrees.
+      Optional<List<Integer>> explicitIndices = formData.contains("replicateIndices")
+          ? ReplicateSelection.parse(formData.getFirst("replicateIndices").getValue())
+          : Optional.empty();
+      replicateIndices = ReplicateSelection.resolve(explicitIndices, replicateStart, replicates);
       customTags = parseCustomTags(formData);
     } catch (IllegalArgumentException e) {
       sendJsonError(exchange, 400, jobId, e.getMessage());
@@ -205,8 +212,8 @@ public class JoshSimBatchHandler implements HttpHandler {
     // deployed with --no-cpu-throttling. See BATCH_EXECUTOR above, #418, #421.
     CompletableFuture.runAsync(() -> {
       runBatchWithStatus(
-          statusMinio, jobId, simulation, workDir, replicates,
-          replicateStart, customTags, statusPath, capturedApiKey
+          statusMinio, jobId, simulation, workDir, replicateIndices,
+          customTags, statusPath, capturedApiKey
       );
     }, BATCH_EXECUTOR);
 
@@ -350,14 +357,14 @@ public class JoshSimBatchHandler implements HttpHandler {
   }
 
   private void runBatchWithStatus(MinioHandler statusMinio, String jobId,
-      String simulation, File workDir, int replicates, int replicateStart,
+      String simulation, File workDir, List<Integer> replicateIndices,
       Map<String, String> customTags, String statusPath, String apiKey) {
     writeStatus(statusMinio, statusPath, buildStatusJson(
         "running", jobId, "startedAt", Instant.now().toString()
     ));
 
     try {
-      executeBatchJob(jobId, simulation, workDir, replicates, replicateStart, customTags);
+      executeBatchJob(jobId, simulation, workDir, replicateIndices, customTags);
 
       writeStatus(statusMinio, statusPath, buildStatusJson(
           "complete", jobId, "completedAt", Instant.now().toString()
@@ -391,7 +398,7 @@ public class JoshSimBatchHandler implements HttpHandler {
   }
 
   private void executeBatchJob(String jobId, String simulation, File workDir,
-      int replicates, int replicateStart, Map<String, String> customTags) throws Exception {
+      List<Integer> replicateIndices, Map<String, String> customTags) throws Exception {
     // Ensure JVM threading for parallel patch export
     CompatibilityLayerKeeper.set(new JvmCompatibilityLayer());
 
@@ -415,15 +422,16 @@ public class JoshSimBatchHandler implements HttpHandler {
     // makes {key} placeholders in exportFiles paths resolve to dispatched values. Without
     // this, custom-tag template resolution silently no-ops on the batch HTTP path.
     JoshJob job = new JoshJobBuilder()
-        .setReplicates(replicates)
+        .setReplicates(replicateIndices.size())
         .setCustomParameters(customTags)
         .build();
 
     // Interpret once — the program doesn't change between replicates.
     // Only the InputOutputLayer changes (replicate index, append mode).
+    int firstReplicate = replicateIndices.get(0);
     InputOutputLayer initialLayer = new JvmInputOutputLayerBuilder()
         .withInputStrategy(new JvmMappedInputGetter(fileMapping))
-        .withTemplateRenderer(new TemplateStringRenderer(job, replicateStart))
+        .withTemplateRenderer(new TemplateStringRenderer(job, firstReplicate))
         .withMinioOptions(minioOptions)
         .build();
 
@@ -435,13 +443,14 @@ public class JoshSimBatchHandler implements HttpHandler {
       throw new IllegalArgumentException("Simulation not found: " + simulation);
     }
 
-    for (int replicate = replicateStart; replicate < replicateStart + replicates; replicate++) {
+    for (int i = 0; i < replicateIndices.size(); i++) {
+      int replicate = replicateIndices.get(i);
       InputOutputLayer replicateLayer = new JvmInputOutputLayerBuilder()
           .withReplicate(replicate)
           .withInputStrategy(new JvmMappedInputGetter(fileMapping))
           .withTemplateRenderer(new TemplateStringRenderer(job, replicate))
           .withMinioOptions(minioOptions)
-          .withAppendMode(replicate > replicateStart)
+          .withAppendMode(i > 0)
           .build();
 
       JoshSimFacadeUtil.runSimulation(

--- a/src/main/java/org/joshsim/cloud/JoshSimLeaderHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimLeaderHandler.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.joshsim.pipeline.remote.LeaderResponseHandler;
 import org.joshsim.pipeline.remote.ParallelWorkerHandler;
 import org.joshsim.pipeline.remote.WorkerTask;
+import org.joshsim.util.ReplicateSelection;
 import org.joshsim.wire.WireRewriteUtil;
 
 
@@ -176,16 +177,30 @@ public class JoshSimLeaderHandler implements HttpHandler {
       }
     }
 
+    // An explicit replicateIndices list (e.g. 3,7,8) takes precedence over the replicateStart
+    // offset; absent both, fall back to the [0, replicates) range. Same resolution as every other
+    // route, via the shared ReplicateSelection helper.
+    List<Integer> replicateIndices;
+    try {
+      Optional<List<Integer>> explicitIndices = formData.contains("replicateIndices")
+          ? ReplicateSelection.parse(formData.getFirst("replicateIndices").getValue())
+          : Optional.empty();
+      replicateIndices = ReplicateSelection.resolve(explicitIndices, replicateStart, replicates);
+    } catch (IllegalArgumentException e) {
+      httpServerExchange.setStatusCode(400);
+      return Optional.of(apiKey);
+    }
+
     // Prepare tasks for parallel execution
     List<WorkerTask> tasks = new ArrayList<>();
-    for (int i = 0; i < replicates; i++) {
+    for (int replicateIndex : replicateIndices) {
       WorkerTask task = new WorkerTask(
           code,
           simulationName,
           apiKey,
           externalData,
           favorBigDecimal,
-          replicateStart + i,
+          replicateIndex,
           outputStepsStr,
           false
       );

--- a/src/main/java/org/joshsim/command/BatchRemoteCommand.java
+++ b/src/main/java/org/joshsim/command/BatchRemoteCommand.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -27,6 +28,7 @@ import org.joshsim.util.MinioHandler;
 import org.joshsim.util.MinioHandler.StagedState;
 import org.joshsim.util.MinioHandler.StagedStatus;
 import org.joshsim.util.OutputOptions;
+import org.joshsim.util.ReplicateSelection;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -101,6 +103,14 @@ public class BatchRemoteCommand implements Callable<Integer> {
   private int replicateStart = 0;
 
   @Option(
+      names = "--replicate-indices",
+      description = "Explicit, possibly non-contiguous list of replicate indices to run "
+          + "(e.g. 3,7,8) instead of the [start, start+count) range. Use to backfill specific "
+          + "missing replicates. Mutually exclusive with --replicates and --replicate-start."
+  )
+  private String replicateIndices;
+
+  @Option(
       names = "--custom-tag",
       description = "Custom template parameters (format: name=value). Can be specified "
           + "multiple times. Resolvable as {name} in exportFiles paths."
@@ -138,6 +148,17 @@ public class BatchRemoteCommand implements Callable<Integer> {
         output.printError("--replicate-start must be >= 0");
         return DISPATCH_ERROR_CODE;
       }
+      boolean indicesGiven = replicateIndices != null && !replicateIndices.trim().isEmpty();
+      if (indicesGiven && replicates > 1) {
+        output.printError("--replicate-indices and --replicates are mutually exclusive");
+        return DISPATCH_ERROR_CODE;
+      }
+      if (indicesGiven && replicateStart != 0) {
+        output.printError("--replicate-indices and --replicate-start are mutually exclusive");
+        return DISPATCH_ERROR_CODE;
+      }
+      final List<Integer> parsedReplicateIndices =
+          ReplicateSelection.parse(replicateIndices).orElse(List.of());
       final Map<String, String> parsedCustomTags = parseCustomTags();
 
       output.printInfo("Loading target profile: " + targetName);
@@ -178,7 +199,8 @@ public class BatchRemoteCommand implements Callable<Integer> {
 
       if (noWait) {
         String jobId = strategy.executeNoWait(
-            normalizedPrefix, simulation, replicates, parsedCustomTags, replicateStart
+            normalizedPrefix, simulation, replicates, parsedCustomTags, replicateStart,
+            parsedReplicateIndices
         );
         ObjectNode node = MAPPER.createObjectNode();
         node.put("jobId", jobId);
@@ -189,7 +211,8 @@ public class BatchRemoteCommand implements Callable<Integer> {
       }
 
       JobStatus finalStatus = strategy.execute(
-          normalizedPrefix, simulation, replicates, parsedCustomTags, replicateStart
+          normalizedPrefix, simulation, replicates, parsedCustomTags, replicateStart,
+          parsedReplicateIndices
       );
 
       if (finalStatus.getState() == JobStatus.State.COMPLETE) {

--- a/src/main/java/org/joshsim/command/RunCommand.java
+++ b/src/main/java/org/joshsim/command/RunCommand.java
@@ -13,6 +13,7 @@ package org.joshsim.command;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -22,6 +23,7 @@ import org.joshsim.lang.io.MapSerializeStrategy;
 import org.joshsim.util.MinioOptions;
 import org.joshsim.util.OutputOptions;
 import org.joshsim.util.OutputStepsParser;
+import org.joshsim.util.ReplicateSelection;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -68,6 +70,15 @@ public class RunCommand implements Callable<Integer> {
       defaultValue = "0"
   )
   private int replicateStart = 0;
+
+  @Option(
+      names = "--replicate-indices",
+      description = "Explicit, possibly non-contiguous list of replicate indices to run "
+          + "(e.g. 3,7,8). Runs exactly these indices; output filenames use the index in the "
+          + "{replicate} slot. Mutually exclusive with --replicates, --replicate-index, and "
+          + "--replicate-start."
+  )
+  private String replicateIndices;
 
   @Option(
       names = "--use-float-64",
@@ -201,15 +212,36 @@ public class RunCommand implements Callable<Integer> {
       output.printError("Number of replicates must be at least 1");
       return 1;
     }
+    boolean indicesGiven = replicateIndices != null && !replicateIndices.trim().isEmpty();
+    if (indicesGiven && replicates > 1) {
+      output.printError("--replicate-indices and --replicates are mutually exclusive");
+      return 1;
+    }
+    if (indicesGiven && replicateIndex != null) {
+      output.printError("--replicate-indices and --replicate-index are mutually exclusive");
+      return 1;
+    }
+    if (indicesGiven && replicateStart != 0) {
+      output.printError("--replicate-indices and --replicate-start are mutually exclusive");
+      return 1;
+    }
 
     // Parse CLI-shaped inputs up front for fail-fast validation.
     Map<String, String> customParameters = parseCustomParameters();
     Optional<Set<Integer>> parsedOutputSteps = parseOutputSteps();
+    Optional<List<Integer>> parsedReplicateIndices;
+    try {
+      parsedReplicateIndices = ReplicateSelection.parse(replicateIndices);
+    } catch (IllegalArgumentException e) {
+      output.printError(e.getMessage());
+      return 1;
+    }
 
     RunUtil.RunOptions options = RunUtil.RunOptions.builder(file, simulation)
         .replicates(replicates)
         .replicateIndex(replicateIndex)
         .replicateStart(replicateStart)
+        .replicateIndices(parsedReplicateIndices)
         .serialPatches(serialPatches)
         .seed(Optional.ofNullable(seed))
         .useFloat64(useFloat64)

--- a/src/main/java/org/joshsim/command/RunRemoteCommand.java
+++ b/src/main/java/org/joshsim/command/RunRemoteCommand.java
@@ -21,6 +21,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.joshsim.compat.CompatibilityLayerKeeper;
 import org.joshsim.compat.JvmCompatibilityLayer;
@@ -36,6 +37,7 @@ import org.joshsim.pipeline.remote.RunRemoteStrategy;
 import org.joshsim.util.MinioOptions;
 import org.joshsim.util.OutputOptions;
 import org.joshsim.util.ProgressCalculator;
+import org.joshsim.util.ReplicateSelection;
 import org.joshsim.util.SimulationMetadata;
 import org.joshsim.util.SimulationMetadataExtractor;
 import picocli.CommandLine.Command;
@@ -157,6 +159,17 @@ public class RunRemoteCommand implements Callable<Integer> {
   )
   private int replicateStart = 0;
 
+  @Option(
+      names = "--replicate-indices",
+      description = "Explicit, possibly non-contiguous list of replicate indices to run "
+          + "(e.g. 3,7,8) instead of the [start, start+count) range. Use to backfill specific "
+          + "missing replicates. Mutually exclusive with --replicates and --replicate-start."
+  )
+  private String replicateIndices;
+
+  /** Parsed form of {@link #replicateIndices}; empty means use the [start, start+count) range. */
+  private Optional<List<Integer>> parsedReplicateIndices = Optional.empty();
+
   /**
    * Parses custom parameter command-line options.
    *
@@ -194,6 +207,21 @@ public class RunRemoteCommand implements Callable<Integer> {
     }
     if (replicateStart < 0) {
       output.printError("--replicate-start must be >= 0");
+      return SERIALIZATION_ERROR_CODE;
+    }
+    boolean indicesGiven = replicateIndices != null && !replicateIndices.trim().isEmpty();
+    if (indicesGiven && replicates > 1) {
+      output.printError("--replicate-indices and --replicates are mutually exclusive");
+      return SERIALIZATION_ERROR_CODE;
+    }
+    if (indicesGiven && replicateStart != 0) {
+      output.printError("--replicate-indices and --replicate-start are mutually exclusive");
+      return SERIALIZATION_ERROR_CODE;
+    }
+    try {
+      parsedReplicateIndices = ReplicateSelection.parse(replicateIndices);
+    } catch (IllegalArgumentException e) {
+      output.printError(e.getMessage());
       return SERIALIZATION_ERROR_CODE;
     }
     try {
@@ -306,10 +334,18 @@ public class RunRemoteCommand implements Callable<Integer> {
         .map(JoshJobBuilder::build)
         .toList();
 
+    // When explicit indices are given, they (not --replicates) determine how many replicates run.
+    int effectiveReplicates = parsedReplicateIndices.map(List::size).orElse(replicates);
+
     // Report grid search information
-    output.printInfo("Grid search will execute " + jobs.size() + " job combination(s) "
-        + "with " + replicates + " replicate(s) each");
-    output.printInfo("Total simulations to run: " + (jobs.size() * replicates));
+    if (parsedReplicateIndices.isPresent()) {
+      output.printInfo("Grid search will execute " + jobs.size() + " job combination(s) "
+          + "with replicate indices " + ReplicateSelection.toCsv(parsedReplicateIndices.get()));
+    } else {
+      output.printInfo("Grid search will execute " + jobs.size() + " job combination(s) "
+          + "with " + replicates + " replicate(s) each");
+    }
+    output.printInfo("Total simulations to run: " + (jobs.size() * effectiveReplicates));
     output.printInfo("");
 
     // Read Josh simulation code
@@ -333,7 +369,7 @@ public class RunRemoteCommand implements Callable<Integer> {
       // Create a new progress calculator for THIS job combination
       // This ensures replicate numbers are 1/N for each simulation, not cumulative
       ProgressCalculator progressCalculator = new ProgressCalculator(
-          metadata.getTotalSteps(), replicates
+          metadata.getTotalSteps(), effectiveReplicates
       );
 
       // Create execution context for this job combination
@@ -352,6 +388,7 @@ public class RunRemoteCommand implements Callable<Integer> {
           .withMinioOptions(minioOptions)
           .withMaxConcurrentWorkers(concurrentWorkers)
           .withReplicateNumber(replicateStart)
+          .withReplicateIndices(parsedReplicateIndices)
           .withEnableProfiler(enableProfiler)
           .build();
 

--- a/src/main/java/org/joshsim/command/RunUtil.java
+++ b/src/main/java/org/joshsim/command/RunUtil.java
@@ -51,6 +51,7 @@ import org.joshsim.util.MinioOptions;
 import org.joshsim.util.OutputOptions;
 import org.joshsim.util.ProgressCalculator;
 import org.joshsim.util.ProgressUpdate;
+import org.joshsim.util.ReplicateSelection;
 import org.joshsim.util.SharedRandom;
 import org.joshsim.util.SimulationMetadata;
 import org.joshsim.util.SimulationMetadataExtractor;
@@ -83,6 +84,7 @@ public final class RunUtil {
     private final int replicates;
     private final Integer replicateIndex;
     private final int replicateStart;
+    private final Optional<List<Integer>> replicateIndices;
     private final boolean serialPatches;
     private final Optional<Long> seed;
     private final boolean useFloat64;
@@ -100,6 +102,7 @@ public final class RunUtil {
       this.replicates = builder.replicates;
       this.replicateIndex = builder.replicateIndex;
       this.replicateStart = builder.replicateStart;
+      this.replicateIndices = builder.replicateIndices;
       this.serialPatches = builder.serialPatches;
       this.seed = builder.seed;
       this.useFloat64 = builder.useFloat64;
@@ -132,6 +135,7 @@ public final class RunUtil {
       private int replicates = 1;
       private Integer replicateIndex = null;
       private int replicateStart = 0;
+      private Optional<List<Integer>> replicateIndices = Optional.empty();
       private boolean serialPatches = false;
       private Optional<Long> seed = Optional.empty();
       private boolean useFloat64 = false;
@@ -179,6 +183,21 @@ public final class RunUtil {
        */
       public Builder replicateStart(int value) {
         this.replicateStart = value;
+        return this;
+      }
+
+      /**
+       * Sets an explicit, ordered list of replicate indices to run, or empty to use the
+       * {@code [start, start+count)} range (default empty). When present, exactly these indices
+       * are run and the replicate count is {@code indices.size()}. Subsumes
+       * {@link #replicateIndex(Integer)} and {@link #replicateStart(int)}; the list is expected to
+       * already be validated (non-negative, unique).
+       *
+       * @param value the explicit replicate indices, or empty for the range
+       * @return this builder
+       */
+      public Builder replicateIndices(Optional<List<Integer>> value) {
+        this.replicateIndices = value;
         return this;
       }
 
@@ -423,8 +442,16 @@ public final class RunUtil {
       boolean serialPatches) {
     final EngineGeometryFactory geometryFactory = new GridGeometryFactory();
 
-    // When --replicate-index is set, run exactly one replicate at that index.
-    int effectiveReplicates = opts.replicateIndex != null ? 1 : opts.replicates;
+    // Resolve how many replicates each job runs: a single --replicate-index, an explicit
+    // --replicate-indices list, or the --replicates count.
+    int effectiveReplicates;
+    if (opts.replicateIndex != null) {
+      effectiveReplicates = 1;
+    } else if (opts.replicateIndices.isPresent()) {
+      effectiveReplicates = opts.replicateIndices.get().size();
+    } else {
+      effectiveReplicates = opts.replicates;
+    }
 
     List<JoshJob> jobs = buildJobs(opts, effectiveReplicates);
     reportPlannedRun(opts, jobs, effectiveReplicates, output);
@@ -445,7 +472,8 @@ public final class RunUtil {
     }
 
     configureCompatibilityLayer(opts);
-    ProgressCalculator progressCalculator = createProgressCalculator(opts, jobs, output);
+    ProgressCalculator progressCalculator =
+        createProgressCalculator(opts, jobs, effectiveReplicates, output);
     GridSpatialInfo spatialInfo = extractSpatialInfo(program, opts.simulation, valueFactory);
 
     ExecutionSummary summary = executeJobs(opts, jobs, valueFactory, geometryFactory, program,
@@ -479,6 +507,10 @@ public final class RunUtil {
       int effectiveReplicates, OutputOptions output) {
     if (opts.replicateIndex != null) {
       output.printInfo("Running replicate index " + opts.replicateIndex
+          + " across " + jobs.size() + " job combination(s)");
+    } else if (opts.replicateIndices.isPresent()) {
+      output.printInfo("Running replicate indices "
+          + ReplicateSelection.toCsv(opts.replicateIndices.get())
           + " across " + jobs.size() + " job combination(s)");
     } else {
       output.printInfo("Grid search will execute " + jobs.size() + " job combination(s) "
@@ -545,7 +577,7 @@ public final class RunUtil {
    * Builds the progress calculator, falling back to default metadata if extraction fails.
    */
   private static ProgressCalculator createProgressCalculator(RunOptions opts, List<JoshJob> jobs,
-      OutputOptions output) {
+      int effectiveReplicates, OutputOptions output) {
     SimulationMetadata metadata;
     try {
       metadata = SimulationMetadataExtractor.extractMetadata(opts.scriptFile, opts.simulation);
@@ -556,7 +588,7 @@ public final class RunUtil {
     }
     return new ProgressCalculator(
         metadata.getTotalSteps(),
-        jobs.size() * opts.replicates // Total simulations = jobs × replicates
+        jobs.size() * effectiveReplicates // Total simulations = jobs × replicates
     );
   }
 
@@ -595,14 +627,17 @@ public final class RunUtil {
         inputStrategy = new JvmMappedInputGetter(currentJob.getFilePaths());
       }
 
-      int startReplicate = opts.replicateIndex != null ? opts.replicateIndex : opts.replicateStart;
-      int endReplicate = opts.replicateIndex != null
-          ? opts.replicateIndex + 1 : opts.replicateStart + currentJob.getReplicates();
+      // Determine the absolute replicate indices this job runs: a single --replicate-index, an
+      // explicit --replicate-indices list, or the [start, start+count) range.
+      List<Integer> replicateIndices;
+      if (opts.replicateIndex != null) {
+        replicateIndices = List.of(opts.replicateIndex);
+      } else {
+        replicateIndices = ReplicateSelection.resolve(opts.replicateIndices,
+            opts.replicateStart, currentJob.getReplicates());
+      }
 
-      for (int currentReplicate = startReplicate; currentReplicate < endReplicate;
-           currentReplicate++) {
-        int effectiveReplicate = opts.replicateIndex != null ? opts.replicateIndex
-            : currentReplicate;
+      for (int effectiveReplicate : replicateIndices) {
         totalReplicateCount++;
 
         if (totalReplicateCount > 1) {

--- a/src/main/java/org/joshsim/mcp/Backend.java
+++ b/src/main/java/org/joshsim/mcp/Backend.java
@@ -12,6 +12,7 @@
 package org.joshsim.mcp;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -183,6 +184,9 @@ public interface Backend {
    * @param script path to the {@code .josh} script file
    * @param simulation name of the simulation to run
    * @param replicates number of replicates to run (default 1)
+   * @param replicateIndices an explicit, ordered list of replicate indices to run (e.g. 3,7,8),
+   *     or empty to run the {@code [0, replicates)} range; mutually exclusive with a
+   *     {@code replicates} greater than 1
    * @param serialPatches if true, patches are processed serially
    * @param seed optional random seed for reproducibility
    * @param dataFiles map of external data resource names (as referenced by {@code external
@@ -194,6 +198,7 @@ public interface Backend {
       Path script,
       String simulation,
       int replicates,
+      Optional<List<Integer>> replicateIndices,
       boolean serialPatches,
       Optional<Long> seed,
       Map<String, Path> dataFiles

--- a/src/main/java/org/joshsim/mcp/LocalBackend.java
+++ b/src/main/java/org/joshsim/mcp/LocalBackend.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -158,6 +159,7 @@ public class LocalBackend implements Backend {
       Path script,
       String simulation,
       int replicates,
+      Optional<List<Integer>> replicateIndices,
       boolean serialPatches,
       Optional<Long> seed,
       Map<String, Path> dataFiles
@@ -187,6 +189,7 @@ public class LocalBackend implements Backend {
     //     history) while still letting models that export to MinIO work over MCP.
     RunUtil.RunOptions options = RunUtil.RunOptions.builder(script.toFile(), simulation)
         .replicates(replicates)
+        .replicateIndices(replicateIndices)
         .serialPatches(serialPatches)
         .seed(seed)
         .dataFiles(dataSpec)

--- a/src/main/java/org/joshsim/mcp/tool/local/RunSimulationTool.java
+++ b/src/main/java/org/joshsim/mcp/tool/local/RunSimulationTool.java
@@ -16,12 +16,15 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.joshsim.mcp.Backend;
 import org.joshsim.mcp.JoshPaths;
 import org.joshsim.mcp.tool.local.ToolHandlers.MissingArgument;
+import org.joshsim.util.ReplicateSelection;
 
 /**
  * Registers the {@code run_simulation} MCP tool.
@@ -89,6 +92,17 @@ public final class RunSimulationTool {
       replicates = repNum.intValue();
     }
 
+    Optional<List<Integer>> replicateIndices;
+    try {
+      replicateIndices = parseReplicateIndices(args.get("replicateIndices"));
+    } catch (IllegalArgumentException e) {
+      return ToolHandlers.errorResult(e.getMessage());
+    }
+    if (replicateIndices.isPresent() && replicates > 1) {
+      return ToolHandlers.errorResult(
+          "replicateIndices and replicates (> 1) are mutually exclusive");
+    }
+
     boolean serialPatches = false;
     Object serialObj = args.get("serialPatches");
     if (serialObj instanceof Boolean serialBool) {
@@ -103,12 +117,49 @@ public final class RunSimulationTool {
 
     Path script = JoshPaths.resolve(scriptArg);
     Backend.RunSimulationResult result = backend.runSimulation(
-        script, simArg, replicates, serialPatches, seed, dataFiles
+        script, simArg, replicates, replicateIndices, serialPatches, seed, dataFiles
     );
     return CallToolResult.builder()
         .addTextContent(result.getMessage())
         .isError(!result.isSuccess())
         .build();
+  }
+
+  /**
+   * Parses the optional {@code replicateIndices} argument into an ordered list of replicate
+   * indices. Accepts either a JSON array of integers (e.g. {@code [3, 7, 8]}) or a comma-separated
+   * string (e.g. {@code "3,7,8"}). Returns empty when the argument is absent.
+   *
+   * @param indicesObj the raw {@code replicateIndices} argument value, or null
+   * @return the ordered, validated indices, or empty if none were given
+   * @throws IllegalArgumentException if the value has the wrong shape, or an index is
+   *     non-integral, negative, or repeated
+   */
+  static Optional<List<Integer>> parseReplicateIndices(Object indicesObj) {
+    if (indicesObj == null) {
+      return Optional.empty();
+    }
+    if (indicesObj instanceof String indicesStr) {
+      return ReplicateSelection.parse(indicesStr);
+    }
+    if (indicesObj instanceof List<?> rawList) {
+      if (rawList.isEmpty()) {
+        return Optional.empty();
+      }
+      List<Integer> indices = new ArrayList<>(rawList.size());
+      for (Object element : rawList) {
+        if (element instanceof Number num && num.doubleValue() == num.longValue()) {
+          indices.add((int) num.longValue());
+        } else {
+          throw new IllegalArgumentException(
+              "replicateIndices must contain only integers, got: " + element);
+        }
+      }
+      ReplicateSelection.validate(indices);
+      return Optional.of(indices);
+    }
+    throw new IllegalArgumentException(
+        "replicateIndices must be an array of integers or a comma-separated string");
   }
 
   /**

--- a/src/main/java/org/joshsim/pipeline/remote/RunRemoteContext.java
+++ b/src/main/java/org/joshsim/pipeline/remote/RunRemoteContext.java
@@ -12,11 +12,14 @@ package org.joshsim.pipeline.remote;
 
 import java.io.File;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.joshsim.pipeline.job.JoshJob;
 import org.joshsim.util.MinioOptions;
 import org.joshsim.util.OutputOptions;
 import org.joshsim.util.ProgressCalculator;
+import org.joshsim.util.ReplicateSelection;
 import org.joshsim.util.SimulationMetadata;
 
 /**
@@ -56,11 +59,58 @@ public class RunRemoteContext {
   // Execution parameters for local leader mode
   private final int maxConcurrentWorkers;
 
+  // Resolved, ordered absolute replicate indices to compute
+  private final List<Integer> replicateIndices;
+
   // Profiler flag
   private final boolean enableProfiler;
 
   /**
    * Creates a new RunRemoteContext with all necessary parameters.
+   *
+   * @param file The Josh simulation file
+   * @param simulation The simulation name to execute
+   * @param useFloat64 Whether to use double precision instead of BigDecimal
+   * @param endpointUri The validated endpoint URI
+   * @param apiKey The API key for authentication
+   * @param job The JoshJob containing file mappings and replicate configuration
+   * @param joshCode The Josh simulation code content
+   * @param externalDataSerialized The serialized external data
+   * @param metadata The simulation metadata for progress tracking
+   * @param progressCalculator The progress calculator instance
+   * @param outputOptions The output options for logging
+   * @param minioOptions The MinIO options for cloud storage
+   * @param maxConcurrentWorkers Maximum concurrent workers for local leader mode
+   * @param replicateIndices The resolved, ordered absolute replicate indices to compute
+   * @param enableProfiler Whether to enable per-request profiling
+   */
+  public RunRemoteContext(File file, String simulation, boolean useFloat64,
+      URI endpointUri, String apiKey, JoshJob job,
+      String joshCode, String externalDataSerialized,
+      SimulationMetadata metadata, ProgressCalculator progressCalculator,
+      OutputOptions outputOptions, MinioOptions minioOptions,
+      int maxConcurrentWorkers, List<Integer> replicateIndices, boolean enableProfiler) {
+    this.file = file;
+    this.simulation = simulation;
+    this.useFloat64 = useFloat64;
+    this.endpointUri = endpointUri;
+    this.apiKey = apiKey;
+    this.job = job;
+    this.joshCode = joshCode;
+    this.externalDataSerialized = externalDataSerialized;
+    this.metadata = metadata;
+    this.progressCalculator = progressCalculator;
+    this.outputOptions = outputOptions;
+    this.minioOptions = minioOptions;
+    this.maxConcurrentWorkers = maxConcurrentWorkers;
+    this.replicateIndices = replicateIndices;
+    this.enableProfiler = enableProfiler;
+  }
+
+  /**
+   * Creates a context whose replicate selection is the default dense range
+   * {@code [0, job.getReplicates())}. Convenience overload for callers that do not set an explicit
+   * index list or start offset; behaves exactly as before that selection existed.
    *
    * @param file The Josh simulation file
    * @param simulation The simulation name to execute
@@ -83,20 +133,9 @@ public class RunRemoteContext {
       SimulationMetadata metadata, ProgressCalculator progressCalculator,
       OutputOptions outputOptions, MinioOptions minioOptions,
       int maxConcurrentWorkers, boolean enableProfiler) {
-    this.file = file;
-    this.simulation = simulation;
-    this.useFloat64 = useFloat64;
-    this.endpointUri = endpointUri;
-    this.apiKey = apiKey;
-    this.job = job;
-    this.joshCode = joshCode;
-    this.externalDataSerialized = externalDataSerialized;
-    this.metadata = metadata;
-    this.progressCalculator = progressCalculator;
-    this.outputOptions = outputOptions;
-    this.minioOptions = minioOptions;
-    this.maxConcurrentWorkers = maxConcurrentWorkers;
-    this.enableProfiler = enableProfiler;
+    this(file, simulation, useFloat64, endpointUri, apiKey, job, joshCode, externalDataSerialized,
+        metadata, progressCalculator, outputOptions, minioOptions, maxConcurrentWorkers,
+        ReplicateSelection.resolve(Optional.empty(), 0, job.getReplicates()), enableProfiler);
   }
 
   /**
@@ -118,21 +157,31 @@ public class RunRemoteContext {
   }
 
   /**
-   * Gets the replicate number for this execution.
+   * Gets the first (lowest-position) replicate index, used as the representative index when
+   * building the initial template/output layer.
    *
-   * @return The replicate number (always 0 for job-based execution)
+   * @return The first resolved replicate index, or 0 if none
    */
   public int getReplicateNumber() {
-    return 0;
+    return replicateIndices.isEmpty() ? 0 : replicateIndices.get(0);
+  }
+
+  /**
+   * Gets the resolved, ordered list of absolute replicate indices to compute.
+   *
+   * @return The replicate indices (the {@code [0, count)} range by default, or an explicit set)
+   */
+  public List<Integer> getReplicateIndices() {
+    return replicateIndices;
   }
 
   /**
    * Gets the number of replicates to run.
    *
-   * @return The number of replicates from the job
+   * @return The number of resolved replicate indices
    */
   public int getReplicates() {
-    return job.getReplicates();
+    return replicateIndices.size();
   }
 
   /**

--- a/src/main/java/org/joshsim/pipeline/remote/RunRemoteContextBuilder.java
+++ b/src/main/java/org/joshsim/pipeline/remote/RunRemoteContextBuilder.java
@@ -12,11 +12,13 @@ package org.joshsim.pipeline.remote;
 
 import java.io.File;
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 import org.joshsim.pipeline.job.JoshJob;
 import org.joshsim.util.MinioOptions;
 import org.joshsim.util.OutputOptions;
 import org.joshsim.util.ProgressCalculator;
+import org.joshsim.util.ReplicateSelection;
 import org.joshsim.util.SimulationMetadata;
 
 /**
@@ -55,6 +57,7 @@ public class RunRemoteContextBuilder {
   // Execution parameters for local leader mode
   private int maxConcurrentWorkers = 10;
   private int replicateNumber = 0;
+  private Optional<List<Integer>> replicateIndices = Optional.empty();
 
   private boolean enableProfiler = false;
 
@@ -203,13 +206,27 @@ public class RunRemoteContextBuilder {
   }
 
   /**
-   * Set the starting replicate number offset.
+   * Set the starting replicate number offset. Used only when no explicit index list is set: the
+   * run computes the half-open range {@code [replicateNumber, replicateNumber + count)}.
    *
    * @param replicateNumber Starting replicate number offset
    * @return This builder instance for chaining
    */
   public RunRemoteContextBuilder withReplicateNumber(int replicateNumber) {
     this.replicateNumber = replicateNumber;
+    return this;
+  }
+
+  /**
+   * Set an explicit, ordered list of absolute replicate indices to compute (e.g. 3,7,8), or empty
+   * to use the {@code [start, start+count)} range. When present, these indices are computed
+   * exactly and supersede the {@link #withReplicateNumber(int)} offset.
+   *
+   * @param replicateIndices The explicit replicate indices, or empty for the range
+   * @return This builder instance for chaining
+   */
+  public RunRemoteContextBuilder withReplicateIndices(Optional<List<Integer>> replicateIndices) {
+    this.replicateIndices = replicateIndices;
     return this;
   }
 
@@ -233,6 +250,13 @@ public class RunRemoteContextBuilder {
   public RunRemoteContext build() {
     validateRequiredParameters();
 
+    // Resolve the absolute replicate indices: an explicit list when given, otherwise the
+    // [replicateNumber, replicateNumber + count) range. Threading the resolved list here is also
+    // what carries the replicate-start offset into the context — previously the offset was stored
+    // but dropped, so getReplicateNumber() always returned 0.
+    List<Integer> resolvedIndices = ReplicateSelection.resolve(
+        replicateIndices, replicateNumber, job.get().getReplicates());
+
     return new RunRemoteContext(
         file.get(), simulation.get(), useFloat64,
         endpointUri.get(), apiKey.get(), job.get(),
@@ -240,6 +264,7 @@ public class RunRemoteContextBuilder {
         metadata.get(), progressCalculator.get(),
         outputOptions.get(), minioOptions.get(),
         maxConcurrentWorkers,
+        resolvedIndices,
         enableProfiler
     );
   }

--- a/src/main/java/org/joshsim/pipeline/remote/RunRemoteLocalLeaderStrategy.java
+++ b/src/main/java/org/joshsim/pipeline/remote/RunRemoteLocalLeaderStrategy.java
@@ -182,9 +182,9 @@ public class RunRemoteLocalLeaderStrategy implements RunRemoteStrategy {
   /**
    * Creates worker tasks for parallel execution.
    *
-   * <p>Creates multiple tasks based on the replicate count specified in the context.
-   * Each task contains all the parameters needed for a worker to execute one replicate
-   * with proper replicate numbering using the offset from replicateNumber.</p>
+   * <p>Creates one task per resolved replicate index in the context. Each task carries its
+   * absolute replicate index, so the index range/offset or an explicit non-contiguous set
+   * (e.g. 3,7,8) is honored identically.</p>
    *
    * @param context The execution context
    * @return List of worker tasks to execute
@@ -193,14 +193,14 @@ public class RunRemoteLocalLeaderStrategy implements RunRemoteStrategy {
     List<WorkerTask> tasks = new ArrayList<>();
     boolean favorBigDecimal = !context.isUseFloat64();
 
-    for (int i = 0; i < context.getReplicates(); i++) {
+    for (int replicateIndex : context.getReplicateIndices()) {
       WorkerTask task = new WorkerTask(
           context.getJoshCode(),
           context.getSimulation(),
           context.getApiKey(),
           context.getExternalDataSerialized(),
           favorBigDecimal,
-          context.getReplicateNumber() + i,  // Offset by replicateNumber
+          replicateIndex,
           "",  // No output filtering for local leader strategy (export all steps)
           context.isEnableProfiler()
       );

--- a/src/main/java/org/joshsim/pipeline/remote/RunRemoteOffloadLeaderStrategy.java
+++ b/src/main/java/org/joshsim/pipeline/remote/RunRemoteOffloadLeaderStrategy.java
@@ -24,6 +24,7 @@ import org.joshsim.command.RemoteResponseHandler;
 import org.joshsim.lang.io.ExportFacadeFactory;
 import org.joshsim.lang.io.InputOutputLayer;
 import org.joshsim.lang.io.JvmInputOutputLayerBuilder;
+import org.joshsim.util.ReplicateSelection;
 
 /**
  * Remote execution strategy that offloads leadership to the remote server.
@@ -120,8 +121,12 @@ public class RunRemoteOffloadLeaderStrategy implements RunRemoteStrategy {
     formData.put("externalData", context.getExternalDataSerialized());
     formData.put("favorBigDecimal", String.valueOf(!context.isUseFloat64()));
     formData.put("enableProfiler", String.valueOf(context.isEnableProfiler()));
-    if (context.getReplicateNumber() != 0) {
-      formData.put("replicateStart", String.valueOf(context.getReplicateNumber()));
+    // Only send explicit indices when the selection is not the default [0, count) range, so a
+    // plain run produces a byte-for-byte identical request. This single field carries both a
+    // replicate-start offset (a contiguous range) and an arbitrary non-contiguous set.
+    if (!ReplicateSelection.isDefaultRange(context.getReplicateIndices())) {
+      formData.put("replicateIndices",
+          ReplicateSelection.toCsv(context.getReplicateIndices()));
     }
 
     // URL encode the form data

--- a/src/main/java/org/joshsim/pipeline/target/BatchJobStrategy.java
+++ b/src/main/java/org/joshsim/pipeline/target/BatchJobStrategy.java
@@ -6,6 +6,7 @@
 
 package org.joshsim.pipeline.target;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.joshsim.util.MinioHandler;
@@ -71,18 +72,24 @@ public class BatchJobStrategy {
    * @param customTags Custom template parameters resolvable as {@code {key}} placeholders
    *     in {@code exportFiles} paths. Empty map means none.
    * @param replicateStart Starting replicate index for the half-open range
-   *     {@code [start, start+replicates)}. {@code 0} preserves prior behavior.
+   *     {@code [start, start+replicates)}. {@code 0} preserves prior behavior. Ignored when
+   *     {@code replicateIndices} is non-empty.
+   * @param replicateIndices Explicit, possibly non-contiguous replicate indices to run; empty
+   *     selects the range and preserves prior behavior.
    * @return The final job status.
    * @throws Exception If dispatch or polling fails.
    */
   public JobStatus execute(String minioPrefix, String simulation, int replicates,
-      Map<String, String> customTags, int replicateStart) throws Exception {
+      Map<String, String> customTags, int replicateStart, List<Integer> replicateIndices)
+      throws Exception {
     String jobId = UUID.randomUUID().toString();
     String prefix = MinioHandler.normalizePrefix(minioPrefix);
 
-    output.printInfo("Dispatching to target (" + replicates + " replicates) against "
+    int effectiveReplicates = replicateIndices.isEmpty() ? replicates : replicateIndices.size();
+    output.printInfo("Dispatching to target (" + effectiveReplicates + " replicates) against "
         + prefix + "...");
-    target.dispatch(jobId, prefix, simulation, replicates, customTags, replicateStart);
+    target.dispatch(jobId, prefix, simulation, replicates, customTags, replicateStart,
+        replicateIndices);
     output.printInfo("Dispatched. Polling for completion...");
 
     return pollUntilTerminal(jobId);
@@ -96,17 +103,21 @@ public class BatchJobStrategy {
    * @param replicates Number of replicates to execute.
    * @param customTags Custom template parameters; same semantics as {@link #execute}.
    * @param replicateStart Starting replicate index; same semantics as {@link #execute}.
+   * @param replicateIndices Explicit replicate indices; same semantics as {@link #execute}.
    * @return The jobId for manual status tracking.
    * @throws Exception If dispatch fails.
    */
   public String executeNoWait(String minioPrefix, String simulation, int replicates,
-      Map<String, String> customTags, int replicateStart) throws Exception {
+      Map<String, String> customTags, int replicateStart, List<Integer> replicateIndices)
+      throws Exception {
     String jobId = UUID.randomUUID().toString();
     String prefix = MinioHandler.normalizePrefix(minioPrefix);
 
-    output.printInfo("Dispatching to target (" + replicates + " replicates) against "
+    int effectiveReplicates = replicateIndices.isEmpty() ? replicates : replicateIndices.size();
+    output.printInfo("Dispatching to target (" + effectiveReplicates + " replicates) against "
         + prefix + "...");
-    target.dispatch(jobId, prefix, simulation, replicates, customTags, replicateStart);
+    target.dispatch(jobId, prefix, simulation, replicates, customTags, replicateStart,
+        replicateIndices);
     output.printInfo("Dispatched. Status path: batch-status/" + jobId + "/status.json");
 
     return jobId;

--- a/src/main/java/org/joshsim/pipeline/target/HttpBatchTarget.java
+++ b/src/main/java/org/joshsim/pipeline/target/HttpBatchTarget.java
@@ -14,8 +14,10 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.joshsim.util.ReplicateSelection;
 
 
 /**
@@ -74,7 +76,8 @@ public class HttpBatchTarget implements RemoteBatchTarget {
 
   @Override
   public void dispatch(String jobId, String minioPrefix, String simulation, int replicates,
-      Map<String, String> customTags, int replicateStart) throws Exception {
+      Map<String, String> customTags, int replicateStart, List<Integer> replicateIndices)
+      throws Exception {
     Map<String, String> formFields = new LinkedHashMap<>();
     formFields.put("apiKey", apiKey);
     formFields.put("jobId", jobId);
@@ -86,7 +89,11 @@ public class HttpBatchTarget implements RemoteBatchTarget {
     if (customTags != null && !customTags.isEmpty()) {
       formFields.put("customTags", BatchArgUtil.encodeCustomTags(customTags));
     }
-    if (replicateStart != 0) {
+    // An explicit index list supersedes the start offset; only one is ever sent, and neither
+    // when the default range is used (byte-for-byte identical to prior requests).
+    if (!replicateIndices.isEmpty()) {
+      formFields.put("replicateIndices", ReplicateSelection.toCsv(replicateIndices));
+    } else if (replicateStart != 0) {
       formFields.put("replicateStart", String.valueOf(replicateStart));
     }
 

--- a/src/main/java/org/joshsim/pipeline/target/KubernetesTarget.java
+++ b/src/main/java/org/joshsim/pipeline/target/KubernetesTarget.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.joshsim.util.MinioOptions;
+import org.joshsim.util.ReplicateSelection;
 
 
 /**
@@ -93,11 +94,17 @@ public class KubernetesTarget implements RemoteBatchTarget {
       String simulation,
       int replicates,
       Map<String, String> customTags,
-      int replicateStart
+      int replicateStart,
+      List<Integer> replicateIndices
   ) throws Exception {
     String secretName = SECRET_NAME_PREFIX + jobId;
 
     createSecret(secretName);
+
+    // An explicit index list sets the pod count to that list's size; each pod maps its
+    // JOB_COMPLETION_INDEX to an absolute replicate index via JOSH_REPLICATE_INDICES. Otherwise
+    // the Indexed Job runs `replicates` pods over the [start, start+count) range.
+    int completions = replicateIndices.isEmpty() ? replicates : replicateIndices.size();
 
     JobBuilder jobBuilder = new JobBuilder()
         .withNewMetadata()
@@ -108,9 +115,9 @@ public class KubernetesTarget implements RemoteBatchTarget {
         .endMetadata()
         .withNewSpec()
             .withCompletionMode("Indexed")
-            .withCompletions(replicates)
+            .withCompletions(completions)
             .withParallelism(
-                Math.min(config.getParallelism(), replicates)
+                Math.min(config.getParallelism(), completions)
             )
             .withBackoffLimit(BACKOFF_LIMIT)
             .withActiveDeadlineSeconds(
@@ -131,7 +138,7 @@ public class KubernetesTarget implements RemoteBatchTarget {
                         .withEnv(buildEnvVars(
                             secretName, jobId,
                             minioPrefix, simulation,
-                            customTags, replicateStart
+                            customTags, replicateStart, replicateIndices
                         ))
                         .withCommand(
                             ENTRYPOINT,
@@ -215,7 +222,8 @@ public class KubernetesTarget implements RemoteBatchTarget {
       String minioPrefix,
       String simulation,
       Map<String, String> customTags,
-      int replicateStart
+      int replicateStart,
+      List<Integer> replicateIndices
   ) {
     List<EnvVar> envVars = new ArrayList<>();
     envVars.add(secretEnvVar(
@@ -238,7 +246,12 @@ public class KubernetesTarget implements RemoteBatchTarget {
           "JOSH_CUSTOM_TAGS", BatchArgUtil.encodeCustomTags(customTags)
       ));
     }
-    if (replicateStart != 0) {
+    if (!replicateIndices.isEmpty()) {
+      // Each pod reads its JOB_COMPLETION_INDEX-th entry from this list as its replicate index.
+      envVars.add(plainEnvVar(
+          "JOSH_REPLICATE_INDICES", ReplicateSelection.toCsv(replicateIndices)
+      ));
+    } else if (replicateStart != 0) {
       envVars.add(plainEnvVar(
           "JOSH_REPLICATE_OFFSET", String.valueOf(replicateStart)
       ));

--- a/src/main/java/org/joshsim/pipeline/target/RemoteBatchTarget.java
+++ b/src/main/java/org/joshsim/pipeline/target/RemoteBatchTarget.java
@@ -6,6 +6,7 @@
 
 package org.joshsim.pipeline.target;
 
+import java.util.List;
 import java.util.Map;
 
 
@@ -47,9 +48,15 @@ public interface RemoteBatchTarget {
    * @param replicateStart Starting replicate index for the half-open range
    *     {@code [start, start+replicates)}. Used for pool/resume workflows where
    *     indices need to be stable across re-dispatch. {@code 0} preserves prior
-   *     behavior.
+   *     behavior. Ignored when {@code replicateIndices} is non-empty.
+   * @param replicateIndices An explicit, possibly non-contiguous list of replicate indices to run
+   *     (e.g. {@code [3, 7, 8]}), used to backfill specific missing replicates. An empty list
+   *     selects the {@code [replicateStart, replicateStart+replicates)} range and preserves prior
+   *     behavior; when non-empty, these indices are run exactly and supersede
+   *     {@code replicates}/{@code replicateStart}.
    * @throws Exception If the dispatch fails (e.g., network error, auth failure).
    */
   void dispatch(String jobId, String minioPrefix, String simulation, int replicates,
-      Map<String, String> customTags, int replicateStart) throws Exception;
+      Map<String, String> customTags, int replicateStart, List<Integer> replicateIndices)
+      throws Exception;
 }

--- a/src/main/java/org/joshsim/util/ReplicateSelection.java
+++ b/src/main/java/org/joshsim/util/ReplicateSelection.java
@@ -1,0 +1,143 @@
+/**
+ * Shared resolver for which replicate indices a run should compute.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Single source of truth for turning replicate selection knobs into a concrete, ordered list of
+ * absolute replicate indices.
+ *
+ * <p>Every execution route (local {@code run}, {@code runRemote} local- and offload-leader, and
+ * {@code batchRemote} via Kubernetes or HTTP) ultimately needs the same thing: the ordered list of
+ * absolute replicate indices to compute. Historically each route expanded {@code (replicates,
+ * replicateStart)} into the half-open range {@code [start, start+count)} on its own. This utility
+ * centralizes that expansion and adds an explicit-index-list mode, so an arbitrary, possibly
+ * non-contiguous set (e.g. {@code 3,7,8}) can be dispatched identically everywhere.</p>
+ *
+ * <p>The explicit list is always optional: when absent, {@link #resolve} reproduces the existing
+ * range behavior byte-for-byte, so callers that never set indices are unaffected.</p>
+ */
+public final class ReplicateSelection {
+
+  private ReplicateSelection() {
+    // Prevent instantiation of utility class
+  }
+
+  /**
+   * Parses a comma-separated list of replicate indices.
+   *
+   * <p>Empty/null/whitespace-only input yields {@link Optional#empty()} (meaning "use the range").
+   * Otherwise the indices are returned in the order written, after validating that each is
+   * non-negative and that none repeats.</p>
+   *
+   * @param csv comma-separated indices (e.g. {@code "3,7,8"}), or null/empty for none
+   * @return the ordered indices, or empty if none were given
+   * @throws IllegalArgumentException if the format is invalid, an index is negative, or an index
+   *     repeats
+   */
+  public static Optional<List<Integer>> parse(String csv) {
+    if (csv == null || csv.trim().isEmpty()) {
+      return Optional.empty();
+    }
+    List<Integer> indices;
+    try {
+      indices = Arrays.stream(csv.split(","))
+          .map(String::trim)
+          .filter(s -> !s.isEmpty())
+          .map(Integer::parseInt)
+          .collect(Collectors.toList());
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid replicate-indices format: " + csv
+          + ". Expected comma-separated non-negative integers (e.g., '3,7,8')");
+    }
+    if (indices.isEmpty()) {
+      return Optional.empty();
+    }
+    validate(indices);
+    return Optional.of(indices);
+  }
+
+  /**
+   * Validates an explicit index list: every index must be non-negative and unique.
+   *
+   * @param indices the indices to validate
+   * @throws IllegalArgumentException if an index is negative or repeats
+   */
+  public static void validate(List<Integer> indices) {
+    for (int idx : indices) {
+      if (idx < 0) {
+        throw new IllegalArgumentException("replicate-indices must be >= 0, got: " + idx);
+      }
+    }
+    LinkedHashSet<Integer> seen = new LinkedHashSet<>(indices);
+    if (seen.size() != indices.size()) {
+      throw new IllegalArgumentException("replicate-indices must be unique, got: " + indices);
+    }
+  }
+
+  /**
+   * Resolves the ordered list of absolute replicate indices to compute.
+   *
+   * @param indices an explicit, already-validated index list, or empty to use the range
+   * @param start the starting index of the half-open range {@code [start, start+count)}, used only
+   *     when {@code indices} is empty
+   * @param count the number of replicates in the range, used only when {@code indices} is empty
+   * @return the ordered list of absolute indices
+   */
+  public static List<Integer> resolve(Optional<List<Integer>> indices, int start, int count) {
+    if (indices.isPresent()) {
+      return indices.get();
+    }
+    List<Integer> range = new ArrayList<>(Math.max(count, 0));
+    for (int i = 0; i < count; i++) {
+      range.add(start + i);
+    }
+    return range;
+  }
+
+  /**
+   * Reports whether an index list is the default dense range {@code [0, size)} — i.e.
+   * {@code 0, 1, ..., size-1} in order.
+   *
+   * <p>Wire formats use this to stay byte-for-byte compatible: when the selection is the default
+   * range, no explicit index field is emitted, exactly as before this option existed.</p>
+   *
+   * @param indices the indices to check
+   * @return true if {@code indices} equals {@code [0, indices.size())} in order
+   */
+  public static boolean isDefaultRange(List<Integer> indices) {
+    for (int i = 0; i < indices.size(); i++) {
+      if (indices.get(i) != i) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Renders an index list back to the canonical comma-separated wire form (e.g. {@code "3,7,8"}).
+   *
+   * @param indices the indices to render
+   * @return the comma-separated representation
+   */
+  public static String toCsv(List<Integer> indices) {
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < indices.size(); i++) {
+      if (i > 0) {
+        builder.append(',');
+      }
+      builder.append(indices.get(i));
+    }
+    return builder.toString();
+  }
+}

--- a/src/main/resources/org/joshsim/mcp/tool/local/run_simulation.schema.json
+++ b/src/main/resources/org/joshsim/mcp/tool/local/run_simulation.schema.json
@@ -15,6 +15,11 @@
       "default": 1,
       "minimum": 1
     },
+    "replicateIndices": {
+      "type": "array",
+      "description": "Explicit, possibly non-contiguous list of replicate indices to run (e.g. [3, 7, 8]) instead of the [0, replicates) range. Use to backfill specific missing replicates. Output filenames use the index in the {replicate} slot. Mutually exclusive with a replicates value greater than 1.",
+      "items": { "type": "integer", "minimum": 0 }
+    },
     "serialPatches": {
       "type": "boolean",
       "description": "If true, patches are processed one at a time rather than in parallel. Serial mode is slower but required for reproducibility when using a fixed seed. Automatically set to true when seed is supplied. Defaults to false.",

--- a/src/test/java/org/joshsim/command/RunCommandReplicatesTest.java
+++ b/src/test/java/org/joshsim/command/RunCommandReplicatesTest.java
@@ -284,6 +284,79 @@ class RunCommandReplicatesTest {
   }
 
   @Test
+  void testReplicateIndicesRunsExactNonContiguousSet(@TempDir Path tempDir) throws Exception {
+    Path joshFile = tempDir.resolve("test.josh");
+    Path outputFile = tempDir.resolve("output.csv");
+    Files.writeString(joshFile,
+        JoshTestFixtures.minimalSimulationWithExport(outputFile.toString()));
+
+    setupBasicFields(runCommand, joshFile);
+    setFieldValue(runCommand, "simulation", "TestSim");
+    setFieldValue(runCommand, "replicateIndices", "3,7,8");
+
+    Integer result = runCommand.call();
+
+    assertEquals(0, result, "--replicate-indices run should succeed");
+    assertTrue(Files.exists(outputFile), "Output CSV file should be created");
+
+    String csvContent = Files.readString(outputFile);
+    java.util.Set<String> replicateValues = csvContent.lines()
+        .skip(1)
+        .filter(line -> !line.isBlank())
+        .map(line -> {
+          int lastComma = line.lastIndexOf(',');
+          return lastComma >= 0 ? line.substring(lastComma + 1).trim() : "";
+        })
+        .collect(java.util.stream.Collectors.toSet());
+    assertEquals(java.util.Set.of("3", "7", "8"), replicateValues,
+        "CSV replicate column should be exactly {3,7,8}; values were: " + replicateValues);
+  }
+
+  @Test
+  void testReplicateIndicesMutexWithReplicates(@TempDir Path tempDir) throws Exception {
+    Path joshFile = tempDir.resolve("test.josh");
+    Files.writeString(joshFile, JoshTestFixtures.MINIMAL_SIMULATION_NO_EXPORT);
+
+    setupBasicFields(runCommand, joshFile);
+    setFieldValue(runCommand, "simulation", "TestSim");
+    setFieldValue(runCommand, "replicates", 5);
+    setFieldValue(runCommand, "replicateIndices", "3,7,8");
+
+    Integer result = runCommand.call();
+
+    assertEquals(1, result, "--replicate-indices with --replicates should fail validation");
+  }
+
+  @Test
+  void testReplicateIndicesMutexWithReplicateStart(@TempDir Path tempDir) throws Exception {
+    Path joshFile = tempDir.resolve("test.josh");
+    Files.writeString(joshFile, JoshTestFixtures.MINIMAL_SIMULATION_NO_EXPORT);
+
+    setupBasicFields(runCommand, joshFile);
+    setFieldValue(runCommand, "simulation", "TestSim");
+    setFieldValue(runCommand, "replicateStart", 5);
+    setFieldValue(runCommand, "replicateIndices", "3,7,8");
+
+    Integer result = runCommand.call();
+
+    assertEquals(1, result, "--replicate-indices with --replicate-start should fail validation");
+  }
+
+  @Test
+  void testReplicateIndicesRejectsDuplicates(@TempDir Path tempDir) throws Exception {
+    Path joshFile = tempDir.resolve("test.josh");
+    Files.writeString(joshFile, JoshTestFixtures.MINIMAL_SIMULATION_NO_EXPORT);
+
+    setupBasicFields(runCommand, joshFile);
+    setFieldValue(runCommand, "simulation", "TestSim");
+    setFieldValue(runCommand, "replicateIndices", "3,7,3");
+
+    Integer result = runCommand.call();
+
+    assertEquals(1, result, "Duplicate --replicate-indices should fail validation");
+  }
+
+  @Test
   void testSimulationNotFound(@TempDir Path tempDir) throws Exception {
     // Arrange - create real Josh file but request nonexistent simulation
     Path joshFile = tempDir.resolve("test.josh");

--- a/src/test/java/org/joshsim/mcp/LocalBackendTest.java
+++ b/src/test/java/org/joshsim/mcp/LocalBackendTest.java
@@ -232,7 +232,8 @@ public class LocalBackendTest {
         java.util.Map.of("bad;name.jshd", tempDir.resolve("x.jshd"));
 
     Backend.RunSimulationResult result =
-        backend.runSimulation(script, "TestSim", 1, false, Optional.empty(), data);
+        backend.runSimulation(script, "TestSim", 1, Optional.empty(), false, Optional.empty(),
+            data);
 
     assertFalse(result.isSuccess(), "Separator in data name should fail fast");
     assertTrue(result.getMessage().contains("bad;name.jshd"),
@@ -271,7 +272,7 @@ public class LocalBackendTest {
     Files.writeString(scriptFile, script);
 
     Backend.RunSimulationResult result = backend.runSimulation(
-        scriptFile, "TestSim", 1, false, Optional.empty(), java.util.Map.of());
+        scriptFile, "TestSim", 1, Optional.empty(), false, Optional.empty(), java.util.Map.of());
 
     assertFalse(result.isSuccess(), "Run with unwritable export target should fail");
     assertNotEquals("Simulation failed: Worker thread failed", result.getMessage(),

--- a/src/test/java/org/joshsim/mcp/tool/local/RunSimulationToolTest.java
+++ b/src/test/java/org/joshsim/mcp/tool/local/RunSimulationToolTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -67,5 +68,34 @@ class RunSimulationToolTest {
     Map<String, Object> data = new HashMap<>();
     data.put("temperature.jshd", "  ");
     assertThrows(IllegalArgumentException.class, () -> RunSimulationTool.parseDataFiles(data));
+  }
+
+  @Test
+  void absentReplicateIndicesYieldsEmpty() {
+    assertTrue(RunSimulationTool.parseReplicateIndices(null).isEmpty());
+  }
+
+  @Test
+  void parsesReplicateIndicesFromJsonArray() {
+    assertEquals(List.of(3, 7, 8),
+        RunSimulationTool.parseReplicateIndices(List.of(3, 7, 8)).orElseThrow());
+  }
+
+  @Test
+  void parsesReplicateIndicesFromCsvString() {
+    assertEquals(List.of(3, 7, 8),
+        RunSimulationTool.parseReplicateIndices("3,7,8").orElseThrow());
+  }
+
+  @Test
+  void rejectsNonIntegerReplicateIndices() {
+    assertThrows(IllegalArgumentException.class,
+        () -> RunSimulationTool.parseReplicateIndices(List.of(3, 7.5, 8)));
+  }
+
+  @Test
+  void rejectsDuplicateReplicateIndices() {
+    assertThrows(IllegalArgumentException.class,
+        () -> RunSimulationTool.parseReplicateIndices(List.of(3, 7, 3)));
   }
 }

--- a/src/test/java/org/joshsim/pipeline/remote/RunRemoteContextBuilderTest.java
+++ b/src/test/java/org/joshsim/pipeline/remote/RunRemoteContextBuilderTest.java
@@ -123,6 +123,52 @@ public class RunRemoteContextBuilderTest {
   }
 
   @Test
+  void testReplicateStartResolvesToOffsetRange() throws Exception {
+    // Regression: withReplicateNumber used to be stored but dropped, so getReplicateNumber()
+    // always returned 0. The offset must now actually reach the context.
+    RunRemoteContext context = new RunRemoteContextBuilder()
+        .withFile(testFile)
+        .withSimulation("TestSim")
+        .withEndpointUri(testEndpointUri)
+        .withApiKey("test-api-key")
+        .withJob(testJob) // 3 replicates
+        .withJoshCode("start simulation TestSim end simulation")
+        .withExternalDataSerialized("serialized-data")
+        .withMetadata(testMetadata)
+        .withProgressCalculator(testProgressCalculator)
+        .withOutputOptions(testOutputOptions)
+        .withMinioOptions(testMinioOptions)
+        .withReplicateNumber(5)
+        .build();
+
+    assertEquals(java.util.List.of(5, 6, 7), context.getReplicateIndices());
+    assertEquals(5, context.getReplicateNumber());
+    assertEquals(3, context.getReplicates());
+  }
+
+  @Test
+  void testExplicitReplicateIndicesSupersedeRange() throws Exception {
+    RunRemoteContext context = new RunRemoteContextBuilder()
+        .withFile(testFile)
+        .withSimulation("TestSim")
+        .withEndpointUri(testEndpointUri)
+        .withApiKey("test-api-key")
+        .withJob(testJob) // 3 replicates, ignored when indices are explicit
+        .withJoshCode("start simulation TestSim end simulation")
+        .withExternalDataSerialized("serialized-data")
+        .withMetadata(testMetadata)
+        .withProgressCalculator(testProgressCalculator)
+        .withOutputOptions(testOutputOptions)
+        .withMinioOptions(testMinioOptions)
+        .withReplicateIndices(java.util.Optional.of(java.util.List.of(3, 7, 8)))
+        .build();
+
+    assertEquals(java.util.List.of(3, 7, 8), context.getReplicateIndices());
+    assertEquals(3, context.getReplicates());
+    assertEquals(3, context.getReplicateNumber()); // first index
+  }
+
+  @Test
   void testMissingJobThrowsException() {
     Exception exception = assertThrows(IllegalStateException.class, () -> {
       builder

--- a/src/test/java/org/joshsim/pipeline/target/BatchJobStrategyTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/BatchJobStrategyTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Map;
 import org.joshsim.util.OutputOptions;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,11 +53,11 @@ class BatchJobStrategyTest {
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
     JobStatus result = strategy.execute(
-        "batch-jobs/foo/inputs/", "Test", 1, Map.of(), 0);
+        "batch-jobs/foo/inputs/", "Test", 1, Map.of(), 0, List.of());
 
     assertEquals(JobStatus.State.COMPLETE, result.getState());
     verify(target).dispatch(
-        anyString(), eq("batch-jobs/foo/inputs/"), eq("Test"), eq(1), anyMap(), eq(0));
+        anyString(), eq("batch-jobs/foo/inputs/"), eq("Test"), eq(1), anyMap(), eq(0), anyList());
   }
 
   @Test
@@ -64,11 +66,11 @@ class BatchJobStrategyTest {
 
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    strategy.execute("batch-jobs/foo/inputs", "Test", 1, Map.of(), 0);
+    strategy.execute("batch-jobs/foo/inputs", "Test", 1, Map.of(), 0, List.of());
 
     ArgumentCaptor<String> prefixCaptor = ArgumentCaptor.forClass(String.class);
     verify(target).dispatch(
-        anyString(), prefixCaptor.capture(), eq("Test"), eq(1), anyMap(), eq(0));
+        anyString(), prefixCaptor.capture(), eq("Test"), eq(1), anyMap(), eq(0), anyList());
     assertEquals("batch-jobs/foo/inputs/", prefixCaptor.getValue());
   }
 
@@ -79,10 +81,10 @@ class BatchJobStrategyTest {
 
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
-    strategy.execute("batch-jobs/foo/inputs/", "Main", 10, Map.of(), 0);
+    strategy.execute("batch-jobs/foo/inputs/", "Main", 10, Map.of(), 0, List.of());
 
     verify(target).dispatch(
-        anyString(), anyString(), eq("Main"), eq(10), anyMap(), eq(0));
+        anyString(), anyString(), eq("Main"), eq(10), anyMap(), eq(0), anyList());
   }
 
   @Test
@@ -93,7 +95,7 @@ class BatchJobStrategyTest {
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
     JobStatus result = strategy.execute(
-        "batch-jobs/foo/inputs/", "BadSim", 1, Map.of(), 0);
+        "batch-jobs/foo/inputs/", "BadSim", 1, Map.of(), 0, List.of());
 
     assertEquals(JobStatus.State.ERROR, result.getState());
     assertEquals("Simulation not found", result.getMessage().get());
@@ -106,7 +108,7 @@ class BatchJobStrategyTest {
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 50);
 
     JobStatus result = strategy.execute(
-        "batch-jobs/foo/inputs/", "SlowSim", 1, Map.of(), 0);
+        "batch-jobs/foo/inputs/", "SlowSim", 1, Map.of(), 0, List.of());
 
     assertEquals(JobStatus.State.ERROR, result.getState());
     assertTrue(result.getMessage().get().contains("timed out"));
@@ -117,11 +119,11 @@ class BatchJobStrategyTest {
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
     String jobId = strategy.executeNoWait(
-        "batch-jobs/foo/inputs/", "Test", 5, Map.of(), 0);
+        "batch-jobs/foo/inputs/", "Test", 5, Map.of(), 0, List.of());
 
     assertTrue(jobId != null && !jobId.isEmpty());
     verify(target).dispatch(
-        anyString(), eq("batch-jobs/foo/inputs/"), eq("Test"), eq(5), anyMap(), eq(0));
+        anyString(), eq("batch-jobs/foo/inputs/"), eq("Test"), eq(5), anyMap(), eq(0), anyList());
     verify(poller, never()).poll(anyString());
   }
 
@@ -129,11 +131,11 @@ class BatchJobStrategyTest {
   void executeThrowsOnDispatchFailure() throws Exception {
     doThrow(new RuntimeException("Connection refused"))
         .when(target).dispatch(
-            anyString(), anyString(), anyString(), eq(1), anyMap(), anyInt());
+            anyString(), anyString(), anyString(), eq(1), anyMap(), anyInt(), anyList());
 
     BatchJobStrategy strategy = new BatchJobStrategy(target, poller, output, 10, 60000);
 
     assertThrows(RuntimeException.class,
-        () -> strategy.execute("batch-jobs/foo/inputs/", "Test", 1, Map.of(), 0));
+        () -> strategy.execute("batch-jobs/foo/inputs/", "Test", 1, Map.of(), 0, List.of()));
   }
 }

--- a/src/test/java/org/joshsim/pipeline/target/HttpBatchTargetTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/HttpBatchTargetTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +43,7 @@ class HttpBatchTargetTest {
     HttpBatchTarget target = new HttpBatchTarget("https://example.com", "test-key", mockClient);
 
     assertDoesNotThrow(() -> target.dispatch(
-        "job-1", "batch-jobs/job-1/inputs/", "Main", 1, Map.of(), 0));
+        "job-1", "batch-jobs/job-1/inputs/", "Main", 1, Map.of(), 0, List.of()));
     verify(mockClient).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
   }
 
@@ -61,7 +62,7 @@ class HttpBatchTargetTest {
     HttpBatchTarget target = new HttpBatchTarget("https://example.com", "test-key", mockClient);
 
     RuntimeException ex = assertThrows(RuntimeException.class,
-        () -> target.dispatch("job-bad", "prefix/", "Main", 1, Map.of(), 0));
+        () -> target.dispatch("job-bad", "prefix/", "Main", 1, Map.of(), 0, List.of()));
     assertTrue(ex.getMessage().contains("HTTP 400"));
     assertTrue(ex.getMessage().contains("missing-fields"));
   }
@@ -79,7 +80,7 @@ class HttpBatchTargetTest {
     HttpBatchTarget target = new HttpBatchTarget("https://example.com", "test-key", mockClient);
 
     RuntimeException ex = assertThrows(RuntimeException.class,
-        () -> target.dispatch("job-err", "prefix/", "Main", 5, Map.of(), 0));
+        () -> target.dispatch("job-err", "prefix/", "Main", 5, Map.of(), 0, List.of()));
     assertTrue(ex.getMessage().contains("HTTP 500"));
   }
 
@@ -94,7 +95,7 @@ class HttpBatchTargetTest {
         .thenReturn(mockResponse);
 
     HttpBatchTarget target = new HttpBatchTarget("https://example.com", "key", mockClient);
-    target.dispatch("job-rep", "prefix/", "Main", 10, Map.of(), 0);
+    target.dispatch("job-rep", "prefix/", "Main", 10, Map.of(), 0, List.of());
 
     // Verify the request was made (form body contains replicates, verified via mock interaction)
     verify(mockClient).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
@@ -122,7 +123,7 @@ class HttpBatchTargetTest {
         org.mockito.ArgumentCaptor.forClass(HttpRequest.class);
     HttpBatchTarget target = new HttpBatchTarget("https://example.com", "key", mockClient);
 
-    target.dispatch("job-1", "prefix/", "Main", 1, Map.of(), 0);
+    target.dispatch("job-1", "prefix/", "Main", 1, Map.of(), 0, List.of());
 
     verify(mockClient).send(reqCaptor.capture(), any(HttpResponse.BodyHandler.class));
     String body = drainBody(reqCaptor.getValue());
@@ -149,7 +150,7 @@ class HttpBatchTargetTest {
     Map<String, String> tags = new java.util.LinkedHashMap<>();
     tags.put("run_hash", "abc123");
     tags.put("region", "west");
-    target.dispatch("job-1", "prefix/", "Main", 3, tags, 5);
+    target.dispatch("job-1", "prefix/", "Main", 3, tags, 5, List.of());
 
     verify(mockClient).send(reqCaptor.capture(), any(HttpResponse.BodyHandler.class));
     String body = drainBody(reqCaptor.getValue());
@@ -159,6 +160,30 @@ class HttpBatchTargetTest {
         "expected tag pairs in body: " + decoded);
     assertTrue(decoded.contains("replicateStart=5"),
         "expected replicateStart in body: " + decoded);
+  }
+
+  @Test
+  void dispatchSendsReplicateIndicesInsteadOfStart() throws Exception {
+    HttpClient mockClient = mock(HttpClient.class);
+    HttpResponse<String> mockResponse = mock(HttpResponse.class);
+    when(mockResponse.statusCode()).thenReturn(202);
+    when(mockResponse.body()).thenReturn("{}");
+    when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(mockResponse);
+
+    final org.mockito.ArgumentCaptor<HttpRequest> reqCaptor =
+        org.mockito.ArgumentCaptor.forClass(HttpRequest.class);
+    HttpBatchTarget target = new HttpBatchTarget("https://example.com", "key", mockClient);
+
+    target.dispatch("job-1", "prefix/", "Main", 1, Map.of(), 0, List.of(3, 7, 8));
+
+    verify(mockClient).send(reqCaptor.capture(), any(HttpResponse.BodyHandler.class));
+    String decoded = java.net.URLDecoder.decode(
+        drainBody(reqCaptor.getValue()), java.nio.charset.StandardCharsets.UTF_8);
+    assertTrue(decoded.contains("replicateIndices=3,7,8"),
+        "expected replicateIndices in body: " + decoded);
+    assertTrue(!decoded.contains("replicateStart="),
+        "replicateStart must not be sent when indices are given: " + decoded);
   }
 
   /**
@@ -213,6 +238,7 @@ class HttpBatchTargetTest {
         .thenReturn(mockResponse);
 
     HttpBatchTarget target = new HttpBatchTarget("https://example.com/", "key", mockClient);
-    assertDoesNotThrow(() -> target.dispatch("job-1", "prefix/", "Main", 1, Map.of(), 0));
+    assertDoesNotThrow(() ->
+        target.dispatch("job-1", "prefix/", "Main", 1, Map.of(), 0, List.of()));
   }
 }

--- a/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
+++ b/src/test/java/org/joshsim/pipeline/target/KubernetesTargetTest.java
@@ -108,7 +108,7 @@ class KubernetesTargetTest {
       throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 5, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 5, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     assertNotNull(job);
@@ -125,7 +125,7 @@ class KubernetesTargetTest {
   void dispatchSetsContainerImage() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     Container container = getContainer(job);
@@ -136,7 +136,7 @@ class KubernetesTargetTest {
   void dispatchCreatesSecretWithMinioCreds() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Secret secret = secretCaptor.getValue();
     assertNotNull(secret);
@@ -161,7 +161,7 @@ class KubernetesTargetTest {
   void dispatchSetsSecretRefEnvVars() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     List<EnvVar> envVars = getContainer(job).getEnv();
@@ -185,7 +185,7 @@ class KubernetesTargetTest {
   void dispatchSetsPlainJobEnvVars() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     List<EnvVar> envVars = getContainer(job).getEnv();
@@ -198,7 +198,7 @@ class KubernetesTargetTest {
   void dispatchOmitsCustomTagsAndOffsetWhenDefault() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     List<EnvVar> envVars = getContainer(job).getEnv();
@@ -213,7 +213,7 @@ class KubernetesTargetTest {
     Map<String, String> tags = new java.util.LinkedHashMap<>();
     tags.put("run_hash", "abc123");
     tags.put("region", "west");
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, tags, 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, tags, 0, List.of());
 
     Job job = jobCaptor.getValue();
     List<EnvVar> envVars = getContainer(job).getEnv();
@@ -229,13 +229,30 @@ class KubernetesTargetTest {
   void dispatchEmitsReplicateOffsetWhenNonZero() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 3, Map.of(), 5);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 3, Map.of(), 5, List.of());
 
     Job job = jobCaptor.getValue();
     List<EnvVar> envVars = getContainer(job).getEnv();
     EnvVar offsetVar = findEnvVar(envVars, "JOSH_REPLICATE_OFFSET");
     assertNotNull(offsetVar);
     assertEquals("5", offsetVar.getValue());
+  }
+
+  @Test
+  void dispatchEmitsReplicateIndicesAndSizesCompletions() throws Exception {
+    KubernetesTarget target = buildTarget(config);
+
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of(3, 7, 8));
+
+    Job job = jobCaptor.getValue();
+    // Completions follow the index list size, not --replicates.
+    assertEquals(3, job.getSpec().getCompletions());
+    List<EnvVar> envVars = getContainer(job).getEnv();
+    EnvVar indicesVar = findEnvVar(envVars, "JOSH_REPLICATE_INDICES");
+    assertNotNull(indicesVar);
+    assertEquals("3,7,8", indicesVar.getValue());
+    // The offset env var is not emitted when an explicit list is used.
+    assertNull(findEnvVar(envVars, "JOSH_REPLICATE_OFFSET"));
   }
 
   @Test
@@ -250,7 +267,7 @@ class KubernetesTargetTest {
     config = buildConfig(10, 3600, resources);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     ResourceRequirements reqs =
@@ -272,7 +289,7 @@ class KubernetesTargetTest {
     config = buildConfig(10, 3600, null);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     ResourceRequirements reqs =
@@ -285,7 +302,7 @@ class KubernetesTargetTest {
     config = buildConfig(10, 3600, null);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 3, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 3, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     assertEquals(3, job.getSpec().getParallelism());
@@ -296,7 +313,7 @@ class KubernetesTargetTest {
   void dispatchJobNameFormat() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     assertEquals(
@@ -320,7 +337,7 @@ class KubernetesTargetTest {
     setField(config, "spot", true);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     Map<String, String> nodeSelector =
@@ -345,7 +362,7 @@ class KubernetesTargetTest {
     config = buildConfig(10, 3600, null);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     Map<String, String> nodeSelector =
@@ -364,7 +381,7 @@ class KubernetesTargetTest {
     ));
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     Map<String, String> selector = job.getSpec()
@@ -384,7 +401,7 @@ class KubernetesTargetTest {
     ));
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     Map<String, String> selector = job.getSpec()
@@ -402,7 +419,7 @@ class KubernetesTargetTest {
     config = buildConfig(10, 3600, null);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     Map<String, String> selector = job.getSpec()
@@ -417,7 +434,7 @@ class KubernetesTargetTest {
     setField(config, "ttlSecondsAfterFinished", 600);
 
     KubernetesTarget target = buildTarget(config);
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     assertEquals(
@@ -430,7 +447,7 @@ class KubernetesTargetTest {
   void dispatchUsesEntrypointScript() throws Exception {
     KubernetesTarget target = buildTarget(config);
 
-    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0);
+    target.dispatch(JOB_ID, PREFIX, SIMULATION, 1, Map.of(), 0, List.of());
 
     Job job = jobCaptor.getValue();
     Container container = getContainer(job);

--- a/src/test/java/org/joshsim/util/ReplicateSelectionTest.java
+++ b/src/test/java/org/joshsim/util/ReplicateSelectionTest.java
@@ -1,0 +1,93 @@
+package org.joshsim.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ReplicateSelection}, the shared resolver that turns replicate-selection knobs
+ * into an ordered list of absolute replicate indices.
+ */
+class ReplicateSelectionTest {
+
+  @Test
+  void parseNullIsEmpty() {
+    assertTrue(ReplicateSelection.parse(null).isEmpty());
+  }
+
+  @Test
+  void parseBlankIsEmpty() {
+    assertTrue(ReplicateSelection.parse("   ").isEmpty());
+  }
+
+  @Test
+  void parsePreservesOrder() {
+    assertEquals(List.of(3, 7, 8), ReplicateSelection.parse("3,7,8").orElseThrow());
+  }
+
+  @Test
+  void parseTrimsAndIgnoresEmptyEntries() {
+    assertEquals(List.of(1, 4, 5), ReplicateSelection.parse(" 1, 4 ,,5 ").orElseThrow());
+  }
+
+  @Test
+  void parseRejectsNonNumeric() {
+    assertThrows(IllegalArgumentException.class, () -> ReplicateSelection.parse("3,x,8"));
+  }
+
+  @Test
+  void parseRejectsNegative() {
+    assertThrows(IllegalArgumentException.class, () -> ReplicateSelection.parse("3,-1,8"));
+  }
+
+  @Test
+  void parseRejectsDuplicates() {
+    assertThrows(IllegalArgumentException.class, () -> ReplicateSelection.parse("3,7,3"));
+  }
+
+  @Test
+  void resolveUsesExplicitIndicesWhenPresent() {
+    List<Integer> resolved = ReplicateSelection.resolve(Optional.of(List.of(3, 7, 8)), 0, 99);
+    assertEquals(List.of(3, 7, 8), resolved);
+  }
+
+  @Test
+  void resolveExpandsRangeWhenNoIndices() {
+    List<Integer> resolved = ReplicateSelection.resolve(Optional.empty(), 5, 3);
+    assertEquals(List.of(5, 6, 7), resolved);
+  }
+
+  @Test
+  void resolveDefaultRangeStartsAtZero() {
+    assertEquals(List.of(0, 1, 2), ReplicateSelection.resolve(Optional.empty(), 0, 3));
+  }
+
+  @Test
+  void resolveZeroCountIsEmpty() {
+    assertTrue(ReplicateSelection.resolve(Optional.empty(), 0, 0).isEmpty());
+  }
+
+  @Test
+  void toCsvRoundTrips() {
+    String csv = ReplicateSelection.toCsv(List.of(3, 7, 8));
+    assertEquals("3,7,8", csv);
+    assertEquals(List.of(3, 7, 8), ReplicateSelection.parse(csv).orElseThrow());
+  }
+
+  @Test
+  void validateRejectsDuplicate() {
+    assertThrows(IllegalArgumentException.class,
+        () -> ReplicateSelection.validate(List.of(1, 1)));
+  }
+
+  @Test
+  void validateAcceptsNonContiguous() {
+    ReplicateSelection.validate(List.of(8, 3, 7));
+    assertFalse(List.of(8, 3, 7).isEmpty());
+  }
+}


### PR DESCRIPTION
## What

Adds an explicit, possibly **non-contiguous** replicate-index selection — `--replicate-indices=3,7,8` — to `run`, `runRemote`, and `batchRemote`, mirrored on the `run_simulation` MCP tool. This lets an orchestrator (joshpy) backfill exactly the missing replicates of a sweep — restoring dense `0..N-1` numbering, or refilling a lost replicate at its own index — instead of re-running the whole target and discarding all-but-the-missing at ingest.

Requested by joshpy. The same flag now behaves identically through **every** deployment route.

## Design — one selection, resolved at each fan-out point

The system had six places that turned `(replicates, replicateStart)` into concrete indices. A new [`ReplicateSelection`](src/main/java/org/joshsim/util/ReplicateSelection.java) helper is the single source of truth: it resolves *(explicit list | start+count)* into one ordered list of absolute indices, with shared CSV parsing + validation. Each fan-out point consumes that list.

**Nothing at the compute leaf changed.** Every route already drives an *absolute* index down to `TemplateStringRenderer` / `josh run --replicate-index=K` / `WorkerTask`, so output naming (`output_3.csv`) already follows the index.

**Backward compatible by construction.** The index list is an additive, optional parameter everywhere. When it's absent each route reproduces the existing `[start, start+count)` range **byte-for-byte** — new form fields / env vars are simply not emitted (mirroring how `replicateStart` is omitted when 0). Existing `--replicates` / `--replicate-start` flows are untouched.

## Bug fixed along the way

`runRemote --replicate-start` was **silently dropped**: the builder stored the offset but [`RunRemoteContext.getReplicateNumber()`](src/main/java/org/joshsim/pipeline/remote/RunRemoteContext.java) hardcoded `return 0`, so every consumer saw 0. The context now carries the resolved index list, so the offset (and explicit indices) actually reach the workers. Adds the regression test it lacked.

## Routes

- **`run` (local)** — flag + mutual-exclusivity validation on [RunCommand](src/main/java/org/joshsim/command/RunCommand.java); [RunUtil](src/main/java/org/joshsim/command/RunUtil.java) iterates the resolved list.
- **`run_simulation` (MCP)** — accepts a JSON int array *or* CSV string; schema + [LocalBackend](src/main/java/org/joshsim/mcp/LocalBackend.java) + [Backend](src/main/java/org/joshsim/mcp/Backend.java) updated.
- **`runRemote`** — offset bug fixed; local-leader builds one `WorkerTask` per index (no wire change); offload-leader sends a `replicateIndices` form field only when non-default; [JoshSimLeaderHandler](src/main/java/org/joshsim/cloud/JoshSimLeaderHandler.java) parses it.
- **`batchRemote`** — `dispatch()` takes an explicit index list; [KubernetesTarget](src/main/java/org/joshsim/pipeline/target/KubernetesTarget.java) sizes `completions` to the list and emits `JOSH_REPLICATE_INDICES`; [run-entrypoint.sh](cloud-img/run-entrypoint.sh) maps `JOB_COMPLETION_INDEX` to the n-th index; [HttpBatchTarget](src/main/java/org/joshsim/pipeline/target/HttpBatchTarget.java) sends a `replicateIndices` form field; [JoshSimBatchHandler](src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java) parses and loops it.

`--replicate-indices` is mutually exclusive with `--replicates` / `--replicate-start` / `--replicate-index`.

## Seeding (deliberately unchanged)

Out of scope. The replicate index remains a **label**: `SharedRandom` is seeded once per process and consumed serially, so there is no per-`(seed, index)` reproducibility. Backfilled indices are valid independent draws (the unseeded, default case); dense numbering is bookkeeping, not a reproducibility guarantee. No engine change.

## Tests

- `ReplicateSelectionTest` — resolver + parsing/validation (order, dupes, negatives, default-range, round-trip).
- Local `run` — non-contiguous end-to-end (CSV replicate column is exactly `{3,7,8}`) + the three mutual-exclusivity guards + duplicate rejection.
- `runRemote` — `RunRemoteContextBuilderTest`: offset now resolves to `[5,6,7]` (the bug-fix regression) and explicit indices supersede the range.
- `batchRemote` — `KubernetesTargetTest` (`completions=3`, `JOSH_REPLICATE_INDICES=3,7,8`, no offset var) and `HttpBatchTargetTest` (`replicateIndices` form field, no `replicateStart`).
- MCP — `RunSimulationToolTest` array/CSV parsing + int/dupe rejection.
- Full `./gradlew test` + `checkstyle` + `spotless` green. Verified the entrypoint index mapping in `sh` (completion 0/1/2 → 3/7/8; out-of-range errors).

## Compatibility note

The offload-leader and HTTP-batch servers parse the request server-side. A *new* client sending `replicateIndices` to an *old* server would be silently ignored (falls back to count/offset). In this repo client and server ship from the same JAR, so co-deploy avoids it; if mixed versions are possible, gate the flag's use on a server capability check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
