### PR TITLE
Add --output-phases output filter (parity with --output-steps)

### DIFF
--- a/examples/validate.sh
+++ b/examples/validate.sh
@@ -174,3 +174,4 @@ assert_run examples/simulations/profiler_multi.josh ProfilerMultiExample --enabl
 
 # Test spin-up / spin-down: phase-anchored clock and resampled discrete years, asserted in-model
 assert_run examples/features/spinup.josh SpinupExample --seed 42 || exit 52
+assert_run examples/features/spinup.josh SpinupExample --seed 42 --output-phases observed || exit 53

--- a/src/main/java/org/joshsim/JoshJsSimFacade.java
+++ b/src/main/java/org/joshsim/JoshJsSimFacade.java
@@ -36,6 +36,7 @@ import org.joshsim.lang.io.SandboxInputOutputLayer;
 import org.joshsim.lang.parse.JoshParser;
 import org.joshsim.lang.parse.ParseError;
 import org.joshsim.lang.parse.ParseResult;
+import org.joshsim.util.OutputPhasesParser;
 import org.joshsim.util.OutputStepsParser;
 import org.joshsim.wire.NamedMap;
 import org.joshsim.wire.WireConverter;
@@ -130,15 +131,40 @@ public class JoshJsSimFacade {
    *     not specified. True if BigDecimal and false otherwise.
    * @param outputSteps Comma-separated string of step numbers to export (e.g., "5,7,8,9,20").
    *     If empty or null, all steps are exported.
+   * @param outputPhases Comma-separated string of phases to export (e.g., "observed,spindown").
+   *     If empty or null, all phases are exported.
+   */
+  @JSExport
+  public static void runSimulation(String code, String simulationName, String externalData,
+        boolean favorBigDecimal, String outputSteps, String outputPhases) {
+    try {
+      runSimulationUnsafe(code, simulationName, externalData, favorBigDecimal, outputSteps,
+          outputPhases);
+    } catch (Exception e) {
+      reportError(e.toString());
+    }
+  }
+
+  /**
+   * Interpret and run a Josh simulation.
+   *
+   * <p>Backward compatibility method that delegates to the new method with empty outputPhases.
+   * This maintains compatibility with existing JavaScript callers that specify outputSteps but
+   * not outputPhases.</p>
+   *
+   * @param code The Josh source code to parse, interpret, and run as a simulation.
+   * @param simulationName The name of the simulation to be executed as defined in the parsed
+   *     program.
+   * @param externalData The serialization of the virtual file system to use in this simulation.
+   * @param favorBigDecimal Flag indicating if numbers should be backed by BigDecimal or double if
+   *     not specified. True if BigDecimal and false otherwise.
+   * @param outputSteps Comma-separated string of step numbers to export (e.g., "5,7,8,9,20").
+   *     If empty or null, all steps are exported.
    */
   @JSExport
   public static void runSimulation(String code, String simulationName, String externalData,
         boolean favorBigDecimal, String outputSteps) {
-    try {
-      runSimulationUnsafe(code, simulationName, externalData, favorBigDecimal, outputSteps);
-    } catch (Exception e) {
-      reportError(e.toString());
-    }
+    runSimulation(code, simulationName, externalData, favorBigDecimal, outputSteps, "");
   }
 
   /**
@@ -158,7 +184,7 @@ public class JoshJsSimFacade {
   @JSExport
   public static void runSimulation(String code, String simulationName, String externalData,
         boolean favorBigDecimal) {
-    runSimulation(code, simulationName, externalData, favorBigDecimal, "");
+    runSimulation(code, simulationName, externalData, favorBigDecimal, "", "");
   }
 
   /**
@@ -287,10 +313,12 @@ public class JoshJsSimFacade {
    *     not specified. True if BigDecimal and false otherwise.
    * @param outputSteps Comma-separated string of step numbers to export (e.g., "5,7,8,9,20").
    *     If empty or null, all steps are exported.
+   * @param outputPhases Comma-separated string of phases to export (e.g., "observed,spindown").
+   *     If empty or null, all phases are exported.
    * @throws RuntimeException If parsing the code results in errors.
    */
   private static void runSimulationUnsafe(String code, String simulationName, String externalData,
-        boolean favorBigDecimal, String outputSteps) {
+        boolean favorBigDecimal, String outputSteps, String outputPhases) {
     setupForWasm();
 
     ParseResult result = JoshSimFacadeUtil.parse(code);
@@ -310,6 +338,7 @@ public class JoshJsSimFacade {
     );
 
     Optional<Set<Integer>> parsedOutputSteps = parseOutputSteps(outputSteps);
+    Optional<Set<String>> parsedOutputPhases = parseOutputPhases(outputPhases);
 
     JoshSimFacadeUtil.runSimulation(
         valueFactory,
@@ -319,7 +348,8 @@ public class JoshJsSimFacade {
         simulationName,
         (x) -> JoshJsSimFacade.reportStepComplete((int) x),
         true,
-        parsedOutputSteps
+        parsedOutputSteps,
+        parsedOutputPhases
     );
   }
 
@@ -339,7 +369,7 @@ public class JoshJsSimFacade {
    */
   private static void runSimulationUnsafe(String code, String simulationName, String externalData,
         boolean favorBigDecimal) {
-    runSimulationUnsafe(code, simulationName, externalData, favorBigDecimal, "");
+    runSimulationUnsafe(code, simulationName, externalData, favorBigDecimal, "", "");
   }
 
   /**
@@ -352,6 +382,18 @@ public class JoshJsSimFacade {
    */
   private static Optional<Set<Integer>> parseOutputSteps(String outputSteps) {
     return OutputStepsParser.parseForWasmOrRemote(outputSteps);
+  }
+
+  /**
+   * Parses the output-phases parameter using the OutputPhasesParser utility.
+   *
+   * @param outputPhases Comma-separated string of phases to export
+   * @return Optional containing the set of phases to export, or empty if all phases should be
+   *     exported
+   * @throws RuntimeException if the output-phases format is invalid
+   */
+  private static Optional<Set<String>> parseOutputPhases(String outputPhases) {
+    return OutputPhasesParser.parseForWasmOrRemote(outputPhases);
   }
 
   /**

--- a/src/main/java/org/joshsim/JoshSimFacade.java
+++ b/src/main/java/org/joshsim/JoshSimFacade.java
@@ -91,11 +91,13 @@ public class JoshSimFacade {
    * @param outputSteps Optional set of step numbers to export. If empty, all steps are exported.
    *     If present, only steps contained in the set will have their output written to export files.
    *     All steps continue to execute for simulation state continuity regardless of this filter.
+   * @param outputPhases Optional set of phase names to export (spinup, observed, spindown). If
+   *     empty, all phases are exported. ANDed with outputSteps.
    */
   public static void runSimulation(EngineGeometryFactory geometryFactory, JoshProgram program,
         String simulationName, JoshSimFacadeUtil.SimulationStepCallback callback,
         boolean serialPatches, int replicateNumber, boolean favorBigDecimal,
-        Optional<Set<Integer>> outputSteps) {
+        Optional<Set<Integer>> outputSteps, Optional<Set<String>> outputPhases) {
     setupForJvm();
 
     ValueSupportFactory valueFactory = buildValueSupportFactory(favorBigDecimal);
@@ -136,7 +138,8 @@ public class JoshSimFacade {
         simulationName,
         callback,
         serialPatches,
-        outputSteps
+        outputSteps,
+        outputPhases
     );
   }
 
@@ -164,7 +167,7 @@ public class JoshSimFacade {
         String simulationName, JoshSimFacadeUtil.SimulationStepCallback callback,
         boolean serialPatches, int replicateNumber, boolean favorBigDecimal) {
     runSimulation(geometryFactory, program, simulationName, callback, serialPatches,
-        replicateNumber, favorBigDecimal, Optional.empty());
+        replicateNumber, favorBigDecimal, Optional.empty(), Optional.empty());
   }
 
   /**

--- a/src/main/java/org/joshsim/JoshSimFacadeUtil.java
+++ b/src/main/java/org/joshsim/JoshSimFacadeUtil.java
@@ -87,11 +87,15 @@ public class JoshSimFacadeUtil {
    * @param outputSteps Optional set of step numbers to export. If empty, all steps are exported.
    *     If present, only steps contained in the set will have their output written to export files.
    *     All steps continue to execute for simulation state continuity regardless of this filter.
+   * @param outputPhases Optional set of phase names to export (spinup, observed, spindown). If
+   *     empty, all phases are exported. If present, only steps whose phase is contained in the set
+   *     will have their output written. ANDed with outputSteps.
    */
   public static void runSimulation(ValueSupportFactory valueFactory,
         EngineGeometryFactory geometryFactory, InputOutputLayer inputOutputLayer,
         JoshProgram program, String simulationName, SimulationStepCallback callback,
-        boolean serialPatches, Optional<Set<Integer>> outputSteps) {
+        boolean serialPatches, Optional<Set<Integer>> outputSteps,
+        Optional<Set<String>> outputPhases) {
     runSimulation(
         valueFactory,
         geometryFactory,
@@ -101,7 +105,8 @@ public class JoshSimFacadeUtil {
         simulationName,
         callback,
         serialPatches,
-        outputSteps
+        outputSteps,
+        outputPhases
     );
   }
 
@@ -122,12 +127,15 @@ public class JoshSimFacadeUtil {
    * @param callback A callback invoked after each simulation step.
    * @param serialPatches If true, patches are processed serially; otherwise in parallel.
    * @param outputSteps Optional set of step numbers to export.
+   * @param outputPhases Optional set of phase names to export (spinup, observed, spindown). ANDed
+   *     with outputSteps.
    */
   public static void runSimulation(ValueSupportFactory valueFactory,
         EngineGeometryFactory geometryFactory, InputOutputLayer inputOutputLayer,
         ExternalResourceGetter externalResourceGetter,
         JoshProgram program, String simulationName, SimulationStepCallback callback,
-        boolean serialPatches, Optional<Set<Integer>> outputSteps) {
+        boolean serialPatches, Optional<Set<Integer>> outputSteps,
+        Optional<Set<String>> outputPhases) {
 
     MutableEntity simEntityRaw = program.getSimulations().getProtoype(simulationName).build();
     MutableEntity simEntity = new ShadowingEntity(valueFactory, simEntityRaw, simEntityRaw);
@@ -178,7 +186,11 @@ public class JoshSimFacadeUtil {
     while (!bridge.isComplete()) {
       long completedStep = stepper.perform(serialPatches);
 
-      if (outputSteps.isEmpty() || outputSteps.get().contains((int) completedStep)) {
+      boolean stepIncluded = outputSteps.isEmpty()
+          || outputSteps.get().contains((int) completedStep);
+      boolean phaseIncluded = outputPhases.isEmpty()
+          || outputPhases.get().contains(bridge.getPhase(completedStep));
+      if (stepIncluded && phaseIncluded) {
         TimeStep completedTimeStep = bridge.getReplicate()
             .getTimeStep(completedStep)
             .orElseThrow();
@@ -228,7 +240,7 @@ public class JoshSimFacadeUtil {
         JoshProgram program, String simulationName, SimulationStepCallback callback,
         boolean serialPatches) {
     runSimulation(valueFactory, geometryFactory, inputOutputLayer, program,
-        simulationName, callback, serialPatches, Optional.empty());
+        simulationName, callback, serialPatches, Optional.empty(), Optional.empty());
   }
 
   /**

--- a/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimBatchHandler.java
@@ -461,6 +461,7 @@ public class JoshSimBatchHandler implements HttpHandler {
           simulation,
           (step) -> { /* progress unused in batch mode */ },
           false,
+          Optional.empty(),
           Optional.empty()
       );
     }

--- a/src/main/java/org/joshsim/cloud/JoshSimLeaderHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimLeaderHandler.java
@@ -162,6 +162,8 @@ public class JoshSimLeaderHandler implements HttpHandler {
     boolean favorBigDecimal = Boolean.parseBoolean(formData.getFirst("favorBigDecimal").getValue());
     String outputStepsStr = formData.contains("outputSteps")
         ? formData.getFirst("outputSteps").getValue() : "";
+    String outputPhasesStr = formData.contains("outputPhases")
+        ? formData.getFirst("outputPhases").getValue() : "";
 
     int replicateStart = 0;
     if (formData.contains("replicateStart")) {
@@ -202,6 +204,7 @@ public class JoshSimLeaderHandler implements HttpHandler {
           favorBigDecimal,
           replicateIndex,
           outputStepsStr,
+          outputPhasesStr,
           false
       );
       tasks.add(task);

--- a/src/main/java/org/joshsim/cloud/JoshSimWorkerHandler.java
+++ b/src/main/java/org/joshsim/cloud/JoshSimWorkerHandler.java
@@ -27,6 +27,7 @@ import org.joshsim.lang.io.SandboxExportCallback;
 import org.joshsim.lang.io.SandboxInputOutputLayer;
 import org.joshsim.lang.io.VirtualFile;
 import org.joshsim.lang.parse.ParseResult;
+import org.joshsim.util.OutputPhasesParser;
 import org.joshsim.util.OutputStepsParser;
 
 
@@ -154,6 +155,7 @@ public class JoshSimWorkerHandler implements HttpHandler {
         formData.getFirst("favorBigDecimal").getValue()
     );
     final Optional<Set<Integer>> outputSteps = getOutputSteps(formData);
+    final Optional<Set<String>> outputPhases = getOutputPhases(formData);
 
     boolean useProfiler = this.enableProfiler || getProfilerEnabled(formData);
 
@@ -185,7 +187,7 @@ public class JoshSimWorkerHandler implements HttpHandler {
     // Execute simulation securely
     boolean simulationSuccess = executeSimulation(
         valueFactory, geometryFactory, externalData, program,
-        simulationName, httpServerExchange, apiKey, outputSteps
+        simulationName, httpServerExchange, apiKey, outputSteps, outputPhases
     );
     if (!simulationSuccess) {
       return Optional.of(apiKey); // Error response already set
@@ -223,6 +225,21 @@ public class JoshSimWorkerHandler implements HttpHandler {
     } else {
       String outputStepsStr = formData.getFirst("outputSteps").getValue();
       return OutputStepsParser.parseForWasmOrRemote(outputStepsStr);
+    }
+  }
+
+  /**
+   * Parse the output-phases form field from the request.
+   *
+   * @param formData The form data submitted with the request.
+   * @return Optional set of phase names to export, or empty if all phases should be exported.
+   */
+  private Optional<Set<String>> getOutputPhases(FormData formData) {
+    if (!formData.contains("outputPhases")) {
+      return OutputPhasesParser.parseForWasmOrRemote("");
+    } else {
+      String outputPhasesStr = formData.getFirst("outputPhases").getValue();
+      return OutputPhasesParser.parseForWasmOrRemote(outputPhasesStr);
     }
   }
 
@@ -270,12 +287,14 @@ public class JoshSimWorkerHandler implements HttpHandler {
    * @param apiKey The API key for secure logging.
    * @param outputSteps Optional set of step numbers to export, or empty if all steps
    *     should be exported.
+   * @param outputPhases Optional set of phase names to export, or empty if all phases
+   *     should be exported.
    * @return true on success, false on failure (400 response set).
    */
   private boolean executeSimulation(ValueSupportFactory valueFactory,
         EngineGeometryFactory geometryFactory, String externalData, JoshProgram program,
         String simulationName, HttpServerExchange httpServerExchange, String apiKey,
-        Optional<Set<Integer>> outputSteps) {
+        Optional<Set<Integer>> outputSteps, Optional<Set<String>> outputPhases) {
     try {
       InputOutputLayer layer = getLayer(httpServerExchange, externalData);
 
@@ -299,7 +318,8 @@ public class JoshSimWorkerHandler implements HttpHandler {
             }
           },
           useSerial,
-          outputSteps
+          outputSteps,
+          outputPhases
       );
 
       // Add end marker for replicate 0 to standardize wire format

--- a/src/main/java/org/joshsim/command/RunCommand.java
+++ b/src/main/java/org/joshsim/command/RunCommand.java
@@ -22,6 +22,7 @@ import org.joshsim.JoshSimCommander;
 import org.joshsim.lang.io.MapSerializeStrategy;
 import org.joshsim.util.MinioOptions;
 import org.joshsim.util.OutputOptions;
+import org.joshsim.util.OutputPhasesParser;
 import org.joshsim.util.OutputStepsParser;
 import org.joshsim.util.ReplicateSelection;
 import picocli.CommandLine.Command;
@@ -121,6 +122,13 @@ public class RunCommand implements Callable<Integer> {
   private String outputSteps = "";
 
   @Option(
+      names = "--output-phases",
+      description = "Comma-separated list of phases to export (spinup,observed,spindown). "
+                  + "If not specified, all phases are exported."
+  )
+  private String outputPhases = "";
+
+  @Option(
       names = "--export-queue-size",
       description = "Maximum number of records to buffer before applying backpressure "
                   + "(default: 1000000)",
@@ -189,6 +197,17 @@ public class RunCommand implements Callable<Integer> {
     return OutputStepsParser.parseForCli(outputSteps);
   }
 
+  /**
+   * Parses the output-phases command line option using the OutputPhasesParser utility.
+   *
+   * @return Optional containing the set of phases to export, or empty if all phases should
+   *     be exported
+   * @throws IllegalArgumentException if the output-phases format is invalid
+   */
+  private Optional<Set<String>> parseOutputPhases() {
+    return OutputPhasesParser.parseForCli(outputPhases);
+  }
+
   @Override
   public Integer call() {
     // Validate replicates parameter
@@ -249,6 +268,7 @@ public class RunCommand implements Callable<Integer> {
         .csvPrecision(csvPrecision)
         .exportQueueSize(exportQueueSize)
         .outputSteps(parsedOutputSteps)
+        .outputPhases(parseOutputPhases())
         .dataFiles(dataFiles)
         .customParameters(customParameters)
         .minioOptions(minioOptions)

--- a/src/main/java/org/joshsim/command/RunUtil.java
+++ b/src/main/java/org/joshsim/command/RunUtil.java
@@ -92,6 +92,7 @@ public final class RunUtil {
     private final int csvPrecision;
     private final int exportQueueSize;
     private final Optional<Set<Integer>> outputSteps;
+    private final Optional<Set<String>> outputPhases;
     private final String[] dataFiles;
     private final Map<String, String> customParameters;
     private final MinioOptions minioOptions;
@@ -110,6 +111,7 @@ public final class RunUtil {
       this.csvPrecision = builder.csvPrecision;
       this.exportQueueSize = builder.exportQueueSize;
       this.outputSteps = builder.outputSteps;
+      this.outputPhases = builder.outputPhases;
       this.dataFiles = builder.dataFiles;
       this.customParameters = builder.customParameters;
       this.minioOptions = builder.minioOptions;
@@ -143,6 +145,7 @@ public final class RunUtil {
       private int csvPrecision = MapSerializeStrategy.DEFAULT_MAX_DECIMAL_PLACES;
       private int exportQueueSize = 1000000;
       private Optional<Set<Integer>> outputSteps = Optional.empty();
+      private Optional<Set<String>> outputPhases = Optional.empty();
       private String[] dataFiles = new String[0];
       private Map<String, String> customParameters = new HashMap<>();
       private MinioOptions minioOptions = new MinioOptions();
@@ -278,6 +281,17 @@ public final class RunUtil {
        */
       public Builder outputSteps(Optional<Set<Integer>> value) {
         this.outputSteps = value;
+        return this;
+      }
+
+      /**
+       * Sets the specific phases to export, or empty to export all phases (default empty).
+       *
+       * @param value set of phases to export (spinup, observed, spindown), or empty
+       * @return this builder
+       */
+      public Builder outputPhases(Optional<Set<String>> value) {
+        this.outputPhases = value;
         return this;
       }
 
@@ -646,8 +660,8 @@ public final class RunUtil {
 
         runReplicate(currentJob, effectiveReplicate, totalReplicateCount > 1,
             valueFactory, geometryFactory, inputStrategy, spatialInfo, program, opts.simulation,
-            progressCalculator, opts.outputSteps, serialPatches, opts.minioOptions,
-            opts.csvPrecision, output, lastStep);
+            progressCalculator, opts.outputSteps, opts.outputPhases, serialPatches,
+            opts.minioOptions, opts.csvPrecision, output, lastStep);
 
         ProgressUpdate completion = progressCalculator.updateReplicateCompleted(
             totalReplicateCount);
@@ -692,7 +706,8 @@ public final class RunUtil {
       ValueSupportFactory valueFactory, EngineGeometryFactory geometryFactory,
       InputGetterStrategy inputStrategy, GridSpatialInfo spatialInfo, JoshProgram program,
       String simulation, ProgressCalculator progressCalculator,
-      Optional<Set<Integer>> parsedOutputSteps, boolean serialPatches, MinioOptions minioOptions,
+      Optional<Set<Integer>> parsedOutputSteps, Optional<Set<String>> parsedOutputPhases,
+      boolean serialPatches, MinioOptions minioOptions,
       int csvPrecision, OutputOptions output, long[] lastStep) {
     TemplateStringRenderer templateRenderer = new TemplateStringRenderer(currentJob,
         currentReplicate);
@@ -714,7 +729,8 @@ public final class RunUtil {
         simulation,
         stepCallback(progressCalculator, output, lastStep),
         serialPatches,
-        parsedOutputSteps
+        parsedOutputSteps,
+        parsedOutputPhases
     );
   }
 

--- a/src/main/java/org/joshsim/lang/bridge/EngineBridge.java
+++ b/src/main/java/org/joshsim/lang/bridge/EngineBridge.java
@@ -127,6 +127,18 @@ public interface EngineBridge {
   String getPhase();
 
   /**
+   * Get the phase a specific (absolute) timestep belongs to.
+   *
+   * <p>Unlike {@link #getPhase()}, which reflects the bridge's current clock position, this
+   * reports the phase of an arbitrary step. This is needed when filtering completed steps for
+   * export, because the clock has already advanced past the step just completed.</p>
+   *
+   * @param step the absolute timestep number to classify.
+   * @return one of {@code "spinup"}, {@code "observed"}, or {@code "spindown"}.
+   */
+  String getPhase(long step);
+
+  /**
    * Get the earliest timestep key the run will ever save.
    *
    * <p>This is {@code steps.low} shifted back by the spin-up length (so it can be negative). Used

--- a/src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java
+++ b/src/main/java/org/joshsim/lang/bridge/MinimalEngineBridge.java
@@ -340,7 +340,11 @@ public class MinimalEngineBridge implements EngineBridge {
 
   @Override
   public String getPhase() {
-    long step = currentStep.getAsInt();
+    return getPhase(currentStep.getAsInt());
+  }
+
+  @Override
+  public String getPhase(long step) {
     if (step < observedLow) {
       return "spinup";
     }

--- a/src/main/java/org/joshsim/pipeline/remote/RunRemoteLocalLeaderStrategy.java
+++ b/src/main/java/org/joshsim/pipeline/remote/RunRemoteLocalLeaderStrategy.java
@@ -202,6 +202,7 @@ public class RunRemoteLocalLeaderStrategy implements RunRemoteStrategy {
           favorBigDecimal,
           replicateIndex,
           "",  // No output filtering for local leader strategy (export all steps)
+          "",  // No phase filtering for local leader strategy (export all phases)
           context.isEnableProfiler()
       );
       tasks.add(task);

--- a/src/main/java/org/joshsim/pipeline/remote/WorkerTask.java
+++ b/src/main/java/org/joshsim/pipeline/remote/WorkerTask.java
@@ -23,6 +23,7 @@ public class WorkerTask {
   private final boolean favorBigDecimal;
   private final int replicateNumber;
   private final String outputSteps;
+  private final String outputPhases;
   private final boolean enableProfiler;
 
   /**
@@ -35,11 +36,12 @@ public class WorkerTask {
    * @param favorBigDecimal Whether to favor BigDecimal precision
    * @param replicateNumber The replicate number for this task
    * @param outputSteps Comma-separated list of time steps to export
+   * @param outputPhases Comma-separated list of phases to export (spinup, observed, spindown)
    * @param enableProfiler Whether to enable per-request profiling
    */
   public WorkerTask(String code, String simulationName, String apiKey,
       String externalData, boolean favorBigDecimal, int replicateNumber, String outputSteps,
-      boolean enableProfiler) {
+      String outputPhases, boolean enableProfiler) {
     this.code = code;
     this.simulationName = simulationName;
     this.apiKey = apiKey;
@@ -47,6 +49,7 @@ public class WorkerTask {
     this.favorBigDecimal = favorBigDecimal;
     this.replicateNumber = replicateNumber;
     this.outputSteps = outputSteps;
+    this.outputPhases = outputPhases;
     this.enableProfiler = enableProfiler;
   }
 
@@ -111,6 +114,15 @@ public class WorkerTask {
    */
   public String getOutputSteps() {
     return outputSteps;
+  }
+
+  /**
+   * Gets the output phases filter for this task.
+   *
+   * @return The output phases as a comma-separated string
+   */
+  public String getOutputPhases() {
+    return outputPhases;
   }
 
   /**

--- a/src/main/java/org/joshsim/util/OutputPhasesParser.java
+++ b/src/main/java/org/joshsim/util/OutputPhasesParser.java
@@ -1,0 +1,94 @@
+package org.joshsim.util;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for parsing output phases parameters across different execution modes.
+ *
+ * <p>This utility provides consistent parsing logic for comma-separated output phase
+ * specifications used throughout the Josh simulation platform. It handles validation,
+ * error reporting, and conversion to appropriate data structures. Valid phases are
+ * {@code spinup}, {@code observed}, and {@code spindown}.</p>
+ */
+public final class OutputPhasesParser {
+
+  private static final Set<String> VALID_PHASES = Set.of("spinup", "observed", "spindown");
+
+  private OutputPhasesParser() {
+    // Prevent instantiation of utility class
+  }
+
+  /**
+   * Parses comma-separated output phases string into a Set of phase names.
+   *
+   * <p>This method handles various input formats gracefully:</p>
+   * <ul>
+   *   <li>Empty/null/whitespace-only strings return Optional.empty() (export all phases)</li>
+   *   <li>Comma-separated phases like "observed,spindown" return Set of those phases</li>
+   *   <li>Filters empty strings to handle cases like "observed,,spindown" gracefully</li>
+   *   <li>Trims whitespace around each phase and lowercases it</li>
+   * </ul>
+   *
+   * @param outputPhases Comma-separated string of phase names (e.g., "observed,spindown")
+   * @return Optional containing the set of phases to export, or empty if all phases
+   *     should be exported
+   * @throws IllegalArgumentException if the output phases format is invalid
+   */
+  public static Optional<Set<String>> parseForCli(String outputPhases) {
+    if (outputPhases == null || outputPhases.trim().isEmpty()) {
+      return Optional.empty();
+    }
+    Set<String> phases = Arrays.stream(outputPhases.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(s -> s.toLowerCase(java.util.Locale.ROOT))
+        .collect(Collectors.toSet());
+    if (phases.isEmpty()) {
+      return Optional.empty();
+    }
+    for (String phase : phases) {
+      if (!VALID_PHASES.contains(phase)) {
+        throw new IllegalArgumentException("Invalid output-phases value: " + phase
+            + ". Valid values are: spinup, observed, spindown");
+      }
+    }
+    return Optional.of(phases);
+  }
+
+  /**
+   * Parses comma-separated output phases string into a Set of phase names for WebAssembly/Remote
+   * use.
+   *
+   * <p>This method provides the same parsing logic as {@link #parseForCli(String)} but
+   * throws RuntimeException instead of IllegalArgumentException for consistency with
+   * WebAssembly and remote execution error handling patterns.</p>
+   *
+   * @param outputPhases Comma-separated string of phase names (e.g., "observed,spindown")
+   * @return Optional containing the set of phases to export, or empty if all phases
+   *     should be exported
+   * @throws RuntimeException if the output phases format is invalid
+   */
+  public static Optional<Set<String>> parseForWasmOrRemote(String outputPhases) {
+    if (outputPhases == null || outputPhases.trim().isEmpty()) {
+      return Optional.empty();
+    }
+    Set<String> phases = Arrays.stream(outputPhases.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(s -> s.toLowerCase(java.util.Locale.ROOT))
+        .collect(Collectors.toSet());
+    if (phases.isEmpty()) {
+      return Optional.empty();
+    }
+    for (String phase : phases) {
+      if (!VALID_PHASES.contains(phase)) {
+        throw new RuntimeException("Invalid output phases value: " + phase
+            + ". Valid values are: spinup, observed, spindown");
+      }
+    }
+    return Optional.of(phases);
+  }
+}

--- a/src/test/java/org/joshsim/command/RunRemoteCommandTest.java
+++ b/src/test/java/org/joshsim/command/RunRemoteCommandTest.java
@@ -439,7 +439,7 @@ public class RunRemoteCommandTest {
   public void testWorkerTaskEnableProfiler() {
     org.joshsim.pipeline.remote.WorkerTask task =
         new org.joshsim.pipeline.remote.WorkerTask(
-            "code", "sim", "key", "", false, 0, "", true);
+            "code", "sim", "key", "", false, 0, "", "", true);
     assertEquals(true, task.isEnableProfiler());
   }
 

--- a/src/test/java/org/joshsim/pipeline/remote/ParallelWorkerHandlerErrorCollectionTest.java
+++ b/src/test/java/org/joshsim/pipeline/remote/ParallelWorkerHandlerErrorCollectionTest.java
@@ -107,7 +107,7 @@ public class ParallelWorkerHandlerErrorCollectionTest {
     List<WorkerTask> tasks = new ArrayList<>();
     for (int i = 1; i <= 5; i++) {
       // Use simulationName to encode replicate number for server-side routing
-      tasks.add(new WorkerTask("code", String.valueOf(i), "key", "", false, i, "", false));
+      tasks.add(new WorkerTask("code", String.valueOf(i), "key", "", false, i, "", "", false));
     }
 
     // Act: execute — should throw aggregate exception
@@ -143,7 +143,7 @@ public class ParallelWorkerHandlerErrorCollectionTest {
 
     List<WorkerTask> tasks = new ArrayList<>();
     for (int i = 1; i <= 3; i++) {
-      tasks.add(new WorkerTask("code", String.valueOf(i), "key", "", false, i, "", false));
+      tasks.add(new WorkerTask("code", String.valueOf(i), "key", "", false, i, "", "", false));
     }
 
     // Act: should not throw
@@ -171,7 +171,7 @@ public class ParallelWorkerHandlerErrorCollectionTest {
 
     List<WorkerTask> tasks = new ArrayList<>();
     for (int i = 1; i <= 2; i++) {
-      tasks.add(new WorkerTask("code", String.valueOf(i), "key", "", false, i, "", false));
+      tasks.add(new WorkerTask("code", String.valueOf(i), "key", "", false, i, "", "", false));
     }
 
     // Act

--- a/src/test/java/org/joshsim/pipeline/remote/ParallelWorkerHandlerTest.java
+++ b/src/test/java/org/joshsim/pipeline/remote/ParallelWorkerHandlerTest.java
@@ -36,6 +36,7 @@ public class ParallelWorkerHandlerTest {
         true,
         5,
         "5,10,15",
+        "observed",
         false
     );
 
@@ -57,6 +58,7 @@ public class ParallelWorkerHandlerTest {
         "",
         false,
         0,
+        "",
         "",
         false
     );

--- a/src/test/java/org/joshsim/util/OutputPhasesParserTest.java
+++ b/src/test/java/org/joshsim/util/OutputPhasesParserTest.java
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for OutputPhasesParser.
+ *
+ * @license BSD-3-Clause
+ */
+
+package org.joshsim.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link OutputPhasesParser} parsing logic and validation.
+ */
+public class OutputPhasesParserTest {
+
+  @Test
+  public void parseForCliEmptyReturnsEmpty() {
+    assertTrue(OutputPhasesParser.parseForCli("").isEmpty());
+  }
+
+  @Test
+  public void parseForCliNullReturnsEmpty() {
+    assertTrue(OutputPhasesParser.parseForCli(null).isEmpty());
+  }
+
+  @Test
+  public void parseForCliWhitespaceReturnsEmpty() {
+    assertTrue(OutputPhasesParser.parseForCli("   ").isEmpty());
+  }
+
+  @Test
+  public void parseForCliValidCsvReturnsSet() {
+    Optional<Set<String>> result = OutputPhasesParser.parseForCli("observed,spindown");
+    assertTrue(result.isPresent());
+    assertEquals(Set.of("observed", "spindown"), result.get());
+  }
+
+  @Test
+  public void parseForCliSinglePhase() {
+    Optional<Set<String>> result = OutputPhasesParser.parseForCli("observed");
+    assertTrue(result.isPresent());
+    assertEquals(Set.of("observed"), result.get());
+  }
+
+  @Test
+  public void parseForCliHandlesWhitespaceAndEmpties() {
+    Optional<Set<String>> result = OutputPhasesParser.parseForCli(" observed , , spindown ");
+    assertTrue(result.isPresent());
+    assertEquals(Set.of("observed", "spindown"), result.get());
+  }
+
+  @Test
+  public void parseForCliLowercasesPhases() {
+    Optional<Set<String>> result = OutputPhasesParser.parseForCli("OBSERVED,SpinUp");
+    assertTrue(result.isPresent());
+    assertEquals(Set.of("observed", "spinup"), result.get());
+  }
+
+  @Test
+  public void parseForCliAllPhases() {
+    Optional<Set<String>> result = OutputPhasesParser.parseForCli("spinup,observed,spindown");
+    assertTrue(result.isPresent());
+    assertEquals(Set.of("spinup", "observed", "spindown"), result.get());
+  }
+
+  @Test
+  public void parseForCliInvalidPhaseThrows() {
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> OutputPhasesParser.parseForCli("observed,bogus"));
+    assertTrue(ex.getMessage().contains("spinup"));
+    assertTrue(ex.getMessage().contains("observed"));
+    assertTrue(ex.getMessage().contains("spindown"));
+  }
+
+  @Test
+  public void parseForWasmEmptyReturnsEmpty() {
+    assertTrue(OutputPhasesParser.parseForWasmOrRemote("").isEmpty());
+  }
+
+  @Test
+  public void parseForWasmValidCsvReturnsSet() {
+    Optional<Set<String>> result = OutputPhasesParser.parseForWasmOrRemote("observed,spindown");
+    assertTrue(result.isPresent());
+    assertEquals(Set.of("observed", "spindown"), result.get());
+  }
+
+  @Test
+  public void parseForWasmInvalidPhaseThrows() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> OutputPhasesParser.parseForWasmOrRemote("nope"));
+    assertTrue(ex.getMessage().contains("spinup"));
+  }
+
+  @Test
+  public void parseForWasmOnlyEmptyTokensReturnsEmpty() {
+    Optional<Set<String>> result = OutputPhasesParser.parseForWasmOrRemote(",,");
+    assertFalse(result.isPresent());
+  }
+}


### PR DESCRIPTION
## What

Adds `--output-phases` so a run can export only certain spin-up/spin-down phases — e.g. `--output-phases observed,spindown` to drop the throwaway spin-up window. Phases are `spinup`, `observed`, `spindown` (from `EngineBridge.getPhase()`, added with spin-up in #462). Threaded **exactly parallel** to `--output-steps`: `Optional<Set<String>>` vs `Optional<Set<Integer>>`, empty = export all, and the two filters AND together.

Note: emitting the phase *as a column* already works today (`export.phase.step = meta.phase`); this PR is the **filter**.

## Design

- **Parser** — new [`OutputPhasesParser`](src/main/java/org/joshsim/util/OutputPhasesParser.java) mirrors `OutputStepsParser` (a `parseForCli` and a `parseForWasmOrRemote`), validating each token against `{spinup, observed, spindown}` with a clear error.
- **Engine hook** — the run-loop write guard in [JoshSimFacadeUtil](src/main/java/org/joshsim/JoshSimFacadeUtil.java) ANDs a phase check onto the existing step check. It uses `getPhase(completedStep)`, **not** the bare `getPhase()`: `SimulationStepper.perform()` advances the clock in `endStep()` before returning, so the parameterless form reports the *next* step's phase (verified — a spin-up row leaked into an `observed` filter without this). Added `EngineBridge.getPhase(long)`; the existing `getPhase()` (used by `meta.phase` mid-step) delegates to it.
- **Plumbing parity** — added alongside `--output-steps` through every route it touches: `RunCommand` (`--output-phases` option), `RunUtil.RunOptions`, `JoshSimFacade`/`JoshSimFacadeUtil`, the WASM `JoshJsSimFacade`, `WorkerTask`, and the leader/worker cloud handlers (the local-leader strategy passes `""`, as it does for steps). **MCP is untouched** — it does not plumb `--output-steps` either, so parity means it gets nothing.

## Tests

- `OutputPhasesParserTest` — empty/null/whitespace → empty, valid CSV → set, lowercasing, and an invalid phase name throws (CLI + wasm/remote variants).
- `examples/validate.sh` runs the spin-up example with `--output-phases observed` (CI).
- Updated `WorkerTask` constructor call sites in three existing tests.
- Full `./gradlew test` green; `spotlessCheck` + `checkstyleMain`/`checkstyleTest` green.
- Verified end-to-end on the meta export path: a −2…4 run gives 7 rows unfiltered, 3 with `--output-phases observed`, 5 with `observed,spindown`, and `--output-steps 0,3 --output-phases observed` → 1 row (confirms the AND).

## Known limitation (shared with `--output-steps`)

The filter governs the **meta / non-incremental** write path, **not** patch rows written through the stepper's incremental export callback. Verified empirically that `--output-steps` has the identical limitation: with `exportFiles.patch`, neither `--output-steps` nor `--output-phases` reduces the patch CSV — all rows are written. So for the common patch-CSV case this does **not** yet drop spin-up rows. Making it do so means gating that incremental `PatchExportCallback`, which would fix **both** flags and is a deliberate follow-up (kept out of scope here to preserve strict parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)