### PR TITLE
Filter incremental patch exports by --output-steps / --output-phases (fixes #465)

### DIFF
--- a/.github/workflows/test-minio.yaml
+++ b/.github/workflows/test-minio.yaml
@@ -205,7 +205,10 @@ jobs:
           echo "Testing large payload upload to exercise multipart upload path..."
 
           # Run simulation that generates >10MB of entity-level CSV data
-          # 1500 organisms * 100 steps * 3 fields = ~15MB CSV
+          # 1500 organisms * 100 steps * 3 fields = ~15MB CSV.
+          # No --output-steps: all steps must be exported to exceed the 10MB multipart threshold.
+          # (--output-steps now correctly filters incremental exports, so capping here would shrink
+          # the payload to a single step.)
           java -Xmx2g -jar build/libs/joshsim-fat.jar run \
             --replicates=1 \
             examples/test/minio/large_payload.josh \
@@ -213,8 +216,7 @@ jobs:
             --minio-endpoint=http://localhost:9000 \
             --minio-access-key=minioadmin \
             --minio-secret-key=minioadmin \
-            --export-queue-size=10000 \
-            --output-steps=100
+            --export-queue-size=10000
 
           # Verify file was uploaded
           ./mc stat testminio/josh-test-bucket/results/large_payload_0.csv

--- a/examples/features/spinup_export.josh
+++ b/examples/features/spinup_export.josh
@@ -1,0 +1,31 @@
+start simulation SpinupExport
+
+  grid.size = 10 m
+  grid.low = 0 m latitude, 0 m longitude
+  grid.high = 10 m latitude, 10 m longitude
+
+  steps.low = 0 years
+  steps.high = 2 years
+
+  exportFiles.patch = "file:///tmp/spinup_export_josh.csv"
+
+  start spinup
+    duration = 2 years
+    year = sample discrete uniform from 0 years to 2 years
+  end spinup
+
+  start spindown
+    duration = 2 years
+    year = sample discrete uniform from 0 years to 2 years
+  end spindown
+
+end simulation
+
+start patch Default
+
+  export.phase.step = meta.phase
+
+end patch
+
+start unit years
+end unit

--- a/examples/validate.sh
+++ b/examples/validate.sh
@@ -175,3 +175,12 @@ assert_run examples/simulations/profiler_multi.josh ProfilerMultiExample --enabl
 # Test spin-up / spin-down: phase-anchored clock and resampled discrete years, asserted in-model
 assert_run examples/features/spinup.josh SpinupExample --seed 42 || exit 52
 assert_run examples/features/spinup.josh SpinupExample --seed 42 --output-phases observed || exit 53
+
+# Test --output-phases actually filters the incremental patch export (not just the meta path).
+rm -f /tmp/spinup_export_josh.csv
+assert_run examples/features/spinup_export.josh SpinupExport --seed 1 || exit 54
+grep -q "spinup" /tmp/spinup_export_josh.csv || exit 55
+rm -f /tmp/spinup_export_josh.csv
+assert_run examples/features/spinup_export.josh SpinupExport --seed 1 --output-phases observed || exit 56
+grep -q "observed" /tmp/spinup_export_josh.csv || exit 57
+! grep -qE "spinup|spindown" /tmp/spinup_export_josh.csv || exit 58

--- a/src/main/java/org/joshsim/JoshSimFacadeUtil.java
+++ b/src/main/java/org/joshsim/JoshSimFacadeUtil.java
@@ -177,8 +177,10 @@ public class JoshSimFacadeUtil {
     // Create incremental export callback if export configured
     Optional<PatchExportCallback> exportCallback = exportFacade.createIncrementalCallback();
 
-    // Pass callback to SimulationStepper
-    SimulationStepper stepper = new SimulationStepper(bridge, exportCallback);
+    // Pass callback + output filters to SimulationStepper so incremental patch exports honor the
+    // same step/phase filtering as the meta write path below.
+    SimulationStepper stepper =
+        new SimulationStepper(bridge, exportCallback, outputSteps, outputPhases);
 
     exportFacade.start();
     debugFacade.start();

--- a/src/main/java/org/joshsim/lang/bridge/PatchExportCallback.java
+++ b/src/main/java/org/joshsim/lang/bridge/PatchExportCallback.java
@@ -22,13 +22,16 @@ public interface PatchExportCallback {
   /**
    * Export a single patch after it completes its substep.
    *
-   * <p>Implementations should freeze the mutable patch, serialize it, and queue it
-   * to the writer thread. The frozen entity should also be saved to the Replicate
-   * for "prior" state access in the next timestep.</p>
+   * <p>Implementations always freeze the mutable patch and return it (so it can be saved to the
+   * Replicate for "prior" state access in the next timestep), but only serialize and queue it to
+   * the writer thread when {@code write} is true. This lets output filters (e.g.
+   * {@code --output-steps} / {@code --output-phases}) suppress a step's output without breaking
+   * state continuity.</p>
    *
    * @param patch The mutable patch that has just completed its substep
    * @param currentStep The current timestep number
+   * @param write Whether to serialize and queue this patch to the writer; if false, only freeze it
    * @return The frozen Entity (for saving to Replicate.pastTimeSteps)
    */
-  Entity exportPatch(MutableEntity patch, long currentStep);
+  Entity exportPatch(MutableEntity patch, long currentStep, boolean write);
 }

--- a/src/main/java/org/joshsim/lang/bridge/SimulationStepper.java
+++ b/src/main/java/org/joshsim/lang/bridge/SimulationStepper.java
@@ -22,6 +22,8 @@ public class SimulationStepper {
   private final EngineBridge target;
   private final Set<String> events;
   private final Optional<PatchExportCallback> exportCallback;
+  private final Optional<Set<Integer>> outputSteps;
+  private final Optional<Set<String>> outputPhases;
 
   /**
    * Create a new stepper around a bridge without export callback.
@@ -36,17 +38,34 @@ public class SimulationStepper {
   }
 
   /**
-   * Create a new stepper around a bridge with optional export callback.
+   * Create a new stepper around a bridge with optional export callback and no output filter.
+   *
+   * @param target EngineBridge in which to perform this operation.
+   * @param exportCallback Optional callback for incremental patch export
+   */
+  public SimulationStepper(EngineBridge target, Optional<PatchExportCallback> exportCallback) {
+    this(target, exportCallback, Optional.empty(), Optional.empty());
+  }
+
+  /**
+   * Create a new stepper around a bridge with optional export callback and output filters.
    *
    * <p>Collects all unique event names from patch event handlers using direct iteration
    * instead of streams for better performance.</p>
    *
    * @param target EngineBridge in which to perform this operation.
    * @param exportCallback Optional callback for incremental patch export
+   * @param outputSteps Optional set of step numbers to export; empty means all steps. Applies to
+   *     incremental patch exports so suppressed steps are still simulated but not written.
+   * @param outputPhases Optional set of phase names to export; empty means all phases. ANDed with
+   *     outputSteps.
    */
-  public SimulationStepper(EngineBridge target, Optional<PatchExportCallback> exportCallback) {
+  public SimulationStepper(EngineBridge target, Optional<PatchExportCallback> exportCallback,
+        Optional<Set<Integer>> outputSteps, Optional<Set<String>> outputPhases) {
     this.target = target;
     this.exportCallback = exportCallback;
+    this.outputSteps = outputSteps;
+    this.outputPhases = outputPhases;
 
     MutableEntity simulation = target.getSimulation();
     Iterable<MutableEntity> patches = target.getCurrentPatches();
@@ -119,6 +138,10 @@ public class SimulationStepper {
   private void performStream(Iterable<MutableEntity> entities, String subStep, boolean serial) {
     long currentStep = target.getCurrentTimestep();
     boolean shouldExport = exportCallback.isPresent() && shouldExportInSubstep(subStep);
+    // Patches are always frozen+saved for prior-state continuity when exporting; only the write to
+    // the output is gated by the step/phase filter. getPhase() is exact here (mid-step, before the
+    // clock advances in endStep).
+    boolean writeOutput = shouldExport && isOutputIncluded(currentStep);
 
     if (serial) {
       // Use direct iteration for serial execution (better performance)
@@ -126,7 +149,7 @@ public class SimulationStepper {
       for (MutableEntity entity : entities) {
         MutableEntity result = updateEntity(entity, subStep);
         if (shouldExport) {
-          Entity frozen = exportCallback.get().exportPatch(result, currentStep);
+          Entity frozen = exportCallback.get().exportPatch(result, currentStep, writeOutput);
           saveFrozenPatchToReplicate(frozen, currentStep);
         }
         numCompleted++;
@@ -138,7 +161,7 @@ public class SimulationStepper {
           .forEach(entity -> {
             MutableEntity result = updateEntity(entity, subStep);
             if (shouldExport) {
-              Entity frozen = exportCallback.get().exportPatch(result, currentStep);
+              Entity frozen = exportCallback.get().exportPatch(result, currentStep, writeOutput);
               saveFrozenPatchToReplicate(frozen, currentStep);
             }
           });
@@ -156,6 +179,20 @@ public class SimulationStepper {
   private void performStream(MutableEntity entity, String subStep) {
     MutableEntity result = updateEntity(entity, subStep);
     assert result != null;
+  }
+
+  /**
+   * Determine whether the current step's output passes the step and phase filters.
+   *
+   * @param currentStep the step about to be written
+   * @return true if both filters include this step (or are absent)
+   */
+  private boolean isOutputIncluded(long currentStep) {
+    boolean stepIncluded = outputSteps.isEmpty()
+        || outputSteps.get().contains((int) currentStep);
+    boolean phaseIncluded = outputPhases.isEmpty()
+        || outputPhases.get().contains(target.getPhase());
+    return stepIncluded && phaseIncluded;
   }
 
   /**

--- a/src/main/java/org/joshsim/lang/io/IncrementalPatchExportCallback.java
+++ b/src/main/java/org/joshsim/lang/io/IncrementalPatchExportCallback.java
@@ -46,10 +46,14 @@ public class IncrementalPatchExportCallback implements PatchExportCallback {
   }
 
   @Override
-  public Entity exportPatch(MutableEntity patch, long currentStep) {
+  public Entity exportPatch(MutableEntity patch, long currentStep, boolean write) {
+    // Always freeze (needed for the Replicate's prior-state); only serialize/queue when included
+    // by the output filter, so suppressing a step's output does not break state continuity.
     Entity frozen = freezePatch(patch);
-    exportPatchData(frozen, currentStep);
-    exportInnerEntities(frozen, currentStep);
+    if (write) {
+      exportPatchData(frozen, currentStep);
+      exportInnerEntities(frozen, currentStep);
+    }
     return frozen;
   }
 


### PR DESCRIPTION
Fixes #465.

## What

`--output-steps` / `--output-phases` previously only gated the **meta / non-incremental** write path. Patch rows emitted through the stepper's incremental `PatchExportCallback` were written unconditionally, so an `exportFiles.patch` CSV ignored both flags — a 500-year spin-up window couldn't actually be dropped from output. This makes the filters apply to the incremental patch path too, which is what makes `--output-phases observed` useful for CSV exports.

> **Stacked on #464** (`feat/output-phases`) because it threads that branch's `outputPhases` plumbing into the stepper. Base will auto-retarget to `dev` when #464 merges — happy to retarget now if #464 lands first.

## Design

`PatchExportCallback.exportPatch` did double duty: **freeze** (needed every step for the Replicate's `prior` state) + **serialize/queue** (the output to filter). The key correctness point is that suppressing output must not skip the freeze, or `prior` breaks during spin-up. So:

- `exportPatch` gains a `write` flag. [`IncrementalPatchExportCallback`](src/main/java/org/joshsim/lang/io/IncrementalPatchExportCallback.java) always freezes and returns the frozen entity, but only serializes/queues when `write` is true.
- [`SimulationStepper`](src/main/java/org/joshsim/lang/bridge/SimulationStepper.java) takes the `outputSteps`/`outputPhases` filters and computes `write` per step via `isOutputIncluded()`. `getPhase()` is exact here — this runs mid-step, before `endStep()` advances the clock — so no `getPhase(long)` is needed (unlike the post-step run-loop guard).
- [`JoshSimFacadeUtil`](src/main/java/org/joshsim/JoshSimFacadeUtil.java) passes the filters into the stepper, matching the meta path.

Blast radius is small: 1 interface method (one impl, two call sites), the stepper, and the facade wiring. The non-incremental/meta path is unchanged.

## Tests

- New `examples/features/spinup_export.josh` (exports a `phase` column); `examples/validate.sh` asserts the unfiltered CSV contains spin-up rows, and that `--output-phases observed` yields observed rows with **no** spin-up/spin-down rows. Runs in CI.
- Verified manually: 7 rows unfiltered → 3 with `--output-phases observed` → 5 with `observed,spindown` → 2 with `--output-steps 1,2`; ANDs correctly; and `prior.n` still resolves across the filtered spin-up→observed boundary (freeze-always path).
- Full `./gradlew test` + `spotlessCheck` + `checkstyleMain`/`checkstyleTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)