### PR TITLE
Add spin-up / spin-down phases to simulations

### DIFF
--- a/SPINUP.md
+++ b/SPINUP.md
@@ -1,0 +1,283 @@
+# Spin-up & Spin-down
+
+Let a simulation warm up to a stable state before the observed period, and keep
+running afterward to watch recovery — without changing any data or model code.
+
+## The idea
+
+Most ecological runs want more than the years for which we have data:
+
+- **Spin-up** — run for a long stretch *before* the observed period so the system
+  settles into equilibrium, drawing forcing (precipitation, temperature, …) by
+  resampling historical years.
+- **Observed** — the real period, driven 1:1 by the actual data.
+- **Spin-down** — keep running *after* the observed period to see how long the
+  system takes to recover from a disturbance, again resampling historical years.
+
+## What it looks like
+
+```josh
+start simulation Fire
+
+  steps.low = 0 years        # observed data spans years 0–86
+  steps.high = 86 years
+
+  start spinup
+    sample discrete uniform from 0 years to 86 years for 500 years
+  end spinup
+
+  start spindown
+    sample discrete uniform from 76 years to 86 years for 500 years
+  end spindown
+
+end simulation
+```
+
+Read aloud: *"warm up for 500 years drawing each year's forcing uniformly from
+0–86; run the observed period 0–86; then run 500 more years drawing from 76–86."*
+
+The phase body is a single resample directive — `<year expression> for
+<duration>`. The year expression is not limited to `sample discrete uniform`: a
+constant (`85 years for 500 years`), `normal`, or a function of `prior` all work.
+
+The year is drawn with the new **`discrete uniform`** form, which reuses the
+existing uniform distribution but draws an actual integer uniformly over the
+inclusive range — `sample discrete uniform from 0 years to 86 years` yields a
+whole year index in `[0..86]`, no coercion. It is an **opt-in qualifier**
+(implemented; `DISCRETE_` token + a `randUniformDiscrete()` machine op): a plain
+`uniform from …` stays continuous, so the random sequence of every existing
+seeded model is byte-for-byte unchanged. *Discrete uniform* is also standard
+statistical terminology, so it reads naturally for an ecologist.
+
+> Why a qualifier and not type-directed inference (integer bounds ⇒ discrete)?
+> The latter is more elegant but reinterprets the ~180 existing integer-bound
+> `uniform from …` usages across the guide tutorials, the paper example, and the
+> conformance suite. Because a discrete draw consumes the RNG differently than a
+> continuous one, that silently shifts every seeded model's sequence — verified to
+> break seed-tuned conformance tests. The explicit qualifier confines the new
+> behavior to code that asks for it.
+
+### Time units
+
+The simulation is written in one **time unit** — `years` for an annual model
+(the common case), or `count` for abstract/unitless models. The window bounds
+(`from 76 years to 86 years`) are *positions* on that axis and share the unit of
+`steps.low`/`steps.high`; the duration (`for 500 years`) is a *length* on the same
+axis. Both reading as `years` is intentional, not an overload — like "from mile 76
+to mile 86, for 500 miles." The engine already accepts `years` on `steps.*`
+(verified), so this is a convention plus light validation (window unit matches
+`steps.*`; window falls inside `[steps.low, steps.high]`).
+
+The rule is **1 step = 1 unit of the declared time unit**. Sub-annual models
+(monthly steps where `for 500 years` ≠ 500 steps) would need an explicit
+time-per-step declaration; that is deliberately out of scope here.
+
+### Multiple scenarios in one file
+
+Because simulations are named and selected at run time, spin-up lives with the
+*scenario*, not with the shared data resources. Keep a plain run and a warmed-up
+run side by side:
+
+```josh
+start simulation Main           # no spin-up
+  steps.low = 0 years
+  steps.high = 86 years
+end simulation
+
+start simulation MainWithSpinup
+  steps.low = 0 years
+  steps.high = 86 years
+  start spinup
+    sample discrete uniform from 0 years to 86 years for 500 years
+  end spinup
+end simulation
+```
+
+Because the phase parameters are ordinary expressions, they are also
+config-tunable for free (`sample uniform from 0 years to config s.start years for
+config s.len years`) — see [COMPOSITION.md](COMPOSITION.md). And designing the
+`spinup`/`spindown` stanza to attach *by simulation name* lets a scenario later
+live in its own imported file, the same merge question as separating exports.
+
+```
+$ java -jar joshsim.jar run fire.josh MainWithSpinup
+```
+
+## How time behaves
+
+There are two clocks. Today they are identical; this feature decouples them. The
+step clock is **anchored at the observed period**: step 0 is always the first
+observed step, spin-up counts backward into the negatives, spin-down continues
+past the end. So `step 0` means the same thing whether or not spin-up exists.
+
+| | meaning | during spin-up | first observed step | during spin-down |
+|---|---|---|---|---|
+| `meta.stepCount` | anchored step (state, `prior`, ordering) | −500 … −1 | 0 | 87 … 586 |
+| `meta.year` | which data year is felt this step (drives every `external` read) | random 0–86 | 0 | random 76–86 |
+| `meta.phase` *(new)* | `"spinup"` / `"observed"` / `"spindown"` | `"spinup"` | `"observed"` | `"spindown"` |
+
+(`steps.low`/`steps.high` define the observed window; the blocks extend the clock
+around it. `meta.stepCount` moves from the old 0-based absolute counter to this
+anchored value — backward-compatible for every model without spin-up. `.init`
+still fires at the true first step, off an internal counter, so it runs at the
+start of spin-up.)
+
+Key consequences:
+
+- **The draw is shared per step.** `external Precipitation` and
+  `external Temperature` in the same spin-up step read the *same* random year, so
+  forcing stays physically consistent.
+- **State carries across boundaries.** `prior` at the first observed step points
+  at the last spin-up step — the spun-up ecosystem *is* the observed run's
+  initial condition. Spin-up is not a separate throwaway run.
+- **No new data.** Resampling only re-reads year indices that already exist in
+  the preprocessed grid (0–86, 76–86). Nothing new to preprocess.
+- **`steps.low` / `steps.high` keep their meaning** — the observed window. The
+  blocks extend the run around it.
+
+### Output
+
+Which phases are written is configurable (e.g. a `--phases` flag driven by
+`meta.phase`), defaulting to all. Spin-up is often throwaway, so suppressing it
+while keeping observed + spin-down is a common choice.
+
+## Scope: build narrow, structure for later
+
+Ship the narrow feature — fixed `spinup` / `spindown` blocks, `for <duration>`
+only — but choose two internal representations now so the deferred features below
+are *additions*, not rewrites:
+
+- **Phases are an ordered list internally**, even though the surface only exposes
+  `spinup` and `spindown`. The bridge holds `[before, observed, after]` with the
+  order hardcoded; nothing else assumes exactly two phases.
+- **A phase's termination is an abstraction.** Today only `for <duration>` (a
+  fixed length) exists; the type leaves room for a *condition* — a boolean
+  evaluated against grid state after each step. Both `until` (end a phase when
+  stable) and `earlyStop` (end the run when collapsed) are this same condition
+  variant, differing only in what the transition does, so the abstraction must
+  cover them even though only `DurationTermination` is built now.
+
+### Reserved for later (accounted for, not built)
+
+- **Convergence spin-up (`until`).** "Warm up *until* the system stabilizes,
+  capped for safety" is the honest form of *find a stable state* — e.g.
+  `sample uniform from 0 years to 86 years until <stable> for at most 2000 years`.
+  It needs a windowed stop condition (history access) and variable-length runs,
+  but the negative-step anchoring already absorbs variable lengths — every
+  replicate realigns at step 0 — so it slots into the termination abstraction
+  without reworking the clock. Reserve the `until` / `for at most` grammar; don't
+  implement.
+- **Early stop (`earlyStop`).** For expensive models, end the *whole run* early
+  when state collapses (or saturates) — e.g. `start earlyStop` with a condition
+  like `mean(ForeverTree.count) < 1`. The step-loop hook is trivial and already
+  located: the driver loop is `while (!bridge.isComplete())` in
+  [JoshSimFacadeUtil.java:178-199](src/main/java/org/joshsim/JoshSimFacadeUtil.java#L178-L199),
+  with the completed `TimeStep` (frozen `meta` + all patches) in hand right after
+  `callback.onStep(...)`. This is the **same condition-termination variant** as
+  `until`; only the transition differs (end the run vs. advance the phase).
+
+  **What it costs — confirmed by tracing the aggregation path.** The blocker is
+  that a stop condition wants a *grid-wide* value like `mean(ForeverTree.count)`,
+  and there is no simulation-scope grid aggregate today. But the trace shows the
+  cost is small and mostly precedented:
+
+  - *The aggregation ladder is fully reusable.* A patch already computes
+    `mean(ForeverTree.age)` over its organisms via
+    [DistributionScope](src/main/java/org/joshsim/engine/func/DistributionScope.java)
+    (projects `.attr` across members) + `mean`/`count` in
+    [SingleThreadEventHandlerMachine](src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java).
+    Both reduce a `Distribution` and need **zero** new logic at simulation scope.
+  - *One precedented rung is missing — the binding.* Organisms are *attributes*
+    on the patch entity, so `EntityScope` resolves the bare name; patches are
+    **not** attributes on the simulation — they live in `Replicate`. But
+    [MinimalEngineBridge.getCurrentPatches()](src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java#L252)
+    already returns them **wrapped in `ShadowingEntity`** as an `Iterable`.
+    Injecting a synthetic grid/patches key whose value is a `Distribution` built
+    from that iterable is the *same pattern* `SyntheticScope` already uses for
+    `meta`/`here`/`current`/`prior`.
+  - *One genuinely new semantic.* A patch is itself a container, so
+    `ForeverTree.count` across patches is a *distribution of distributions* —
+    `mean(ForeverTree.count)` could mean mean-over-patches-of-within-patch-count
+    or mean over all organisms grid-wide. That nested flattening is the only new
+    design choice.
+
+  **The de-risking constraint (recommended):** require the condition to reference
+  only a value the simulation **already declares** (a `meta.*` / export scalar
+  the user computed), not an inline grid aggregate. Then the condition contains
+  no grid query at all — the grid was already collapsed to a scalar by the user's
+  own declaration, on a reading *they* chose — and the nested-distribution
+  question moves out of the termination feature into "can a simulation attribute
+  aggregate the grid," which is that same single binding rung. Verdict:
+  low-to-medium risk, low end reachable; the future build is the patches-as-scope
+  binding, **not** new aggregation primitives. Reserve `start earlyStop`; don't
+  implement.
+- **User-defined / ordered phases.** A `start state "Seedling"`-style named-phase
+  surface plus an order declaration is *not* low-cost: parsing is cheap (reuse
+  `STR_`), but assembling the order, placing the observed window, computing per-
+  phase ranges, and validating it is the expensive part — exactly what the fixed
+  two-block form gets for free. Because phases are already an ordered list
+  internally, this stays an additive change if a real need (staged warm-up,
+  repeated disturbance–recovery cycles) appears.
+
+## Effort — high level
+
+Six localized touch points, none large; the engine already has the two-clock
+structure to build on.
+
+| Area | Change | Size |
+|---|---|---|
+| Grammar | `spinup`/`spindown` + `for` tokens; a phase stanza with a `<year expr> for <duration>` body (reuses `distributionDescription`) | S |
+| Entity build | capture each block's duration and year expression onto the simulation as an ordered phase list (attach by simulation name) | S |
+| Bridge | read phase lengths, anchor the clock at the observed period (negative spin-up steps), add `getDataTimestep()` + `getPhase()` | **M** |
+| External read | resolve at `getDataTimestep()` instead of the raw step (one line) | S |
+| Meta attrs | `meta.stepCount` → anchored step; `meta.year` → data year; add `meta.phase` | S |
+| Per-step year eval | evaluate the dynamic year expression through the normal step/RNG pipeline and cache per step (gets per-replicate reproducibility for free) | **M** |
+
+Plus: configurable export filter, spec/docs updates, and a runnable example
+wired into CI with `assert_run` (not just `validate`).
+
+### Implementation notes (verified against the code)
+
+- **Negative anchored steps are safe in the core.** Timesteps are stored in a
+  `HashMap<Long,TimeStep>` (`Replicate`), and `TimeStep`/`Query`/exporters treat
+  the step as an opaque `long` — negatives just work. **Critical invariant:**
+  external/grid reads resolve at the *data year* (`getDataTimestep()`, always in
+  `[steps.low, steps.high]`), never the anchored step, because the precomputed
+  grid (`DoublePrecomputedGrid`) indexes by `timestep − minTimestep` and would go
+  out of bounds on a negative. Internal patch-state queries (`getPriorTimestep`)
+  use the anchored step against the HashMap, which is negative-safe.
+- **Two cleanups in the run loop / replicate:** (1) the memory-retention guard
+  `deleteTimeStep(completedStep − 2)` gated by `completedStep > 2`
+  (`JoshSimFacadeUtil`) frees nothing during spin-up — re-gate on
+  `completedStep − 2 >= firstAnchoredStep`; (2) confirm `Replicate.stepNumber`
+  tracks the anchored `currentStep` so the live-step query guard doesn't misfire.
+- **Phase carrier = existing event-handler machinery.** The simulation entity
+  already runs per-step handlers (`SimulationStepper.performStream(simulation,
+  "step")`), and handlers are `CompiledCallable`s in a
+  `Map<EventKey, EventHandlerGroup>`. Durations (`for <expr>`) ride as
+  constant-substep attributes the bridge reads like `steps.low`; year expressions
+  ride as synthetic handlers reusing `evaluate(Scope)`. No new invocation path —
+  this drops "entity build" and "per-step year eval" toward S.
+- **Gate the year draw to its phase.** A simulation step handler fires every
+  step, so the year expression must be evaluated *only* during its own phase
+  (on-demand from the bridge inside `getDataTimestep()` is preferred), or it
+  consumes RNG draws during observed/spin-down and shifts every other `sample`,
+  breaking reproducibility.
+
+### Open decisions
+
+- ~~Discretization convention for a sampled year used as a grid index.~~
+  **Resolved & implemented:** an opt-in `discrete uniform from X to Y` qualifier
+  draws an integer over the inclusive range (no coercion); a plain `uniform`
+  stays continuous. Chosen over type-directed inference specifically to avoid
+  perturbing the RNG sequence of the ~180 existing integer-bound `uniform`
+  usages (tutorials, paper, conformance) — that perturbation was verified to
+  break seed-tuned tests. Backed by a `DISCRETE_` grammar token (also kept as a
+  valid identifier) + `randUniformDiscrete()`; full distribution/stochastic
+  conformance stays green.
+- `meta.stepCount` moving to the anchored value (vs keeping the old absolute
+  counter and exposing the anchor under a new name) — recommended as above.
+- Merge/attach semantics so a `spinup`/`spindown` block can live in a separate
+  imported file (shared with the exports-separation question in COMPOSITION.md).
+- Whether to also generalize `external Name at <expression>` (currently only
+  `at <integer>`) as a power-user escape hatch alongside the declarative blocks.

--- a/SPINUP.md
+++ b/SPINUP.md
@@ -23,11 +23,13 @@ start simulation Fire
   steps.high = 86 years
 
   start spinup
-    sample discrete uniform from 0 years to 86 years for 500 years
+    duration = 500 years
+    year = sample discrete uniform from 0 years to 86 years
   end spinup
 
   start spindown
-    sample discrete uniform from 76 years to 86 years for 500 years
+    duration = 500 years
+    year = sample discrete uniform from 76 years to 86 years
   end spindown
 
 end simulation
@@ -36,9 +38,14 @@ end simulation
 Read aloud: *"warm up for 500 years drawing each year's forcing uniformly from
 0–86; run the observed period 0–86; then run 500 more years drawing from 76–86."*
 
-The phase body is a single resample directive — `<year expression> for
-<duration>`. The year expression is not limited to `sample discrete uniform`: a
-constant (`85 years for 500 years`), `normal`, or a function of `prior` all work.
+The phase body is a set of named properties (`name = expression`), reusing the
+same assignment form as the rest of the language: `duration` (the phase length)
+and `year` (resampled each step to pick which data year's forcing is felt).
+Naming `year` explicitly is the point — it is what `meta.year` *becomes* during
+the phase. The year expression is not limited to `sample discrete uniform`: a
+constant (`year = 85 years`), `normal`, or a function of `prior` all work. Making
+the body a property set also leaves room for future properties (e.g. a
+convergence `until`, below) with no grammar change.
 
 The year is drawn with the new **`discrete uniform`** form, which reuses the
 existing uniform distribution but draws an actual integer uniformly over the
@@ -62,14 +69,14 @@ statistical terminology, so it reads naturally for an ecologist.
 The simulation is written in one **time unit** — `years` for an annual model
 (the common case), or `count` for abstract/unitless models. The window bounds
 (`from 76 years to 86 years`) are *positions* on that axis and share the unit of
-`steps.low`/`steps.high`; the duration (`for 500 years`) is a *length* on the same
+`steps.low`/`steps.high`; the `duration = 500 years` is a *length* on the same
 axis. Both reading as `years` is intentional, not an overload — like "from mile 76
 to mile 86, for 500 miles." The engine already accepts `years` on `steps.*`
 (verified), so this is a convention plus light validation (window unit matches
 `steps.*`; window falls inside `[steps.low, steps.high]`).
 
 The rule is **1 step = 1 unit of the declared time unit**. Sub-annual models
-(monthly steps where `for 500 years` ≠ 500 steps) would need an explicit
+(monthly steps where `duration = 500 years` ≠ 500 steps) would need an explicit
 time-per-step declaration; that is deliberately out of scope here.
 
 ### Multiple scenarios in one file
@@ -88,14 +95,16 @@ start simulation MainWithSpinup
   steps.low = 0 years
   steps.high = 86 years
   start spinup
-    sample discrete uniform from 0 years to 86 years for 500 years
+    duration = 500 years
+    year = sample discrete uniform from 0 years to 86 years
   end spinup
 end simulation
 ```
 
-Because the phase parameters are ordinary expressions, they are also
-config-tunable for free (`sample uniform from 0 years to config s.start years for
-config s.len years`) — see [COMPOSITION.md](COMPOSITION.md). And designing the
+Because the phase properties are ordinary expressions, they are also
+config-tunable for free (`year = sample discrete uniform from 0 years to config
+s.start years`, `duration = config s.len years`) — see
+[COMPOSITION.md](COMPOSITION.md). And designing the
 `spinup`/`spindown` stanza to attach *by simulation name* lets a scenario later
 live in its own imported file, the same merge question as separating exports.
 
@@ -143,15 +152,15 @@ while keeping observed + spin-down is a common choice.
 
 ## Scope: build narrow, structure for later
 
-Ship the narrow feature — fixed `spinup` / `spindown` blocks, `for <duration>`
+Ship the narrow feature — fixed `spinup` / `spindown` blocks with a `duration`
 only — but choose two internal representations now so the deferred features below
 are *additions*, not rewrites:
 
 - **Phases are an ordered list internally**, even though the surface only exposes
   `spinup` and `spindown`. The bridge holds `[before, observed, after]` with the
   order hardcoded; nothing else assumes exactly two phases.
-- **A phase's termination is an abstraction.** Today only `for <duration>` (a
-  fixed length) exists; the type leaves room for a *condition* — a boolean
+- **A phase's termination is an abstraction.** Today only a fixed `duration`
+  exists; the type leaves room for a *condition* — a boolean
   evaluated against grid state after each step. Both `until` (end a phase when
   stable) and `earlyStop` (end the run when collapsed) are this same condition
   variant, differing only in what the transition does, so the abstraction must
@@ -160,13 +169,23 @@ are *additions*, not rewrites:
 ### Reserved for later (accounted for, not built)
 
 - **Convergence spin-up (`until`).** "Warm up *until* the system stabilizes,
-  capped for safety" is the honest form of *find a stable state* — e.g.
-  `sample uniform from 0 years to 86 years until <stable> for at most 2000 years`.
+  capped for safety" is the honest form of *find a stable state*. With the
+  named-property body it is simply another property alongside `duration` (which
+  becomes the safety cap), no grammar change:
+
+  ```josh
+  start spinup
+    duration = 2000 years    # safety cap
+    year = sample discrete uniform from 0 years to 86 years
+    until = mean(ForeverTree.count) > 100 count
+  end spinup
+  ```
+
   It needs a windowed stop condition (history access) and variable-length runs,
   but the negative-step anchoring already absorbs variable lengths — every
   replicate realigns at step 0 — so it slots into the termination abstraction
-  without reworking the clock. Reserve the `until` / `for at most` grammar; don't
-  implement.
+  without reworking the clock. The `until` *property* is reserved; don't
+  implement (and see `earlyStop` below for the shared missing capability).
 - **Early stop (`earlyStop`).** For expensive models, end the *whole run* early
   when state collapses (or saturates) — e.g. `start earlyStop` with a condition
   like `mean(ForeverTree.count) < 1`. The step-loop hook is trivial and already
@@ -226,7 +245,7 @@ structure to build on.
 
 | Area | Change | Size |
 |---|---|---|
-| Grammar | `spinup`/`spindown` + `for` tokens; a phase stanza with a `<year expr> for <duration>` body (reuses `distributionDescription`) | S |
+| Grammar | `spinup`/`spindown` tokens; a phase stanza whose body is `name = expression` properties (`year`, `duration`), reusing the event-handler form | S |
 | Entity build | capture each block's duration and year expression onto the simulation as an ordered phase list (attach by simulation name) | S |
 | Bridge | read phase lengths, anchor the clock at the observed period (negative spin-up steps), add `getDataTimestep()` + `getPhase()` | **M** |
 | External read | resolve at `getDataTimestep()` instead of the raw step (one line) | S |

--- a/examples/features/spinup.josh
+++ b/examples/features/spinup.josh
@@ -8,11 +8,13 @@ start simulation SpinupExample
   steps.high = 4 years
 
   start spinup
-    sample discrete uniform from 0 years to 4 years for 3 years
+    duration = 3 years
+    year = sample discrete uniform from 0 years to 4 years
   end spinup
 
   start spindown
-    sample discrete uniform from 3 years to 4 years for 2 years
+    duration = 2 years
+    year = sample discrete uniform from 3 years to 4 years
   end spindown
 
 end simulation

--- a/examples/features/spinup.josh
+++ b/examples/features/spinup.josh
@@ -1,0 +1,38 @@
+start simulation SpinupExample
+
+  grid.size = 1 m
+  grid.low = 0 m latitude, 0 m longitude
+  grid.high = 2 m latitude, 2 m longitude
+
+  steps.low = 0 years
+  steps.high = 4 years
+
+  start spinup
+    sample discrete uniform from 0 years to 4 years for 3 years
+  end spinup
+
+  start spindown
+    sample discrete uniform from 3 years to 4 years for 2 years
+  end spindown
+
+end simulation
+
+start patch Default
+
+  assert.spinupStepNegative.step:if(meta.phase == "spinup") = meta.stepCount < 0 count
+  assert.spinupYearLow.step:if(meta.phase == "spinup") = meta.year >= 0 years
+  assert.spinupYearHigh.step:if(meta.phase == "spinup") = meta.year <= 4 years
+
+  assert.observedStepLow.step:if(meta.phase == "observed") = meta.stepCount >= 0 count
+  assert.observedStepHigh.step:if(meta.phase == "observed") = meta.stepCount <= 4 count
+  assert.observedYearLow.step:if(meta.phase == "observed") = meta.year >= 0 years
+  assert.observedYearHigh.step:if(meta.phase == "observed") = meta.year <= 4 years
+
+  assert.spindownStep.step:if(meta.phase == "spindown") = meta.stepCount > 4 count
+  assert.spindownYearLow.step:if(meta.phase == "spindown") = meta.year >= 3 years
+  assert.spindownYearHigh.step:if(meta.phase == "spindown") = meta.year <= 4 years
+
+end patch
+
+start unit years
+end unit

--- a/examples/validate.sh
+++ b/examples/validate.sh
@@ -171,3 +171,6 @@ rm -f /tmp/profiler_multi_josh.csv
 assert_run examples/simulations/profiler_multi.josh ProfilerMultiExample --enable-profiler || exit 49
 [ -f "/tmp/profiler_multi_josh.csv" ] || exit 50
 [ -s "/tmp/profiler_multi_josh.csv" ] || exit 51
+
+# Test spin-up / spin-down: phase-anchored clock and resampled discrete years, asserted in-model
+assert_run examples/features/spinup.josh SpinupExample --seed 42 || exit 52

--- a/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
+++ b/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
@@ -53,6 +53,7 @@ CONST_: 'const';
 CREATE_: 'create';
 CURRENT_: 'current';
 DEBUG_: 'debug';
+DISCRETE_: 'discrete';
 DISTURBANCE_: 'disturbance';
 ELIF_: 'elif';
 ELSE_: 'else';
@@ -104,7 +105,7 @@ IDENTIFIER_: [A-Za-z][A-Za-z0-9_]*;
 WHITE_SPACE: [ \u000B\t\r\n] -> channel(HIDDEN);
 
 // Identifiers
-nakedIdentifier: (IDENTIFIER_|DEBUG_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_|ORGANISM_|N_|P_);
+nakedIdentifier: (IDENTIFIER_|DEBUG_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_|ORGANISM_|N_|P_|DISCRETE_);
 identifier: nakedIdentifier (DOT_ (nakedIdentifier))*;
 
 // Values
@@ -175,7 +176,7 @@ statement: (assignment | return | fullConditional);
 
 bool: (TRUE_ | FALSE_);
 
-distributionDescription: UNIFORM_ FROM_ low=expression TO_ high=expression # uniformSample
+distributionDescription: DISCRETE_? UNIFORM_ FROM_ low=expression TO_ high=expression # uniformSample
   | NORMAL_ WITH_ MEAN_ OF_ mean=expression STD_ OF_ stdev=expression # normalSample
   | BINOMIAL_ WITH_ N_ OF_ n=expression P_ OF_ p=expression # binomialSample
   ;

--- a/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
+++ b/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
@@ -60,7 +60,6 @@ ELSE_: 'else';
 END_: 'end';
 EXTERNAL_: 'external';
 FALSE_: 'false';
-FOR_: 'for';
 FORCE_: 'force';
 FROM_: 'from';
 HERE_: 'here';
@@ -108,7 +107,7 @@ IDENTIFIER_: [A-Za-z][A-Za-z0-9_]*;
 WHITE_SPACE: [ \u000B\t\r\n] -> channel(HIDDEN);
 
 // Identifiers
-nakedIdentifier: (IDENTIFIER_|DEBUG_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_|ORGANISM_|N_|P_|DISCRETE_|FOR_|SPINUP_|SPINDOWN_);
+nakedIdentifier: (IDENTIFIER_|DEBUG_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_|ORGANISM_|N_|P_|DISCRETE_|SPINUP_|SPINDOWN_);
 identifier: nakedIdentifier (DOT_ (nakedIdentifier))*;
 
 // Values
@@ -212,11 +211,12 @@ eventHandlerGeneral: eventHandlerGroup;
 stateStanza: START_ STATE_ STR_ eventHandlerGeneral* END_ STATE_;
 
 // Spin-up / spin-down phase stanzas (valid only inside a simulation; enforced in the visitor).
-// The body is `<year expression> for <duration>` — the year expression is resampled each step
-// of the phase to pick which data year's forcing is felt; the duration sets the phase length.
+// The body is a set of named properties (`name = expression`), reusing the event-handler form:
+// `year` (resampled each step to pick which data year's forcing is felt) and `duration` (the
+// phase length). Reads like the rest of the language and leaves room for future properties.
 phaseType: (SPINUP_ | SPINDOWN_);
 
-phaseStanza: START_ phaseType yearExpr=expression FOR_ duration=expression END_ phaseType;
+phaseStanza: START_ phaseType eventHandlerGeneral* END_ phaseType;
 
 entityStanzaType: (DISTURBANCE_ | EXTERNAL_ | ORGANISM_ | MANAGEMENT_ | PATCH_ | SIMULATION_);
 

--- a/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
+++ b/src/main/antlr/org/joshsim/lang/antlr/JoshLang.g4
@@ -60,6 +60,7 @@ ELSE_: 'else';
 END_: 'end';
 EXTERNAL_: 'external';
 FALSE_: 'false';
+FOR_: 'for';
 FORCE_: 'force';
 FROM_: 'from';
 HERE_: 'here';
@@ -85,6 +86,8 @@ REPLACEMENT_: 'replacement';
 RETURN_: 'return';
 SAMPLE_: 'sample';
 SIMULATION_: 'simulation';
+SPINDOWN_: 'spindown';
+SPINUP_: 'spinup';
 START_: 'start';
 STATE_: 'state';
 STD_: 'std';
@@ -105,7 +108,7 @@ IDENTIFIER_: [A-Za-z][A-Za-z0-9_]*;
 WHITE_SPACE: [ \u000B\t\r\n] -> channel(HIDDEN);
 
 // Identifiers
-nakedIdentifier: (IDENTIFIER_|DEBUG_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_|ORGANISM_|N_|P_|DISCRETE_);
+nakedIdentifier: (IDENTIFIER_|DEBUG_|INIT_|START_|STEP_|END_|HERE_|CURRENT_|PRIOR_|STATE_|ASSERT_|PATCH_|SIMULATION_|AGENT_|ORGANISM_|N_|P_|DISCRETE_|FOR_|SPINUP_|SPINDOWN_);
 identifier: nakedIdentifier (DOT_ (nakedIdentifier))*;
 
 // Values
@@ -208,9 +211,16 @@ eventHandlerGeneral: eventHandlerGroup;
 // Regular stanzas
 stateStanza: START_ STATE_ STR_ eventHandlerGeneral* END_ STATE_;
 
+// Spin-up / spin-down phase stanzas (valid only inside a simulation; enforced in the visitor).
+// The body is `<year expression> for <duration>` — the year expression is resampled each step
+// of the phase to pick which data year's forcing is felt; the duration sets the phase length.
+phaseType: (SPINUP_ | SPINDOWN_);
+
+phaseStanza: START_ phaseType yearExpr=expression FOR_ duration=expression END_ phaseType;
+
 entityStanzaType: (DISTURBANCE_ | EXTERNAL_ | ORGANISM_ | MANAGEMENT_ | PATCH_ | SIMULATION_);
 
-entityStanza: START_ entityStanzaType identifier (eventHandlerGeneral | stateStanza)* END_ entityStanzaType;
+entityStanza: START_ entityStanzaType identifier (eventHandlerGeneral | stateStanza | phaseStanza)* END_ entityStanzaType;
 
 // Unit definitions
 unitConversion: ALIAS_ identifier # noopConversion

--- a/src/main/java/org/joshsim/JoshSimFacadeUtil.java
+++ b/src/main/java/org/joshsim/JoshSimFacadeUtil.java
@@ -193,7 +193,10 @@ public class JoshSimFacadeUtil {
 
       callback.onStep(completedStep);
 
-      if (completedStep > 2) {
+      // Prune the step two behind once it exists. Gated on the earliest saved step (which is
+      // negative during spin-up) rather than a hardcoded 0, so spin-up steps are freed too instead
+      // of accumulating for the whole warm-up.
+      if (completedStep - 2 >= bridge.getEarliestTimestep()) {
         bridge.getReplicate().deleteTimeStep(completedStep - 2);
       }
     }

--- a/src/main/java/org/joshsim/lang/bridge/EngineBridge.java
+++ b/src/main/java/org/joshsim/lang/bridge/EngineBridge.java
@@ -109,6 +109,34 @@ public interface EngineBridge {
   long getCurrentTimestep();
 
   /**
+   * Get the data timestep felt during the current step.
+   *
+   * <p>During the observed period this equals {@link #getCurrentTimestep()}. During a spin-up or
+   * spin-down phase it is the resampled year drawn for this step, which every {@code external} read
+   * and {@code meta.year} bind to so forcing stays physically consistent within the step.</p>
+   *
+   * @return the data year whose forcing is felt this step.
+   */
+  long getDataTimestep();
+
+  /**
+   * Get the phase the simulation is currently in.
+   *
+   * @return one of {@code "spinup"}, {@code "observed"}, or {@code "spindown"}.
+   */
+  String getPhase();
+
+  /**
+   * Get the earliest timestep key the run will ever save.
+   *
+   * <p>This is {@code steps.low} shifted back by the spin-up length (so it can be negative). Used
+   * to bound memory-retention pruning during spin-up.</p>
+   *
+   * @return the earliest (possibly negative) anchored timestep.
+   */
+  long getEarliestTimestep();
+
+  /**
    * Get the prior simulation step as a long value.
    *
    * @return the prior simulation step count as a long.

--- a/src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java
+++ b/src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java
@@ -16,9 +16,13 @@ import org.joshsim.engine.config.Config;
 import org.joshsim.engine.entity.base.Entity;
 import org.joshsim.engine.entity.base.GeoKey;
 import org.joshsim.engine.entity.base.MutableEntity;
+import org.joshsim.engine.entity.handler.EventHandler;
+import org.joshsim.engine.entity.handler.EventHandlerGroup;
+import org.joshsim.engine.entity.handler.EventKey;
 import org.joshsim.engine.entity.prototype.EntityPrototype;
 import org.joshsim.engine.entity.prototype.EntityPrototypeStore;
 import org.joshsim.engine.func.CompiledCallable;
+import org.joshsim.engine.func.EntityScope;
 import org.joshsim.engine.func.SingleValueScope;
 import org.joshsim.engine.geometry.EngineGeometry;
 import org.joshsim.engine.geometry.EngineGeometryFactory;
@@ -59,6 +63,17 @@ public class MinimalEngineBridge implements EngineBridge {
   private EngineValue currentStep;
   private boolean inStep;
 
+  // Spin-up / spin-down phase configuration. With no phase blocks these are zero/empty and the
+  // clock behaves exactly as before: currentStep runs steps.low..steps.high.
+  private long spinupSteps;
+  private long spindownSteps;
+  private long observedLow;
+  private long observedHigh;
+  private Optional<CompiledCallable> spinupYearCallable = Optional.empty();
+  private Optional<CompiledCallable> spindownYearCallable = Optional.empty();
+  private long memoizedYearStep = Long.MIN_VALUE;
+  private long memoizedYear;
+
   private final Map<MutableEntity, MutableEntity> patchWrapperCache = new IdentityHashMap<>();
 
   /**
@@ -98,13 +113,23 @@ public class MinimalEngineBridge implements EngineBridge {
       .getAttributeValue("steps.low")
       .orElseGet(() -> engineValueFactory.build(DEFAULT_START_STEP, Units.of("count")));
 
-    currentStep = startStep;
-
     endStep = simulation
       .getAttributeValue("steps.high")
       .orElseGet(() -> engineValueFactory.build(DEFAULT_END_STEP, Units.of("count")));
 
+    spinupSteps = readPhaseDuration("__spinupSteps");
+    spindownSteps = readPhaseDuration("__spindownSteps");
+
     simulation.endSubstep();
+
+    observedLow = startStep.getAsInt();
+    observedHigh = endStep.getAsInt();
+
+    // Anchor the clock at the observed period: spin-up counts backward into the negatives, so the
+    // first observed step is always the same value regardless of spin-up length.
+    currentStep = engineValueFactory.build(observedLow - spinupSteps, Units.of("count"));
+    spinupYearCallable = retrievePhaseYearCallable("__spinupYear", "spinup");
+    spindownYearCallable = retrievePhaseYearCallable("__spindownYear", "spindown");
 
     absoluteStep = 0;
     inStep = false;
@@ -141,13 +166,23 @@ public class MinimalEngineBridge implements EngineBridge {
       .getAttributeValue("steps.low")
       .orElseGet(() -> engineValueFactory.build(DEFAULT_START_STEP, Units.of("count")));
 
-    currentStep = startStep;
-
     endStep = simulation
       .getAttributeValue("steps.high")
       .orElseGet(() -> engineValueFactory.build(DEFAULT_END_STEP, Units.of("count")));
 
+    spinupSteps = readPhaseDuration("__spinupSteps");
+    spindownSteps = readPhaseDuration("__spindownSteps");
+
     simulation.endSubstep();
+
+    observedLow = startStep.getAsInt();
+    observedHigh = endStep.getAsInt();
+
+    // Anchor the clock at the observed period: spin-up counts backward into the negatives, so the
+    // first observed step is always the same value regardless of spin-up length.
+    currentStep = engineValueFactory.build(observedLow - spinupSteps, Units.of("count"));
+    spinupYearCallable = retrievePhaseYearCallable("__spinupYear", "spinup");
+    spindownYearCallable = retrievePhaseYearCallable("__spindownYear", "spindown");
 
     absoluteStep = 0;
     inStep = false;
@@ -190,7 +225,7 @@ public class MinimalEngineBridge implements EngineBridge {
 
   @Override
   public boolean isComplete() {
-    return currentStep.greaterThan(endStep).getAsBoolean();
+    return currentStep.getAsInt() > observedHigh + spindownSteps;
   }
 
   @Override
@@ -282,6 +317,45 @@ public class MinimalEngineBridge implements EngineBridge {
   }
 
   @Override
+  public long getDataTimestep() {
+    long step = currentStep.getAsInt();
+    if (step >= observedLow && step <= observedHigh) {
+      return step;
+    }
+
+    Optional<CompiledCallable> yearCallable =
+        step < observedLow ? spinupYearCallable : spindownYearCallable;
+    if (yearCallable.isEmpty()) {
+      return step;
+    }
+
+    // Draw once per step and memoize so every external read in the same step shares the same year.
+    if (memoizedYearStep != step) {
+      EngineValue drawn = yearCallable.get().evaluate(new EntityScope(simulation));
+      memoizedYear = drawn.getAsInt();
+      memoizedYearStep = step;
+    }
+    return memoizedYear;
+  }
+
+  @Override
+  public String getPhase() {
+    long step = currentStep.getAsInt();
+    if (step < observedLow) {
+      return "spinup";
+    }
+    if (step > observedHigh) {
+      return "spindown";
+    }
+    return "observed";
+  }
+
+  @Override
+  public long getEarliestTimestep() {
+    return observedLow - spinupSteps;
+  }
+
+  @Override
   public long getPriorTimestep() {
     return currentStep.getAsInt() - 1;
   }
@@ -319,6 +393,38 @@ public class MinimalEngineBridge implements EngineBridge {
     }
 
     return prototypeStore.get(name);
+  }
+
+  /**
+   * Read a phase duration (in steps) from a synthetic constant-substep attribute.
+   *
+   * <p>Must be called while the {@code "constant"} substep is open. Returns 0 when the phase is
+   * absent, which keeps the clock identical to a simulation without spin-up/spin-down.</p>
+   *
+   * @param attribute The synthetic duration attribute (e.g. {@code "__spinupSteps"}).
+   * @return The phase length in steps, or 0 if not declared.
+   */
+  private long readPhaseDuration(String attribute) {
+    return simulation.getAttributeValue(attribute).map(EngineValue::getAsInt).orElse(0L);
+  }
+
+  /**
+   * Retrieve the per-step year expression for a phase, if declared.
+   *
+   * <p>The handler is registered under a dedicated event so the stepper never runs it; the bridge
+   * evaluates it on demand only while that phase is active.</p>
+   *
+   * @param attribute The synthetic year attribute (e.g. {@code "__spinupYear"}).
+   * @param event The event under which the year handler is registered (the phase name).
+   * @return The compiled year expression, or empty if the phase is not declared.
+   */
+  private Optional<CompiledCallable> retrievePhaseYearCallable(String attribute, String event) {
+    Optional<EventHandlerGroup> group = simulation.getEventHandlers(EventKey.of(attribute, event));
+    if (group.isEmpty()) {
+      return Optional.empty();
+    }
+    Iterator<EventHandler> handlers = group.get().getEventHandlers().iterator();
+    return handlers.hasNext() ? Optional.of(handlers.next().getCallable()) : Optional.empty();
   }
 
   /**

--- a/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
@@ -575,6 +575,17 @@ public interface EventHandlerMachine {
   long getCurrentTimestep();
 
   /**
+   * Get the data timestep felt during the current step.
+   *
+   * <p>Equals {@link #getCurrentTimestep()} during the observed period; during a spin-up or
+   * spin-down phase it is the resampled year drawn for this step. External reads bind to this so
+   * forcing lines up with {@code meta.year}.</p>
+   *
+   * @return The data year whose forcing is felt this step.
+   */
+  long getDataTimestep();
+
+  /**
    * Get a value from an external resource at a given time.
    *
    * @param name The name of the external resource.

--- a/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/EventHandlerMachine.java
@@ -338,6 +338,18 @@ public interface EventHandlerMachine {
   EventHandlerMachine randUniform();
 
   /**
+   * Draw a single integer randomly from a discrete uniform distribution.
+   *
+   * <p>Draw a single value uniformly over the inclusive integer range [low, high], pushing the
+   * integer drawn to the top of the stack. Prior to pushing the result, the high end is popped
+   * followed by the low end. Unlike {@link #randUniform()} this yields an actual integer with no
+   * coercion; it backs the {@code discrete uniform} surface form.</p>
+   *
+   * @return Reference to this machine for chaining.
+   */
+  EventHandlerMachine randUniformDiscrete();
+
+  /**
    * Draw a single value randomly from a normal distribution.
    *
    * <p>Draw a single value randomly from a normal distribution, pushing the value drawn to the top

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -617,10 +617,17 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
   private Optional<EngineValue> getBuiltinMetaAttribute(String name) {
     return switch (name) {
       case "stepCount" -> Optional.of(
-          valueFactory.build(bridge.getAbsoluteTimestep(), COUNT_UNITS)
+          // Anchored at the observed period: 0 is the first observed step, spin-up is negative.
+          // For a run without spin-up this equals the old absolute step count.
+          valueFactory.build(
+              bridge.getCurrentTimestep() - bridge.getStartTimestep(), COUNT_UNITS)
       );
       case "year" -> Optional.of(
-          valueFactory.build(bridge.getCurrentTimestep(), Units.of("years"))
+          // The data year felt this step (resampled during spin-up/spin-down).
+          valueFactory.build(bridge.getDataTimestep(), Units.of("years"))
+      );
+      case "phase" -> Optional.of(
+          valueFactory.build(bridge.getPhase(), Units.EMPTY)
       );
       default -> Optional.empty();
     };
@@ -977,6 +984,11 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
   @Override
   public long getCurrentTimestep() {
     return bridge.getCurrentTimestep();
+  }
+
+  @Override
+  public long getDataTimestep() {
+    return bridge.getDataTimestep();
   }
 
   @Override

--- a/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
+++ b/src/main/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachine.java
@@ -705,6 +705,25 @@ public class SingleThreadEventHandlerMachine implements EventHandlerMachine {
   }
 
   @Override
+  public EventHandlerMachine randUniformDiscrete() {
+    startConversionGroup();
+    EngineValue max = pop();
+    EngineValue min = pop();
+    endConversionGroup();
+
+    // `discrete uniform` draws an actual integer uniformly over the inclusive range [low, high]
+    // (no coercion), reusing the uniform distribution. This is opt-in, so a plain `uniform`
+    // remains continuous and the random sequence of existing seeded models is unchanged.
+    long low = min.getAsInt();
+    long high = max.getAsInt();
+    long span = high - low + 1;
+    long drawn = span <= 1 ? low : low + SharedRandom.nextInt((int) span);
+    memory.push(valueFactory.build(drawn, min.getUnits()));
+
+    return this;
+  }
+
+  @Override
   public EventHandlerMachine randNorm() {
     startConversionGroup();
     EngineValue std = pop();

--- a/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshDistributionVisitor.java
@@ -152,11 +152,16 @@ public class JoshDistributionVisitor implements JoshVisitorDelegate {
   public JoshFragment visitUniformSample(JoshLangParser.UniformSampleContext ctx) {
     EventHandlerAction lowAction = ctx.low.accept(parent).getCurrentAction();
     EventHandlerAction highAction = ctx.high.accept(parent).getCurrentAction();
+    boolean discrete = ctx.DISCRETE_() != null;
 
     EventHandlerAction action = (machine) -> {
       lowAction.apply(machine);
       highAction.apply(machine);
-      machine.randUniform();
+      if (discrete) {
+        machine.randUniformDiscrete();
+      } else {
+        machine.randUniform();
+      }
       return machine;
     };
 

--- a/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshExternalVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshExternalVisitor.java
@@ -38,10 +38,10 @@ public class JoshExternalVisitor implements JoshVisitorDelegate {
   public JoshFragment visitExternalValue(JoshLangParser.ExternalValueContext ctx) {
     String name = ctx.name.getText();
     EventHandlerAction action = (machine) -> {
-      // Resolve against the semantic (steps.low-based) timestep so external data lines up with
-      // how its grid is keyed and with meta.year; getStepCount()'s 0-based value only matches
-      // the grid when steps.low is zero.
-      long step = machine.getCurrentTimestep();
+      // Resolve against the data timestep so external data lines up with how its grid is keyed and
+      // with meta.year. During the observed period this equals the current (steps.low-based) step;
+      // during spin-up/spin-down it is the resampled year drawn for this step.
+      long step = machine.getDataTimestep();
       machine.pushExternal(name, step);
       return machine;
     };

--- a/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshStanzaVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshStanzaVisitor.java
@@ -21,15 +21,12 @@ import org.joshsim.engine.value.converter.DirectConversion;
 import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.ValueSupportFactory;
 import org.joshsim.lang.antlr.JoshLangParser;
-import org.joshsim.lang.interpret.BridgeGetter;
-import org.joshsim.lang.interpret.action.EventHandlerAction;
 import org.joshsim.lang.interpret.fragment.ProgramBuilder;
 import org.joshsim.lang.interpret.fragment.josh.ConversionsFragment;
 import org.joshsim.lang.interpret.fragment.josh.EntityFragment;
 import org.joshsim.lang.interpret.fragment.josh.JoshFragment;
 import org.joshsim.lang.interpret.fragment.josh.ProgramFragment;
 import org.joshsim.lang.interpret.fragment.josh.StateFragment;
-import org.joshsim.lang.interpret.machine.PushDownMachineCallable;
 import org.joshsim.lang.interpret.visitor.JoshParserToMachineVisitor;
 
 
@@ -43,7 +40,6 @@ public class JoshStanzaVisitor implements JoshVisitorDelegate {
 
   private final JoshParserToMachineVisitor parent;
   private final ValueSupportFactory valueFactory;
-  private final BridgeGetter bridgeGetter;
 
   /**
    * Create a new stanza visitor.
@@ -53,7 +49,6 @@ public class JoshStanzaVisitor implements JoshVisitorDelegate {
   public JoshStanzaVisitor(DelegateToolbox toolbox) {
     parent = toolbox.getParent();
     valueFactory = toolbox.getValueFactory();
-    bridgeGetter = toolbox.getBridgeGetter();
   }
 
   /**
@@ -134,12 +129,13 @@ public class JoshStanzaVisitor implements JoshVisitorDelegate {
   /**
    * Capture a spin-up / spin-down phase onto the simulation being built.
    *
-   * <p>A phase contributes two synthetic handlers: a constant-substep duration
-   * ({@code __<phase>Steps}) the bridge reads at construction to anchor the clock, and a per-step
-   * year expression ({@code __<phase>Year}) the bridge evaluates on demand while in that phase to
-   * pick which data year's forcing is felt. The year handler is registered under a dedicated event
-   * (the phase name) so the stepper never runs it automatically — it is only drawn while the phase
-   * is active, leaving the random sequence of other phases untouched.</p>
+   * <p>The phase body is a set of named properties ({@code name = expression}): {@code year} (the
+   * data year resampled each step while in the phase) and {@code duration} (the phase length). Each
+   * is compiled like an ordinary handler and re-registered under a synthetic key: {@code duration}
+   * as a constant-substep attribute ({@code __<phase>Steps}) the bridge reads at construction to
+   * anchor the clock, and {@code year} under a dedicated event (the phase name) so the stepper
+   * never runs it automatically — the bridge evaluates it on demand only while the phase is active,
+   * leaving the random sequence of other phases untouched.</p>
    *
    * @param ctx The phase stanza to capture.
    * @param entityBuilder The simulation entity builder to attach the phase handlers to.
@@ -159,11 +155,35 @@ public class JoshStanzaVisitor implements JoshVisitorDelegate {
           "Phase start and end type different: %s, %s", phase, closePhase));
     }
 
-    EventHandlerAction yearAction = ctx.yearExpr.accept(parent).getCurrentAction();
-    EventHandlerAction durationAction = ctx.duration.accept(parent).getCurrentAction();
+    boolean hasYear = false;
+    boolean hasDuration = false;
+    for (JoshLangParser.EventHandlerGeneralContext propertyCtx : ctx.eventHandlerGeneral()) {
+      for (EventHandlerGroupBuilder groupBuilder
+          : propertyCtx.accept(parent).getEventHandlerGroups()) {
+        String property = groupBuilder.buildKey().getAttribute();
+        CompiledCallable callable = groupBuilder.build()
+            .getEventHandlers().iterator().next().getCallable();
+        switch (property) {
+          case "year" -> {
+            addPhaseHandler(entityBuilder, "__" + phase + "Year", phase, callable);
+            hasYear = true;
+          }
+          case "duration" -> {
+            addPhaseHandler(entityBuilder, "__" + phase + "Steps", "constant", callable);
+            hasDuration = true;
+          }
+          default -> throw new IllegalArgumentException(String.format(
+              "Unknown %s property '%s'. Expected 'year' or 'duration'.", phase, property));
+        }
+      }
+    }
 
-    addPhaseHandler(entityBuilder, "__" + phase + "Steps", "constant", durationAction);
-    addPhaseHandler(entityBuilder, "__" + phase + "Year", phase, yearAction);
+    if (!hasDuration) {
+      throw new IllegalArgumentException(phase + " block is missing a 'duration'.");
+    }
+    if (!hasYear) {
+      throw new IllegalArgumentException(phase + " block is missing a 'year' expression.");
+    }
   }
 
   /**
@@ -172,18 +192,10 @@ public class JoshStanzaVisitor implements JoshVisitorDelegate {
    * @param entityBuilder The entity builder to attach the handler to.
    * @param attribute The synthetic attribute name the handler resolves.
    * @param event The substep / event under which the handler resolves.
-   * @param action The compiled action evaluated by the handler.
+   * @param callable The compiled expression evaluated by the handler.
    */
   private void addPhaseHandler(EntityBuilder entityBuilder, String attribute, String event,
-        EventHandlerAction action) {
-    // Wrap so the machine is ended after the expression runs, matching how a handler body (lambda)
-    // is compiled; getResult() requires the machine to have ended.
-    EventHandlerAction endedAction = (machine) -> {
-      action.apply(machine);
-      machine.end();
-      return machine;
-    };
-    CompiledCallable callable = new PushDownMachineCallable(endedAction, bridgeGetter);
+        CompiledCallable callable) {
     EventKey eventKey = EventKey.of(attribute, event);
     EventHandlerGroupBuilder groupBuilder = new EventHandlerGroupBuilder();
     groupBuilder.setEventKey(eventKey);

--- a/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshStanzaVisitor.java
+++ b/src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshStanzaVisitor.java
@@ -9,21 +9,27 @@ package org.joshsim.lang.interpret.visitor.delegates;
 import java.util.ArrayList;
 import java.util.List;
 import org.joshsim.engine.entity.base.EntityBuilder;
+import org.joshsim.engine.entity.handler.EventHandler;
 import org.joshsim.engine.entity.handler.EventHandlerGroupBuilder;
+import org.joshsim.engine.entity.handler.EventKey;
 import org.joshsim.engine.entity.prototype.EntityPrototype;
 import org.joshsim.engine.entity.prototype.ParentlessEntityPrototype;
 import org.joshsim.engine.entity.type.EntityType;
+import org.joshsim.engine.func.CompiledCallable;
 import org.joshsim.engine.value.converter.Conversion;
 import org.joshsim.engine.value.converter.DirectConversion;
 import org.joshsim.engine.value.converter.Units;
 import org.joshsim.engine.value.engine.ValueSupportFactory;
 import org.joshsim.lang.antlr.JoshLangParser;
+import org.joshsim.lang.interpret.BridgeGetter;
+import org.joshsim.lang.interpret.action.EventHandlerAction;
 import org.joshsim.lang.interpret.fragment.ProgramBuilder;
 import org.joshsim.lang.interpret.fragment.josh.ConversionsFragment;
 import org.joshsim.lang.interpret.fragment.josh.EntityFragment;
 import org.joshsim.lang.interpret.fragment.josh.JoshFragment;
 import org.joshsim.lang.interpret.fragment.josh.ProgramFragment;
 import org.joshsim.lang.interpret.fragment.josh.StateFragment;
+import org.joshsim.lang.interpret.machine.PushDownMachineCallable;
 import org.joshsim.lang.interpret.visitor.JoshParserToMachineVisitor;
 
 
@@ -37,6 +43,7 @@ public class JoshStanzaVisitor implements JoshVisitorDelegate {
 
   private final JoshParserToMachineVisitor parent;
   private final ValueSupportFactory valueFactory;
+  private final BridgeGetter bridgeGetter;
 
   /**
    * Create a new stanza visitor.
@@ -46,6 +53,7 @@ public class JoshStanzaVisitor implements JoshVisitorDelegate {
   public JoshStanzaVisitor(DelegateToolbox toolbox) {
     parent = toolbox.getParent();
     valueFactory = toolbox.getValueFactory();
+    bridgeGetter = toolbox.getBridgeGetter();
   }
 
   /**
@@ -102,6 +110,11 @@ public class JoshStanzaVisitor implements JoshVisitorDelegate {
 
     for (int innerIndex = 0; innerIndex < numInner; innerIndex++) {
       int childIndex = innerIndex + 3;
+      if (ctx.getChild(childIndex) instanceof JoshLangParser.PhaseStanzaContext phaseCtx) {
+        capturePhase(phaseCtx, entityBuilder, entityType);
+        continue;
+      }
+
       JoshFragment childFragment = ctx.getChild(childIndex).accept(parent);
 
       for (EventHandlerGroupBuilder groupBuilder : childFragment.getEventHandlerGroups()) {
@@ -116,6 +129,66 @@ public class JoshStanzaVisitor implements JoshVisitorDelegate {
     );
 
     return new EntityFragment(prototype);
+  }
+
+  /**
+   * Capture a spin-up / spin-down phase onto the simulation being built.
+   *
+   * <p>A phase contributes two synthetic handlers: a constant-substep duration
+   * ({@code __<phase>Steps}) the bridge reads at construction to anchor the clock, and a per-step
+   * year expression ({@code __<phase>Year}) the bridge evaluates on demand while in that phase to
+   * pick which data year's forcing is felt. The year handler is registered under a dedicated event
+   * (the phase name) so the stepper never runs it automatically — it is only drawn while the phase
+   * is active, leaving the random sequence of other phases untouched.</p>
+   *
+   * @param ctx The phase stanza to capture.
+   * @param entityBuilder The simulation entity builder to attach the phase handlers to.
+   * @param entityType The enclosing stanza type; phases are only valid inside a simulation.
+   */
+  private void capturePhase(JoshLangParser.PhaseStanzaContext ctx, EntityBuilder entityBuilder,
+        String entityType) {
+    if (!"simulation".equals(entityType)) {
+      throw new IllegalArgumentException(
+          "spinup / spindown blocks are only allowed inside a simulation stanza.");
+    }
+
+    String phase = ctx.phaseType(0).getText();
+    String closePhase = ctx.phaseType(1).getText();
+    if (!phase.equals(closePhase)) {
+      throw new IllegalArgumentException(String.format(
+          "Phase start and end type different: %s, %s", phase, closePhase));
+    }
+
+    EventHandlerAction yearAction = ctx.yearExpr.accept(parent).getCurrentAction();
+    EventHandlerAction durationAction = ctx.duration.accept(parent).getCurrentAction();
+
+    addPhaseHandler(entityBuilder, "__" + phase + "Steps", "constant", durationAction);
+    addPhaseHandler(entityBuilder, "__" + phase + "Year", phase, yearAction);
+  }
+
+  /**
+   * Register a single synthetic event handler on the entity being built.
+   *
+   * @param entityBuilder The entity builder to attach the handler to.
+   * @param attribute The synthetic attribute name the handler resolves.
+   * @param event The substep / event under which the handler resolves.
+   * @param action The compiled action evaluated by the handler.
+   */
+  private void addPhaseHandler(EntityBuilder entityBuilder, String attribute, String event,
+        EventHandlerAction action) {
+    // Wrap so the machine is ended after the expression runs, matching how a handler body (lambda)
+    // is compiled; getResult() requires the machine to have ended.
+    EventHandlerAction endedAction = (machine) -> {
+      action.apply(machine);
+      machine.end();
+      return machine;
+    };
+    CompiledCallable callable = new PushDownMachineCallable(endedAction, bridgeGetter);
+    EventKey eventKey = EventKey.of(attribute, event);
+    EventHandlerGroupBuilder groupBuilder = new EventHandlerGroupBuilder();
+    groupBuilder.setEventKey(eventKey);
+    groupBuilder.addEventHandler(new EventHandler(callable, attribute, event));
+    entityBuilder.addEventHandlerGroup(groupBuilder.buildKey(), groupBuilder.build());
   }
 
   /**

--- a/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/machine/SingleThreadEventHandlerMachineTest.java
@@ -777,6 +777,32 @@ public class SingleThreadEventHandlerMachineTest {
   }
 
   @Test
+  void randUniformDiscrete_shouldDrawIntegerWithinInclusiveRange() {
+    // `discrete uniform` draws an actual integer (no coercion) over the inclusive range.
+    machine.push(makeIntScalar(1));
+    machine.push(makeIntScalar(3));
+    machine.randUniformDiscrete();
+
+    machine.end();
+    EngineValue result = machine.getResult();
+    assertEquals("int", result.getLanguageType().getRootType());
+    long value = result.getAsInt();
+    assertTrue(value >= 1);
+    assertTrue(value <= 3);
+  }
+
+  @Test
+  void randUniformDiscrete_shouldReturnBoundForEqualBounds() {
+    // Given equal bounds, the draw is deterministic.
+    machine.push(makeIntScalar(5));
+    machine.push(makeIntScalar(5));
+    machine.randUniformDiscrete();
+
+    machine.end();
+    assertEquals(makeIntScalar(5), machine.getResult());
+  }
+
+  @Test
   void randNorm_shouldGenerateNumberFromNormalDistribution() {
     // Given
     EngineValue mean = makeDecimalScalar(new BigDecimal("5.0"));

--- a/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshExternalVisitorTest.java
+++ b/src/test/java/org/joshsim/lang/interpret/visitor/delegates/JoshExternalVisitorTest.java
@@ -50,14 +50,14 @@ class JoshExternalVisitorTest {
     assertNotNull(action);
 
     EventHandlerMachine mockMachine = mock(EventHandlerMachine.class);
-    // External reads resolve at the semantic (steps.low-based) timestep so the lookup lines up
-    // with how the data grid is keyed and with meta.year.
-    when(mockMachine.getCurrentTimestep()).thenReturn(42L);
+    // External reads resolve at the data timestep so the lookup lines up with how the data grid is
+    // keyed and with meta.year (the resampled year during spin-up/spin-down).
+    when(mockMachine.getDataTimestep()).thenReturn(42L);
     org.mockito.Mockito.doNothing().when(mockMachine).pushExternal("externalVar", 42L);
 
     action.apply(mockMachine);
 
-    verify(mockMachine).getCurrentTimestep();
+    verify(mockMachine).getDataTimestep();
     verify(mockMachine).pushExternal("externalVar", 42L);
   }
 


### PR DESCRIPTION
## What

Lets a simulation warm up *before* the observed period and keep running *after* it — resampling historical forcing years — without changing any data or model code. The motivating case: 86 years of data, 500 years of spin-up to reach equilibrium, the observed 0–86, then 500 years of spin-down to watch recovery.

```josh
start simulation Fire
  steps.low = 0 years
  steps.high = 86 years
  start spinup
    duration = 500 years
    year = sample discrete uniform from 0 years to 86 years
  end spinup
  start spindown
    duration = 500 years
    year = sample discrete uniform from 76 years to 86 years
  end spindown
end simulation
```

The phase body is a set of named properties (`name = expression`), the same idiom as the rest of the language: `duration` (the phase length) and `year` (resampled each step to pick which data year's forcing is felt). Naming `year` explicitly is the point — it is what `meta.year` *becomes* during the phase. Design doc: [SPINUP.md](SPINUP.md).

## Design

Built as two independently-useful pieces.

**1. `discrete uniform` ([commit 393437c4](https://github.com/SchmidtDSE/josh/pull/462/commits/393437c4))** — a new opt-in qualifier that draws an actual integer uniformly over an inclusive range (`sample discrete uniform from 0 years to 86 years` → a whole year, no float coercion). A year index *is* discrete, so this is the right primitive. Deliberately a qualifier rather than inferring discreteness from integer bounds: a discrete draw consumes the RNG differently than a continuous one, so silently reinterpreting the ~180 existing integer-bound `uniform from …` usages (tutorials, paper example, conformance) would shift every seeded model's random sequence — verified to break seed-tuned conformance tests. A plain `uniform` stays continuous and byte-for-byte reproducible.

**2. Phases ([commits ec2d67ac](https://github.com/SchmidtDSE/josh/pull/462/commits/ec2d67ac) + [0d827491](https://github.com/SchmidtDSE/josh/pull/462/commits/0d827491))**
- **Grammar** — `spinup`/`spindown` tokens and a `phaseStanza` whose body is ordinary `name = expression` handlers, reusing the event-handler form (no special keywords; `spinup`/`spindown`/`discrete` all remain valid identifiers). Simulation-only is enforced in [JoshStanzaVisitor](src/main/java/org/joshsim/lang/interpret/visitor/delegates/JoshStanzaVisitor.java), which also gives clear errors for a missing `duration`/`year` or an unknown property.
- **Capture** — `duration` is re-registered as a constant-substep attribute (`__<phase>Steps`) the bridge reads at construction; `year` under a dedicated event (`__<phase>Year`) so the stepper never auto-runs it. Both compile through the normal handler path.
- **Anchored clock** ([MinimalEngineBridge](src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java)) — `currentStep` runs `steps.low − spinupSteps … steps.high + spindownSteps`. **Step 0 is always the first observed step**; spin-up counts backward into the negatives. With no phases declared this reproduces the old clock exactly.
- **Data year** — `getDataTimestep()` returns the observed step 1:1, or a resampled year drawn **once per step** (memoized) and **only while that phase is active** (so other phases' RNG is untouched). Every `external` read and `meta.year` bind to it, so forcing stays physically consistent within a step.
- **meta** — `meta.year` → data year; new `meta.phase` → `spinup`/`observed`/`spindown`; `meta.stepCount` → anchored step (equals the old absolute count when there is no spin-up).
- **Memory** — the run loop prunes the step two behind, gated on the earliest (possibly negative) saved step, so spin-up steps are freed instead of accumulating across a long warm-up.

Negative timestep keys are safe in the core (timesteps are `HashMap<Long,…>`-keyed); the precomputed external grid is only ever read at the *data year*, which stays inside the observed window, so it never sees a negative index.

## Backward compatibility

For any model **without** phase blocks, `meta.*`, the step clock, external resolution, and the RNG sequence are unchanged. `meta.stepCount` moves from `getAbsoluteTimestep()` to `currentStep − steps.low`, which is identical when there is no spin-up. `discrete` / `spinup` / `spindown` are added as keywords but remain usable as identifiers. Verified: the 18 conformance files that fail to run standalone in this sandbox fail **identically** on clean `dev` (pre-existing/environmental), i.e. this branch adds no new failures.

## Tests

- `SingleThreadEventHandlerMachineTest` — discrete uniform draws an integer in the inclusive range; equal bounds are deterministic.
- `JoshExternalVisitorTest` — external reads now bind to the data timestep.
- **`examples/features/spinup.josh`** — an end-to-end example whose in-model assertions check the anchored clock (spin-up `stepCount < 0`, observed `0..4`, spin-down `> 4`) and that resampled years stay within each phase's window. Wired into `examples/validate.sh` (runs in CI) via `assert_run`; passes across many seeds.
- Full `./gradlew test` green (2088 tests); `spotlessCheck` + `checkstyleMain`/`checkstyleTest` green. Distribution/stochastic conformance green (continuous `uniform` unchanged).
- Smoke-tested the full arc (spin-up 3 / observed 5 / spin-down 2): correct step anchoring (−3…6), phase labels, discrete in-range years, and one shared draw per step.

## Scope

Builds the narrow `spinup`/`spindown` form, but the internals are structured so the reserved features are additive, not rewrites: phases are an ordered list, a phase's termination is an abstraction (only a fixed `duration` now), and the named-property body means a future convergence `until` is just another property — no grammar change. Reserved and documented in SPINUP.md, **not** built: `until`, and `earlyStop` for expensive models (with the analysis of the one missing rung — a simulation-scope grid aggregate). Window-bounds validation (`window ⊆ [steps.low, steps.high]`) and a configurable `--phases` export filter are noted as fast-follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)